### PR TITLE
Removed hardcoded DEBUG label from Resume Builder UI

### DIFF
--- a/app/resume-builder/page.tsx
+++ b/app/resume-builder/page.tsx
@@ -361,7 +361,6 @@ function ResumeBuilderContent() {
                       ✏️ Editing Template: {templateId}
                     </p>
                     <p className="text-xs text-gray-600">Click any text to edit directly • Changes save automatically</p>
-                    <p className="text-xs text-blue-600 font-mono mt-1">DEBUG: template="{templateId}"</p>
                   </div>
                 </div>
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
## Description

Removed the hardcoded DEBUG label from the Resume Builder UI.

## Changes Made

* Removed unnecessary DEBUG text from production UI
* Cleaned up Resume Builder interface

## Related Issue

Closes #424
