### PR TITLE
fix(auth): use supabase.auth.getSession() instead of non-existent localStorage key

### DIFF
--- a/components/resume/ATSScoreDisplay.tsx
+++ b/components/resume/ATSScoreDisplay.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
+import { createClient } from '@/lib/supabase/client';
 import { 
   CheckCircle2, 
   XCircle, 
@@ -50,12 +51,14 @@ export default function ATSScoreDisplay({ resumeData, onClose }: ATSScoreProps) 
   const calculateScore = async () => {
     setLoading(true);
     try {
-      const token = localStorage.getItem('supabase_token');
+      const supabase = createClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token;
       const response = await fetch('/api/resume/ats-score', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          ...(token && { 'Authorization': `Bearer ${token}` })
         },
         body: JSON.stringify({
           resumeData,

--- a/components/resume/ai-resume-chat.tsx
+++ b/components/resume/ai-resume-chat.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Loader2, Send, Sparkles, CheckCircle2, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
+import { createClient } from '@/lib/supabase/client';
 
 interface Message {
   role: 'user' | 'assistant';
@@ -47,12 +48,14 @@ export function AIResumeChat({ resumeData, onResumeUpdate }: AIResumeChatProps) 
     setIsLoading(true);
 
     try {
-      const token = localStorage.getItem('supabase_token');
+      const supabase = createClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token;
       const response = await fetch('/api/resume/improve', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
+          ...(token && { 'Authorization': `Bearer ${token}` })
         },
         body: JSON.stringify({
           resumeData,


### PR DESCRIPTION
## Summary

Fixes a silent auth failure in two user-facing resume features. Both `AIResumeChat` and `ATSScoreDisplay` were reading a Supabase access token from `localStorage.getItem('supabase_token')` — but that key is **never written anywhere in the repo** (verified by repo-wide grep). Result: every request was sent as `Authorization: Bearer null` and rejected by the API, so the features failed for all users.

Replaced with the project-standard `supabase.auth.getSession()` pattern that 24 other files already use (e.g. `hooks/use-user.ts`, `components/auth-provider.tsx`).

Closes #557

## Changes

| File | Change |
|---|---|
| `components/resume/ai-resume-chat.tsx` | Replace `localStorage.getItem('supabase_token')` with `supabase.auth.getSession()` |
| `components/resume/ATSScoreDisplay.tsx` | Same fix |

Diff stats: **2 files changed, +10 / -4**. No new dependencies, no architectural change, no API change.

## Before / After

**Before (broken):**
```tsx
const token = localStorage.getItem('supabase_token'); // always null
const response = await fetch('/api/resume/improve', {
  headers: {
    'Content-Type': 'application/json',
    'Authorization': `Bearer ${token}` // sends "Bearer null"
  },
  ...
});
```

**After (fixed):**
```tsx
const supabase = createClient();
const { data: { session } } = await supabase.auth.getSession();
const token = session?.access_token;
const response = await fetch('/api/resume/improve', {
  headers: {
    'Content-Type': 'application/json',
    ...(token && { 'Authorization': `Bearer ${token}` })
  },
  ...
});
```

The conditional spread `...(token && { Authorization: ... })` ensures we never send a literal `Bearer null` header again — if the user is not logged in, the header is simply omitted (and the API can return a proper 401 instead of attempting to validate `"null"`).

## Why this is correct

- **The pattern is proven** — `hooks/use-user.ts` and 23 other files in the repo already use `supabase.auth.getSession()` to retrieve the current session/token.
- **Scope is minimal** — only the two broken files are touched; no refactor, no abstraction, no new helper.
- **No behavior change for callers** — same component API, same network endpoint, same payload shape.

## Test Plan

- [x] Verified `localStorage.setItem('supabase_token', ...)` has zero matches in the repo (confirming the key is never written)
- [x] Confirmed `@/lib/supabase/client` is the standard client import used elsewhere (e.g. `hooks/use-user.ts:3`)
- [x] Diff reviewed: only the two affected files changed
- [ ] Manual: send a message in AI Resume Coach — should now receive a valid AI response instead of error
- [ ] Manual: click "Calculate ATS Score" — should now return the analysis instead of failing silently
- [ ] Network tab: Authorization header now contains the real JWT (or is omitted if logged out), never `Bearer null`

## Notes

- CI baseline: the existing `test-and-build (20.x)` failure on `main` is a pre-existing TS5103 issue unrelated to this PR (same as #551). This PR only changes two component files; no build/TS config is touched.
- Submitting under GSSoC '26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved authentication mechanism for resume analysis features to enhance security and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->