### PR TITLE
fix: connect shareDiagram logic to header button #421

### DIFF
--- a/app/diagram/page.tsx
+++ b/app/diagram/page.tsx
@@ -5,9 +5,34 @@ import { CreateDocumentGuard } from "@/components/ui/auth-guard";
 import { Sparkles, Workflow, Zap, Star, Wand2, Share2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { DiagramGeneratorSkeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
 
 export default function DiagramPage() {
   const [isLoading, setIsLoading] = useState(true);
+  const { toast } = useToast();
+
+  const handleShare = async () => {
+    try {
+      const shareData = {
+        title: 'DraftDeckAI Diagram Studio',
+        text: 'Check out this AI Diagram Studio!',
+        url: window.location.href
+      };
+      
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(window.location.href);
+        toast({
+          title: "Link copied!",
+          description: "The link has been copied to your clipboard.",
+        });
+      }
+    } catch (error) {
+      console.error('Error sharing:', error);
+    }
+  };
 
   useEffect(() => {
     // Simulate loading
@@ -36,11 +61,16 @@ export default function DiagramPage() {
         <div className="container py-8 sm:py-12 px-4 sm:px-6 lg:px-8">
           {/* Enhanced Header */}
           <div className="text-center mb-8 sm:mb-12">
-            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full glass-effect mb-4 sm:mb-6 shimmer">
-              <Workflow className="h-4 w-4 text-yellow-500" />
+            <Button 
+              variant="ghost" 
+              size="sm" 
+              onClick={handleShare}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-full glass-effect mb-4 sm:mb-6 shimmer hover:scale-105 transition-all group"
+            >
+              <Workflow className="h-4 w-4 text-yellow-500 group-hover:rotate-12 transition-transform" />
               <span className="text-sm font-medium">Diagram Studio</span>
-              <Share2 className="h-4 w-4 text-blue-500" />
-            </div>
+              <Share2 className="h-4 w-4 text-blue-500 group-hover:scale-110 transition-transform" />
+            </Button>
 
             <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 sm:mb-6 leading-tight ">
               Create Visual{" "}

--- a/app/diagram/page.tsx
+++ b/app/diagram/page.tsx
@@ -7,10 +7,49 @@ import { useEffect, useState } from "react";
 import { DiagramGeneratorSkeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+
+  const { toast } = useToast();
+
+  const handleShare = async () => {
+    try {
+      const shareData = {
+        title: 'DraftDeckAI Diagram Studio',
+        text: 'Check out this AI Diagram Studio!',
+        url: window.location.href
+      };
+      
+      if (navigator.share) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(window.location.href);
+        toast({
+          title: "Link copied!",
+          description: "The link has been copied to your clipboard.",
+        });
+      }
+    } catch (error) {
+      console.error('Error sharing:', error);
+    }
+  };
+
 
 export default function DiagramPage() {
   const [isLoading, setIsLoading] = useState(true);
   const { toast } = useToast();
+  
+              <Button 
+              variant="ghost" 
+              size="sm" 
+              onClick={handleShare}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-full glass-effect mb-4 sm:mb-6 shimmer hover:scale-105 transition-all group"
+            >
+              <Workflow className="h-4 w-4 text-yellow-500 group-hover:rotate-12 transition-transform" />
+              <span className="text-sm font-medium">Diagram Studio</span>
+              <Share2 className="h-4 w-4 text-blue-500 group-hover:scale-110 transition-transform" />
+            </Button>
+
 
   const handleShare = async () => {
     try {


### PR DESCRIPTION
This PR resolves issue #421 by converting the static Diagram Studio badge into a functional share button. Closes #421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a share control to Diagram Studio, enabling users to share diagrams via native sharing on supported devices or copy the link to clipboard with a confirmation notification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/433)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->