### PR TITLE
fix: Prevent app crash on boot when Stripe secret key is missing

### DIFF
--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,14 +1,13 @@
 import Stripe from "stripe";
 
-if (!process.env.STRIPE_SECRET_KEY) {
-  throw new Error('STRIPE_SECRET_KEY is not set in environment variables');
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY || 'dummy_key_to_prevent_build_errors';
+
+// Warn instead of throwing to prevent crashing the app at module load
+if (!process.env.STRIPE_SECRET_KEY || process.env.STRIPE_SECRET_KEY.includes('your_str')) {
+  console.warn('⚠️ STRIPE_SECRET_KEY is missing or using a placeholder. Stripe features will not work until this is updated in .env');
 }
 
-if (process.env.STRIPE_SECRET_KEY.includes('your_str')) {
-  throw new Error('STRIPE_SECRET_KEY is still set to placeholder value. Please update your .env file with your actual Stripe secret key from https://dashboard.stripe.com/apikeys');
-}
-
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+export const stripe = new Stripe(stripeSecretKey, {
   apiVersion: "2023-10-16",
   typescript: true,
 });


### PR DESCRIPTION
## Description

This PR fixes a critical initialization bug where the application crashes on boot if the STRIPE_SECRET_KEY is missing or set to the default placeholder in .env.

Previously, lib/stripe.ts threw a hard error at the module level. Since this file is imported by API routes, simply starting the development server (npm run dev) or building the project would cause an immediate crash. This fix allows the application to boot normally for new contributors while logging a warning.

Fixes #512

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] [ ] Other (please specify): ____________________

## Changes Made

- Modified lib/stripe.ts to use a dummy_key_to_prevent_build_errors fallback when STRIPE_SECRET_KEY is not correctly configured.
- Replaced the top-level throw new Error() with a console.warn(). This prevents the Next.js compilation step from crashing while still actively warning the developer that Stripe functionality will not work until the .env file is updated.

## Dependencies

- No new dependencies were added.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers/devices
- [x] I have tested my changes in development mode (`npm run dev`)
- [ ] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.
