### PR TITLE
✨ Feature Added: Send Welcome Email on Signup

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from '@supabase/supabase-js';
+import { sendWelcomeEmail } from "@/lib/email";
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -55,6 +56,13 @@ export async function POST(request: Request) {
 
     if (error) {
       throw error;
+    }
+
+    // Send welcome email (non-blocking - we won't fail the signup if email sending fails)
+    if (user?.email) {
+      sendWelcomeEmail(user.email, name).catch((emailErr) => {
+        console.error("Failed to send welcome email:", emailErr);
+      });
     }
 
     return NextResponse.json({

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,60 @@
+import nodemailer from 'nodemailer';
+
+// Helper to create a reusable Nodemailer transporter.
+// In development (no EMAIL_HOST provided) it will fallback to Ethereal test account.
+async function createTransporter() {
+  if (process.env.EMAIL_HOST) {
+    return nodemailer.createTransport({
+      host: process.env.EMAIL_HOST,
+      port: parseInt(process.env.EMAIL_PORT || '587'),
+      secure: false, // true for 465, false for other ports
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS,
+      },
+    });
+  }
+
+  // Fallback: create a test account for local development
+  const testAccount = await nodemailer.createTestAccount();
+  return nodemailer.createTransport({
+    host: 'smtp.ethereal.email',
+    port: 587,
+    secure: false,
+    auth: {
+      user: testAccount.user,
+      pass: testAccount.pass,
+    },
+  });
+}
+
+/**
+ * Sends a welcome email to a newly registered user.
+ * @param to The recipient email address.
+ * @param name Optional recipient name for personalisation.
+ * @returns The result from Nodemailer and an optional previewUrl when using Ethereal.
+ */
+export async function sendWelcomeEmail(to: string, name?: string) {
+  const transporter = await createTransporter();
+
+  const subject = 'Welcome to DocMagic!';
+  const html = `
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+      <h2>Welcome${name ? `, ${name}` : ''}!</h2>
+      <p>Thank you for joining <strong>DocMagic</strong>, your AI-powered document creation platform.</p>
+      <p>We're excited to help you create professional resumes, presentations, CVs, and letters in seconds.</p>
+      <p>If you have any questions, just reply to this email—we're always happy to help.</p>
+      <p style="margin-top: 30px;">Cheers,<br/>The DocMagic Team</p>
+    </div>
+  `;
+
+  const info = await transporter.sendMail({
+    from: process.env.EMAIL_FROM || 'noreply@docmagic.com',
+    to,
+    subject,
+    html,
+  });
+
+  const previewUrl = process.env.EMAIL_HOST ? null : nodemailer.getTestMessageUrl(info);
+  return { info, previewUrl };
+} 


### PR DESCRIPTION
## Title : Feature Added: Send Welcome Email on Signup

## Summary:
Adds automatic delivery of a branded “Welcome to DocMagic” email every time a new user signs up.
This improves onboarding, increases engagement, and provides a template for future email notifications.

## What's New:
1. lib/email.ts
     - Introduces a reusable Nodemailer transporter that
           - Uses production SMTP credentials when EMAIL_* env vars are present.
           - Falls back to an Ethereal test account for local development, returning a preview URL.
      Exports sendWelcomeEmail(to, name?) which sends a styled HTML email.
2. app/api/auth/register/route.ts
   - Imports sendWelcomeEmail.
   - After successful supabase.auth.signUp, triggers the welcome email.
   - Runs non-blocking—signup won’t fail if email delivery encounters an error (error is logged).

## Testing:
1. npm run dev
2. Register a new account.
   - If SMTP vars are unset, check console for an Ethereal “Preview URL” and open it to view the email.
   - If SMTP vars are set, confirm delivery in your inbox/SMTP logs.
3. Verify no errors in server logs and that the email renders correctly.

# Closes : #9 

## Additional:
This feature increase the trust towards this product.
I hope you will like this.

Regards.