### PR TITLE
Fix: Dark theme text contrast in Resume/ATS analyzer (Issue #314)

### DIFF
--- a/components/resume/ats-analyzer.tsx
+++ b/components/resume/ats-analyzer.tsx
@@ -204,7 +204,7 @@ export function ATSAnalyzer() {
                       </h5>
                       <div className="flex flex-wrap gap-1">
                         {displayAnalysis.analysis.keywordMatch.found?.map((k: string, i: number) => (
-                          <span key={i} className="text-xs px-2 py-1 rounded-full bg-green-100 text-green-700">
+                          <span key={i} className="text-xs px-2 py-1 rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300">
                             {k}
                           </span>
                         ))}
@@ -217,7 +217,7 @@ export function ATSAnalyzer() {
                       </h5>
                       <div className="flex flex-wrap gap-1">
                         {displayAnalysis.analysis.keywordMatch.missing?.map((k: string, i: number) => (
-                          <span key={i} className="text-xs px-2 py-1 rounded-full bg-red-100 text-red-700">
+                          <span key={i} className="text-xs px-2 py-1 rounded-full bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300">
                             {k}
                           </span>
                         ))}
@@ -231,7 +231,7 @@ export function ATSAnalyzer() {
               {displayAnalysis.improvements?.critical && (
                 <div>
                   <h4 className="font-medium mb-2">Critical Improvements</h4>
-                  <ul className="space-y-2 text-sm text-red-600">
+                  <ul className="space-y-2 text-sm text-red-600 dark:text-red-400">
                     {displayAnalysis.improvements.critical.map((tip: string, i: number) => (
                       <li key={i} className="flex items-start gap-2">
                         <AlertCircle className="h-4 w-4 mt-1 flex-shrink-0" />
@@ -245,7 +245,7 @@ export function ATSAnalyzer() {
               {displayAnalysis.improvements?.recommended && (
                 <div>
                   <h4 className="font-medium mb-2">Recommended Enhancements</h4>
-                  <ul className="space-y-2 text-sm text-yellow-600">
+                  <ul className="space-y-2 text-sm text-yellow-600 dark:text-yellow-400">
                     {displayAnalysis.improvements.recommended.map((tip: string, i: number) => (
                       <li key={i} className="flex items-start gap-2">
                         <AlertCircle className="h-4 w-4 mt-1 flex-shrink-0" />
@@ -261,7 +261,7 @@ export function ATSAnalyzer() {
                   <h4 className="font-medium mb-2">AI Suggestions</h4>
                   <div className="space-y-2">
                     {displayAnalysis.improvements.aiSuggestions.map((suggestion: string, i: number) => (
-                      <div key={i} className="flex gap-2 p-3 bg-blue-50 rounded-lg text-sm">
+                      <div key={i} className="flex gap-2 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg text-sm">
                         <Sparkles className="h-4 w-4 mt-1 flex-shrink-0 text-blue-500" />
                         {suggestion}
                       </div>

--- a/components/resume/ats-score-display.tsx
+++ b/components/resume/ats-score-display.tsx
@@ -41,13 +41,13 @@ export function ATSScoreDisplay({ atsScore }: { atsScore: ATSScoreProps }) {
   };
 
   const getScoreBgColor = (score: number) => {
-    if (score >= 90) return 'bg-green-100 border-green-300';
-    if (score >= 85) return 'bg-green-50 border-green-200';
-    if (score >= 80) return 'bg-blue-100 border-blue-300';
-    if (score >= 75) return 'bg-blue-50 border-blue-200';
-    if (score >= 70) return 'bg-yellow-100 border-yellow-300';
-    if (score >= 60) return 'bg-orange-100 border-orange-300';
-    return 'bg-red-100 border-red-300';
+    if (score >= 90) return 'bg-green-100 border-green-300 dark:bg-green-900/20 dark:border-green-800';
+    if (score >= 85) return 'bg-green-50 border-green-200 dark:bg-green-900/10 dark:border-green-800/50';
+    if (score >= 80) return 'bg-blue-100 border-blue-300 dark:bg-blue-900/20 dark:border-blue-800';
+    if (score >= 75) return 'bg-blue-50 border-blue-200 dark:bg-blue-900/10 dark:border-blue-800/50';
+    if (score >= 70) return 'bg-yellow-100 border-yellow-300 dark:bg-yellow-900/20 dark:border-yellow-800';
+    if (score >= 60) return 'bg-orange-100 border-orange-300 dark:bg-orange-900/20 dark:border-orange-800';
+    return 'bg-red-100 border-red-300 dark:bg-red-900/20 dark:border-red-800';
   };
 
   const getProgressColor = (score: number) => {
@@ -82,7 +82,9 @@ export function ATSScoreDisplay({ atsScore }: { atsScore: ATSScoreProps }) {
     <Card className="glass-effect border-2 border-green-200/50 shadow-xl overflow-hidden dark:bg-gray-800 dark:border-green-700/50">
       <CardHeader className={cn(
         "bg-gradient-to-r border-b transition-colors dark:from-gray-800 dark:to-gray-800",
-        atsScore.score >= 85 ? "from-green-50 to-blue-50" : "from-orange-50 to-yellow-50"
+        atsScore.score >= 85 
+          ? "from-green-50 to-blue-50 dark:from-green-900/10 dark:to-blue-900/10" 
+          : "from-orange-50 to-yellow-50 dark:from-orange-900/10 dark:to-yellow-900/10"
       )}>
         <CardTitle className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <span className="flex items-center gap-2 text-base sm:text-lg">


### PR DESCRIPTION
This PR resolves the text contrast issues in the Resume/ATS analyzer section when using the dark theme. By implementing adaptive Tailwind CSS classes (dark:bg-* and dark:text-*), it ensures that feedback boxes, tags, and score displays have proper contrast in both light and dark modes. Resolves #314.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style
- Added comprehensive dark-mode visuals for keyword tags, improvement lists, and suggestion panels in the ATS analyzer.
- Enhanced dark-mode styling for the score display, including background, border, and gradient variants across all score ranges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->