### PR TITLE
fix: complete rebranding consistency for active UI (#426)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 GEMINI_API_KEY=your-gemini-api-key-here
 TESTMAIL_API_KEY=your-testmail-api-key-here
 # APP CONFIGURATION
-NEXT_PUBLIC_APP_NAME=DocMagic
+NEXT_PUBLIC_APP_NAME=Draftdeckai
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # SECURITY CONFIGURATION

--- a/components/ui/Footer.tsx
+++ b/components/ui/Footer.tsx
@@ -30,7 +30,7 @@ export default function Footer() {
             </p>
             <div className="flex items-center justify-center sm:justify-start gap-4 pt-2">
               <Link
-                href="https://github.com/Muneerali199/DocMagic"
+                href="https://github.com/Muneerali199/Draftdeckai"
                 className="p-2 rounded-full bg-gray-200/50 dark:bg-gray-800/50 hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-all duration-300 hover:scale-110"
                 aria-label="GitHub"
               >
@@ -101,7 +101,7 @@ export default function Footer() {
             </h4>
             <ul className="space-y-2 sm:space-y-3">
               <li>
-                <Link href="https://github.com/Muneerali199/DocMagic/tree/main/docs" className="text-sm sm:text-base text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300">
+                <Link href="https://github.com/Muneerali199/Draftdeckai/tree/main/docs" className="text-sm sm:text-base text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300">
                   Documentation
                 </Link>
               </li>
@@ -116,12 +116,12 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="https://github.com/Muneerali199/DocMagic/discussions" className="text-sm sm:text-base text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300">
+                <Link href="https://github.com/Muneerali199/Draftdeckai/discussions" className="text-sm sm:text-base text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300">
                   Community
                 </Link>
               </li>
               <li>
-                <Link href="https://github.com/Muneerali199/DocMagic/issues" className="text-sm sm:text-base text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300">
+                <Link href="https://github.com/Muneerali199/Draftdeckai/issues" className="text-sm sm:text-base text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300">
                   Report Issues
                 </Link>
               </li>
@@ -141,12 +141,12 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="https://github.com/Muneerali199/DocMagic/graphs/contributors" className="text-sm sm:text-base text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300">
+                <Link href="https://github.com/Muneerali199/Draftdeckai/graphs/contributors" className="text-sm sm:text-base text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300">
                   Contributors
                 </Link>
               </li>
               <li>
-                <Link href="https://github.com/Muneerali199/DocMagic/blob/main/LICENSE" className="text-sm sm:text-base text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300 flex items-center justify-center sm:justify-start gap-2">
+                <Link href="https://github.com/Muneerali199/Draftdeckai/blob/main/LICENSE" className="text-sm sm:text-base text-muted-foreground hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-300 flex items-center justify-center sm:justify-start gap-2">
                   <Shield className="h-4 w-4" />
                   MIT License
                 </Link>


### PR DESCRIPTION
## Summary
Completed rebranding consistency for active UI components from DocMagic to DraftDeckAI as per issue #426.

## Changes
- Updated Footer repository and external links
- Fixed GitHub URLs across active UI components
- Updated NEXT_PUBLIC_APP_NAME in environment configuration

## Scope Compliance
- Only active UI routes/components were modified
- No changes made to documentation, backups, or historical files (out of scope)
- No link-registry or architectural changes introduced (as instructed in issue #426)

## Grep Summary
- Ran: `grep -r "DocMagic" .`
- Remaining occurrences are ONLY in:
  - Documentation files (Rebranding.md, PromptAllowAllEmails.md, EnhancedPreview.md)
  - Legacy/backup auth pages (page-old-backup.tsx, page-gamma-backup.tsx)
- No DocMagic references remain in active UI components

## Notes
This PR strictly follows maintainer coordination instructions and keeps scope limited to active UI rebranding consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application branding from DocMagic to Draftdeckai
  * Updated project repository links in footer to reflect new project location

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/445)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->