### PR TITLE
Fix/export button animation

### DIFF
--- a/components/diagram/diagram-generator.tsx
+++ b/components/diagram/diagram-generator.tsx
@@ -165,7 +165,7 @@ export function DiagramGenerator() {
   const [selectedDiagramType, setSelectedDiagramType] = useState("flowchart");
   const [isGenerating, setIsGenerating] = useState(false);
   const [isCopying, setIsCopying] = useState(false);
-  const [isExporting, setIsExporting] = useState(false);
+  const [exportingFormat, setExportingFormat] = useState<'png' | 'svg' | null>(null);
   const [activeTab, setActiveTab] = useState("editor");
   const { toast } = useToast();
   const { user } = useAuth();
@@ -294,7 +294,7 @@ export function DiagramGenerator() {
   const exportDiagram = async (format: 'png' | 'svg') => {
     if (!diagramRef.current) return;
     
-    setIsExporting(true);
+    setExportingFormat(format);
     
     try {
       const element = diagramRef.current.querySelector('#mermaid-diagram');
@@ -359,7 +359,7 @@ export function DiagramGenerator() {
         variant: "destructive",
       });
     } finally {
-      setIsExporting(false);
+      setExportingFormat(null);
     }
   };
 
@@ -661,10 +661,10 @@ export function DiagramGenerator() {
                   <Button
                     variant="outline"
                     onClick={() => exportDiagram('png')}
-                    disabled={isExporting}
+                    disabled={exportingFormat === 'png'}
                     className="glass-effect border-yellow-400/30 hover:border-yellow-400/60"
                   >
-                    {isExporting ? (
+                    {exportingFormat === 'png' ? (
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                     ) : (
                       <FileImage className="mr-2 h-4 w-4" />
@@ -674,10 +674,10 @@ export function DiagramGenerator() {
                   <Button
                     variant="outline"
                     onClick={() => exportDiagram('svg')}
-                    disabled={isExporting}
+                    disabled={exportingFormat === 'svg'}
                     className="glass-effect border-yellow-400/30 hover:border-yellow-400/60"
                   >
-                    {isExporting ? (
+                    {exportingFormat === 'svg' ? (
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                     ) : (
                       <Download className="mr-2 h-4 w-4" />
@@ -742,7 +742,7 @@ export function DiagramGenerator() {
               <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-4">
                 <Button
                   onClick={() => exportDiagram('png')}
-                  disabled={isExporting}
+                  disabled={exportingFormat === 'png'}
                   className="bolt-gradient text-white font-semibold hover:scale-105 transition-all duration-300 text-sm sm:text-base py-2 sm:py-3"
                 >
                   <FileImage className="mr-1 sm:mr-2 h-3 w-3 sm:h-4 sm:w-4" />
@@ -751,7 +751,7 @@ export function DiagramGenerator() {
                 </Button>
                 <Button
                   onClick={() => exportDiagram('svg')}
-                  disabled={isExporting}
+                  disabled={exportingFormat === 'svg'}
                   variant="outline"
                   className="glass-effect border-yellow-400/30 hover:border-yellow-400/60 text-sm sm:text-base py-2 sm:py-3"
                 >

--- a/components/resume/resume-navigation.tsx
+++ b/components/resume/resume-navigation.tsx
@@ -38,7 +38,7 @@ export function ResumeNavigation({ currentStep, onStepChange, progress = 0 }: Re
 
   return (
     <div className="w-full mb-6">
-      <div className="flex items-center justify-center gap-2 mb-2 overflow-x-auto pb-2 resume-nav">
+      <div className="flex items-center justify-center gap-2 mb-2 overflow-x-auto pb-3 pt-1 px-1 resume-nav">
         {steps.map((step, index) => (
           <div key={step.id} className="flex items-center">
             <button
@@ -46,7 +46,7 @@ export function ResumeNavigation({ currentStep, onStepChange, progress = 0 }: Re
                 "flex items-center gap-2 px-3 py-2 rounded-full transition-all whitespace-nowrap cursor-pointer resume-nav-item",
                 currentStep === step.id
                   ? "active bg-primary text-white font-semibold shadow-md"
-                  : "hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                  : "hover:bg-blue-50 dark:hover:bg-blue-900/20 dark:hover:text-white"
               )}
               onClick={() => onStepChange(step.id)}
             >

--- a/components/resume/resume-navigation.tsx
+++ b/components/resume/resume-navigation.tsx
@@ -38,7 +38,7 @@ export function ResumeNavigation({ currentStep, onStepChange, progress = 0 }: Re
 
   return (
     <div className="w-full mb-6">
-      <div className="flex items-center justify-center gap-2 mb-2 overflow-x-auto pb-3 pt-1 px-1 resume-nav">
+      <div className="flex items-center justify-center gap-2 mb-2 overflow-x-auto pb-2 resume-nav">
         {steps.map((step, index) => (
           <div key={step.id} className="flex items-center">
             <button
@@ -46,7 +46,7 @@ export function ResumeNavigation({ currentStep, onStepChange, progress = 0 }: Re
                 "flex items-center gap-2 px-3 py-2 rounded-full transition-all whitespace-nowrap cursor-pointer resume-nav-item",
                 currentStep === step.id
                   ? "active bg-primary text-white font-semibold shadow-md"
-                  : "hover:bg-blue-50 dark:hover:bg-blue-900/20 dark:hover:text-white"
+                  : "hover:bg-blue-50 dark:hover:bg-blue-900/20"
               )}
               onClick={() => onStepChange(step.id)}
             >


### PR DESCRIPTION
## Description

Fixes #277

Both Export PNG and Export SVG buttons shared a single `isExporting` 
state, causing both buttons to animate when only PNG was clicked.

## Type of Change


- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Replaced `isExporting: boolean` with `exportingFormat: 'png' | 'svg' | null`
- PNG button now only animates when PNG is exporting
- SVG button now only animates when SVG is exporting
- Both buttons work independently without affecting each other
## Dependencies

none

## Add Screenshots
Unable to capture screenshot locally as OAuth login is not configured 
in dev environment. Bug and expected behavior clearly described in issue #277.

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] I have tested my changes across major browsers/devices
- [x] I have tested my changes in development mode (`npm run dev`)
- [ ] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.
