### PR TITLE
fix(config): enable reactStrictMode

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@ import withPWACore from 'next-pwa';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: false,
+  reactStrictMode: true,
   allowedDevOrigins: ['https://kindlier-tawna-nontypographic.ngrok-free.dev'],
 images: {
     unoptimized: false,


### PR DESCRIPTION
Closes #591

Enables React Strict Mode by setting reactStrictMode: true in next.config.js.

Strict Mode intentionally double-invokes renders in development to surface 
bugs such as missing useEffect cleanup, deprecated API usage, and unexpected 
side effects in component bodies — none of which are caught with it disabled.

Changes:
- `next.config.js`: reactStrictMode set from false to true