### PR TITLE
fix: improve text contrast for gradient buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1436,7 +1436,7 @@ img {
     #f472b6 100%
   );
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+  -webkit-text-fill-color: rgb(255, 250, 250);
   background-clip: text;
   background-size: 200% 200%;
   animation: gradient-shift 4s ease infinite;


### PR DESCRIPTION
This PR improves text accessibility by adjusting the text to have higher contrast on gradient backgrounds. Specifically, updated `.bolt-gradient-text` to use solid white text instead of partially transparent fill, fixing visibility issues on the following:

- "About DocMagic" section
- "100% Open Source" section

Tested locally and verified improved readability.
