### PR TITLE
fix: remove hardcoded debug label from resume builder UI

### DIFF
--- a/app/resume-builder/page.tsx
+++ b/app/resume-builder/page.tsx
@@ -361,7 +361,7 @@ function ResumeBuilderContent() {
                       ✏️ Editing Template: {templateId}
                     </p>
                     <p className="text-xs text-gray-600">Click any text to edit directly • Changes save automatically</p>
-                    <p className="text-xs text-blue-600 font-mono mt-1">DEBUG: template="{templateId}"</p>
+          
                   </div>
                 </div>
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
## Description

Removed the hardcoded DEBUG label rendered in the Resume Builder UI.

## Changes Made

* Removed unnecessary debug text:
  `DEBUG: template="{templateId}"`
* Kept existing template editing UI unchanged.

## Issue Fixed

Closes #424


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed debug template information that was inadvertently displayed in the resume builder interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->