### PR TITLE
Making instructions clear about opening in localhost

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,7 @@ Create a new file named `.env.local` in your project root directory (same level 
 #### **Add Required Environment Variables**
 
 Copy the following into your `.env.local` file and replace the placeholder values:
+MAKE SURE TO RENAME `.env.local.example` file to `.env.local` , else npm will keep showing problems. 
 
 ```bash
 # App Configuration
@@ -142,6 +143,7 @@ PEXELS_API_KEY=your_pexels_api_key
 2. Create a new project
 3. Go to Settings → API
 4. Copy your Project URL and anon public key
+5. Make sure to not give spaces will copying into `.env.local` file
 
 **Google Gemini AI** (Required):
 1. Visit [Google AI Studio](https://ai.google.dev/)


### PR DESCRIPTION
## Description

Added clear instructions in CONTRIBUTING.md about renaming .env.example → .env.local and avoiding spaces after = in API keys. This prevents the common "Missing Supabase env vars" error.
Fixes common setup issues for new contributors.

Fixes #397 

## Type of Change
- [x] Documentation update (README, contribution guidelines, etc.)

## Changes Made
  - "Rename `.env.example` → `.env.local` (required for Next.js dev)"
  - "No spaces after `=`: `KEY=value`, not `KEY= value`"

## Dependencies
- None

## Add Screenshots
N/A (docs only)

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes in development mode (`npm run dev`)
- [x] This is already assigned Issue to me, not an unassigned issue.