### PR TITLE
fix(security): add rel="noopener noreferrer" to target="_blank" links

### DIFF
--- a/app/diagnostic/page.tsx
+++ b/app/diagnostic/page.tsx
@@ -132,9 +132,10 @@ export default async function DiagnosticPage() {
             >
               Sign In
             </a>
-            <a 
-              href="https://dashboard.stripe.com/test/products" 
+            <a
+              href="https://dashboard.stripe.com/test/products"
               target="_blank"
+              rel="noopener noreferrer"
               className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 transition"
             >
               Stripe Dashboard

--- a/components/sponsor-banner.tsx
+++ b/components/sponsor-banner.tsx
@@ -16,9 +16,10 @@ export function SponsorBanner() {
           <span className="text-muted-foreground">Powered by</span>
         </div>
         
-        <Link 
-          href="https://teamblitz.netlify.app/" 
+        <Link
+          href="https://teamblitz.netlify.app/"
           target="_blank"
+          rel="noopener noreferrer"
           className="inline-flex items-center gap-1 bolt-gradient-text font-bold hover:scale-105 transition-transform duration-200 flex-shrink-0"
         >
           <Zap className="h-3 w-3 sm:h-4 sm:w-4" />

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -418,7 +418,7 @@
                 </div>
             </div>
             <div class="footer-links">
-                <a href="https://draftdeckai.com" target="_blank">Powered by DraftDeckAI</a>
+                <a href="https://draftdeckai.com" target="_blank" rel="noopener noreferrer">Powered by DraftDeckAI</a>
                 <span>•</span>
                 <a href="#" id="settings-link">Settings</a>
             </div>

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -86,9 +86,9 @@
                         <button class="btn-toggle-visibility" onclick="togglePasswordVisibility('gemini-api-key')">👁️</button>
                     </div>
                     <div class="api-key-help">
-                        <a href="https://makersuite.google.com/app/apikey" target="_blank">Get API Key</a>
+                        <a href="https://makersuite.google.com/app/apikey" target="_blank" rel="noopener noreferrer">Get API Key</a>
                         <span>•</span>
-                        <a href="https://ai.google.dev/tutorials/setup" target="_blank">Documentation</a>
+                        <a href="https://ai.google.dev/tutorials/setup" target="_blank" rel="noopener noreferrer">Documentation</a>
                     </div>
                 </div>
 
@@ -103,9 +103,9 @@
                         <button class="btn-toggle-visibility" onclick="togglePasswordVisibility('openai-api-key')">👁️</button>
                     </div>
                     <div class="api-key-help">
-                        <a href="https://platform.openai.com/api-keys" target="_blank">Get API Key</a>
+                        <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener noreferrer">Get API Key</a>
                         <span>•</span>
-                        <a href="https://platform.openai.com/docs" target="_blank">Documentation</a>
+                        <a href="https://platform.openai.com/docs" target="_blank" rel="noopener noreferrer">Documentation</a>
                     </div>
                 </div>
 
@@ -120,9 +120,9 @@
                         <button class="btn-toggle-visibility" onclick="togglePasswordVisibility('mistral-api-key')">👁️</button>
                     </div>
                     <div class="api-key-help">
-                        <a href="https://console.mistral.ai/api-keys" target="_blank">Get API Key</a>
+                        <a href="https://console.mistral.ai/api-keys" target="_blank" rel="noopener noreferrer">Get API Key</a>
                         <span>•</span>
-                        <a href="https://docs.mistral.ai" target="_blank">Documentation</a>
+                        <a href="https://docs.mistral.ai" target="_blank" rel="noopener noreferrer">Documentation</a>
                     </div>
                 </div>
 
@@ -137,9 +137,9 @@
                         <button class="btn-toggle-visibility" onclick="togglePasswordVisibility('claude-api-key')">👁️</button>
                     </div>
                     <div class="api-key-help">
-                        <a href="https://console.anthropic.com/account/keys" target="_blank">Get API Key</a>
+                        <a href="https://console.anthropic.com/account/keys" target="_blank" rel="noopener noreferrer">Get API Key</a>
                         <span>•</span>
-                        <a href="https://docs.anthropic.com" target="_blank">Documentation</a>
+                        <a href="https://docs.anthropic.com" target="_blank" rel="noopener noreferrer">Documentation</a>
                     </div>
                 </div>
             </section>
@@ -218,7 +218,7 @@
 
         <!-- Footer -->
         <footer class="settings-footer">
-            <p>DraftDeckAI Extension v2.0 • <a href="https://draftdeckai.com" target="_blank">Documentation</a></p>
+            <p>DraftDeckAI Extension v2.0 • <a href="https://draftdeckai.com" target="_blank" rel="noopener noreferrer">Documentation</a></p>
         </footer>
     </div>
 


### PR DESCRIPTION
## Summary

Adds the missing `rel="noopener noreferrer"` attribute to 12 external `target="_blank"` links across the web app and the browser extension. Without this attribute, the opened page receives a `window.opener` reference and can silently redirect the original tab to an arbitrary URL (reverse-tabnabbing). This is OWASP-recommended hardening and is flagged by the standard ESLint rule `react/jsx-no-target-blank`.

Closes #550

## Changes

| File | Instances |
|------|-----------|
| `app/diagnostic/page.tsx` | 1 (Stripe Dashboard link) |
| `components/sponsor-banner.tsx` | 1 (Team⚡Blitz sponsor link) |
| `extension/popup.html` | 1 (footer "Powered by" link) |
| `extension/settings.html` | 9 (Gemini, OpenAI, Mistral, Anthropic API-key + docs links, plus footer) |

Diff stats: **4 files changed, +16 / -14**. Purely additive HTML/JSX attribute; no behavioral change.

## Why this matters

A page opened from an unprotected `target="_blank"` link can execute:

```js
window.opener.location = "https://phishing-example.com";
```

…silently redirecting the user's original tab to a malicious page. While modern Chromium/Firefox/Safari versions added implicit `noopener` for `target="_blank"`, this is **not** guaranteed across older browsers or in browser-extension contexts, so the explicit attribute is industry-standard. Reference: [OWASP — Reverse Tabnabbing](https://owasp.org/www-community/attacks/Reverse_Tabnabbing), [MDN — `rel=noopener`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noopener).

## Test plan

- [x] All 12 instances now include `rel="noopener noreferrer"` (verified via `grep -rn 'target="_blank"' app/ components/ extension/`)
- [x] No remaining instances of `target="_blank"` without `rel` in the repo
- [x] No logic, type, or import changes — purely HTML attribute additions
- [x] Diff reviewed: only the 4 files in scope are touched
- [ ] CI: lint / typecheck / build

## Notes

- Filed this issue myself (#550) and prepared the fix immediately. Submitting under **GSSoC '26**.
- Scope intentionally minimal — only adds the missing `rel` attribute. Did not touch links that already had `rel` correctly set (e.g. `components/resume/resume-preview.tsx`, `app/profile/page.tsx`, `components/resume-editor/preview-panel.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced security attributes on external links throughout the application diagnostic page, sponsor banner component, and browser extension interfaces (popup and settings pages) to standardize external navigation handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->