### PR TITLE
Added Top Contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,14 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ---
 
 <div align="center">
+## 🌟 Top Contributors
+
+We sincerely thank the amazing individuals who have contributed to DocMagic. Your time, effort, and ideas make this project better every day.
+
+<!-- You can use GitHub's built-in contributors image -->
+[![Contributors](https://contrib.rocks/image?repo=Muneerali199/DocMagic)](https://github.com/Muneerali199/DocMagic/graphs/contributors)
+
+> Want to contribute? Check out our [CONTRIBUTING.md](CONTRIBUTING.md) guide and submit your first PR!
   <p>Built with ❤️ by the DocMagic Team</p>
   <p>© 2025 DocMagic. All rights reserved.</p>
 </div>


### PR DESCRIPTION
This PR adds a "Top Contributors" section to the README to recognize the individuals who have contributed to the project. It includes a dynamic contributors image via contrib.rocks.

Preview:
![Contributors](https://contrib.rocks/image?repo=Muneerali199/DocMagic)

Let me know if any modifications are needed!
