### PR TITLE
fix: replace getSession() with getUser() in server-side routes

### DIFF
--- a/app/api/stripe/check-subscription/route.ts
+++ b/app/api/stripe/check-subscription/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+const { NextResponse } = require('next/server');
 import { createRoute } from '@/lib/supabase/server';
 
 export const dynamic = 'force-dynamic';
@@ -7,17 +7,16 @@ export const runtime = 'nodejs';
 export async function GET() {
   const supabase = await createRoute();
   
-  // Get the current user session
-  const { data: { session } } = await supabase.auth.getSession();
-  
-  if (!session?.user?.email) {
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !user?.email) {
     return NextResponse.json({ subscribed: false }, { status: 200 });
   }
 
   const { data: userData, error } = await supabase
     .from('users')
     .select('subscription:subscriptions(stripe_subscription_id)')
-    .eq('email', session.user.email)
+    .eq('email', user.email)
     .single();
 
   if (error || !userData) {

--- a/app/api/stripe/create-checkout/route.ts
+++ b/app/api/stripe/create-checkout/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+const { NextResponse } = require("next/server");
 import { stripe } from "@/lib/stripe";
 import { createRoute } from "@/lib/supabase/server";
 
@@ -11,10 +11,9 @@ export async function POST() {
   try {
     const supabase = await createRoute();
     
-    // Get the current user session
-    const { data: { session } } = await supabase.auth.getSession();
-    
-    if (!session?.user?.email) {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user?.email) {
       return new NextResponse("Unauthorized", { status: 401 });
     }
 
@@ -22,7 +21,7 @@ export async function POST() {
     const { data: userData, error: userDbError } = await supabase
       .from("users")
       .select("*, subscription:subscriptions(*)")
-      .eq("email", session.user.email)
+      .eq("email", user.email)
       .single();
 
     if (userDbError || !userData) {

--- a/app/api/stripe/create-payment-intent/route.ts
+++ b/app/api/stripe/create-payment-intent/route.ts
@@ -14,10 +14,9 @@ export async function POST(request: Request) {
   try {
     const supabase = await createRoute();
     
-    // Get the current user session
-    const { data: { session } } = await supabase.auth.getSession();
-    
-    if (!session?.user?.email) {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user?.email) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
         status: 401,
         headers: {
@@ -45,8 +44,8 @@ export async function POST(request: Request) {
         enabled: true,
       },
       metadata: {
-        userId: session.user.id,
-        email: session.user.email,
+        userId: user.id,
+        email: user.email,
         ...metadata,
       },
     });

--- a/app/api/stripe/create-portal/route.ts
+++ b/app/api/stripe/create-portal/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+const { NextResponse } = require("next/server");
 import { stripe } from "@/lib/stripe";
 import { createRoute } from "@/lib/supabase/server";
 
@@ -11,18 +11,17 @@ export async function POST() {
   try {
     const supabase = await createRoute();
     
-    // Get the current user session
-    const { data: { session } } = await supabase.auth.getSession();
-    
-    if (!session?.user?.email) {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user?.email) {
       return new NextResponse("Unauthorized", { status: 401 });
     }
-    
+
     // Get user data with subscription
     const { data: userData, error: userError } = await supabase
       .from('users')
       .select('*, subscription:subscriptions(stripe_subscription_id)')
-      .eq('email', session.user.email)
+      .eq('email', user.email)
       .single();
 
     if (userError || !userData) {

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,5 +1,5 @@
 import { createRoute } from "@/lib/supabase/server";
-import { NextResponse } from "next/server";
+const { NextResponse } = require("next/server");
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -7,17 +7,16 @@ export const runtime = 'nodejs';
 export async function GET() {
   const supabase = await createRoute();
   
-  // Get the current user session
-  const { data: { session } } = await supabase.auth.getSession();
-  
-  if (!session?.user?.email) {
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !user?.email) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
   const { data, error } = await supabase
     .from("users")
     .select("*, subscription:subscriptions(*)")
-    .eq("email", session.user.email)
+    .eq("email", user.email)
     .single();
 
   if (error || !data) {


### PR DESCRIPTION
<p style="white-space: pre-wrap; margin-top: 0px; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Title:</strong> <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fix: Replace getSession() with getUser() in Server-Side Routes</code></p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>4 server-side API routes were using<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">supabase.auth.getSession()</code><span> </span>to authenticate requests</li><li>Supabase explicitly warns this is insecure on the server — session data comes from the client cookie and is<span> </span><strong>never validated</strong><span> </span>against the Auth server</li><li>Replaced with<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">supabase.auth.getUser()</code><span> </span>which makes a network call to verify the token is legitimate</li></ul><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files Changed</h2>
File | Risk
-- | --
app/api/user/route.ts | Exposed user + subscription data
app/api/stripe/check-subscription/route.ts | Leaked subscription status
app/api/stripe/create-portal/route.ts | Created Stripe billing portal for unverified user
app/api/stripe/create-checkout/route.ts | Created Stripe checkout under unverified identity

<h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Change Made (same in all 4 files)</h2><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(18, 19, 20); border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-ts" style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">// Before — insecure ❌
const { data: { session } } = await supabase.auth.getSession();
if (!session?.user?.email) {
  return new NextResponse("Unauthorized", { status: 401 });
}
// session.user.email is never server-validated

// After — secure ✅
const { data: { user }, error: authError } = await supabase.auth.getUser();
if (authError || !user?.email) {
  return new NextResponse("Unauthorized", { status: 401 });
}
// user.email is verified against Supabase Auth server
</code></pre></div><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">References</h2><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><a href="https://supabase.com/docs/guides/auth/server-side/nextjs" target="_blank" rel="noopener noreferrer" style="color: rgb(72, 160, 199);">Supabase Docs — Auth with Next.js</a>:<span> </span><em>"Never trust data from getSession() on the server. Always use getUser() to verify the user's identity."</em></li></ul><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test Plan</h2><ul class="contains-task-list" style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Sign in and call<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/api/user</code><span> </span>→ should return user data</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Call<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/api/user</code><span> </span>without a session → should return<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">401</code></li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Call<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/api/stripe/check-subscription</code><span> </span>without a session → should return<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">{ subscribed: false }</code></li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Call<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/api/stripe/create-portal</code><span> </span>without a session → should return<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">401</code></li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Call<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/api/stripe/create-checkout</code><span> </span>without a session → should return<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">401</code></li></ul>Title: fix: Replace getSession() with getUser() in Server-Side Routes

Summary
4 server-side API routes were using supabase.auth.getSession() to authenticate requests
Supabase explicitly warns this is insecure on the server — session data comes from the client cookie and is never validated against the Auth server
Replaced with supabase.auth.getUser() which makes a network call to verify the token is legitimate
Files Changed
File	Risk
app/api/user/route.ts	Exposed user + subscription data
app/api/stripe/check-subscription/route.ts	Leaked subscription status
app/api/stripe/create-portal/route.ts	Created Stripe billing portal for unverified user
app/api/stripe/create-checkout/route.ts	Created Stripe checkout under unverified identity
Change Made (same in all 4 files)

// Before — insecure ❌
const { data: { session } } = await supabase.auth.getSession();
if (!session?.user?.email) {
  return new NextResponse("Unauthorized", { status: 401 });
}
// session.user.email is never server-validated

// After — secure ✅
const { data: { user }, error: authError } = await supabase.auth.getUser();
if (authError || !user?.email) {
  return new NextResponse("Unauthorized", { status: 401 });
}
// user.email is verified against Supabase Auth server
References
[Supabase Docs — Auth with Next.js](https://supabase.com/docs/guides/auth/server-side/nextjs): "Never trust data from getSession() on the server. Always use getUser() to verify the user's identity."
Test Plan
 Sign in and call /api/user → should return user data
 Call /api/user without a session → should return 401
 Call /api/stripe/check-subscription without a session → should return { subscribed: false }
 Call /api/stripe/create-portal without a session → should return 401
 Call /api/stripe/create-checkout without a session → should return 401



CLOSES ##473