### PR TITLE
fix(diagram): implement share button functionality with clipboard copy and toast feedback (closes #410)

### DIFF
--- a/app/diagram/page.tsx
+++ b/app/diagram/page.tsx
@@ -5,15 +5,42 @@ import { CreateDocumentGuard } from "@/components/ui/auth-guard";
 import { Sparkles, Workflow, Zap, Star, Wand2, Share2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { DiagramGeneratorSkeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/hooks/use-toast";
 
 export default function DiagramPage() {
   const [isLoading, setIsLoading] = useState(true);
+  const [copied, setCopied] = useState(false);
+  const { toast } = useToast();
 
   useEffect(() => {
     // Simulate loading
     const timer = setTimeout(() => setIsLoading(false), 1500);
     return () => clearTimeout(timer);
   }, []);
+
+  const handleClick = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+
+      setCopied(true)
+
+      setTimeout(() => {
+        setCopied(false)
+      }, 2000);
+
+      toast({
+        title: "Copied!",
+        description: "Link copied to clipboard.",
+      });
+
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to copy link.",
+        variant: "destructive",
+      });
+    }
+  };
 
   return (
     <div className="min-h-screen flex flex-col relative overflow-hidden">
@@ -36,9 +63,9 @@ export default function DiagramPage() {
         <div className="container py-8 sm:py-12 px-4 sm:px-6 lg:px-8">
           {/* Enhanced Header */}
           <div className="text-center mb-8 sm:mb-12">
-            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full glass-effect mb-4 sm:mb-6 shimmer">
+            <div onClick={handleClick} className="inline-flex items-center cursor-pointer gap-2 px-4 py-2 rounded-full glass-effect mb-4 sm:mb-6 shimmer">
               <Workflow className="h-4 w-4 text-yellow-500" />
-              <span className="text-sm font-medium">Diagram Studio</span>
+              <span className={`text-sm font-medium ${copied ? "text-green-600" : ""}`}>{copied ? "Link Copied ✓" : "Diagram Studio"}</span>
               <Share2 className="h-4 w-4 text-blue-500" />
             </div>
 


### PR DESCRIPTION
## Fix: Share Button Not Working on Diagram Studio Page

This PR fixes the non-functional **Share button** on the Diagram Studio page.

Previously, clicking the Share button produced **no action or feedback**, making it misleading for users who expected a sharing functionality.

---

## Changes Implemented

* Added a click handler for the **Share button**

* Implemented clipboard copy functionality using:

  ```js
  navigator.clipboard.writeText(window.location.href)
  ```

* Added **toast notifications** to provide user feedback

  * Success toast when link is copied
  * Error toast if clipboard copy fails

* Implemented a temporary UI state change:

  * Button text changes to **"Link Copied ✓"** for 2 seconds after clicking

---

## Result

When the Share button is clicked:

1. The current page URL is copied to the clipboard
2. A success toast notification appears
3. The button text temporarily updates to indicate success

This improves **usability and feedback**, ensuring the button performs a meaningful action.

---

## Files Modified

```
app/diagram/page.tsx
```

---

## UI Behavior After Fix

* Share button copies the current page link
* Displays toast notification: **"Link copied to clipboard"**
* Button text temporarily changes to **"Link Copied ✓"**

---

## Screenshots

Code Changes:

<img width="1293" height="739" alt="Screenshot (841)" src="https://github.com/user-attachments/assets/11e7efcb-2dba-4bb8-a020-a180f1154970" />

<img width="1070" height="184" alt="Screenshot (838)" src="https://github.com/user-attachments/assets/5bf97dc1-2f90-4509-9879-e5bfd113d9f6" />

Before:

<img width="1288" height="648" alt="Screenshot (850)" src="https://github.com/user-attachments/assets/7731fb72-6d2a-428f-a8ca-8e040821f30c" />

* Share button appeared clickable but performed no action.

After:

<img width="1289" height="650" alt="Screenshot (840)" src="https://github.com/user-attachments/assets/f2776db4-f020-43aa-857e-06b7a6ee0253" />

* Clicking the button copies the link and shows feedback.

---

## Testing

Verified that:

* Clipboard copy works correctly
* Toast notification appears on success
* Error handling works if clipboard access fails
* Button state resets after 2 seconds

---

## Related Issue

Closes **#410**
