### PR TITLE
fix: resolve invalid html nesting in desktop site header

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -403,12 +403,12 @@ export function SiteHeader() {
             ) : (
               /* Desktop Sign In Button */
               <TooltipWithShortcut content="Sign in to save and manage your documents">
-                <Link href="/auth/signin">
-                  <Button className="bolt-gradient text-white font-semibold hover:scale-105 transition-all duration-300 text-sm px-4 h-9 hidden md:flex">
+                <Button asChild className="bolt-gradient text-white font-semibold hover:scale-105 transition-all duration-300 text-sm px-4 h-9 hidden md:flex">
+                  <Link href="/auth/signin" className="flex items-center gap-2">
                     <Zap className="h-4 w-4" />
                     <span>Sign In</span>
-                  </Button>
-                </Link>
+                  </Link>
+                </Button>
               </TooltipWithShortcut>
             )}
           </div>


### PR DESCRIPTION
Fixes #431

Implemented the semantic fix by utilizing the `asChild` prop on the Shadcn `Button` component. This resolves the hydration warnings and accessibility issues caused by nesting an interactive `<button>` element inside an anchor `<a>` tag. 

Tested locally to ensure no layout regressions in the desktop header CTA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated site header structure for improved component composition.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/439)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->