### PR TITLE
Fix/react query devtools prod [GSSoC 2026]

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -41,7 +41,9 @@ export function Providers({ children }: { children: ReactNode }) {
           </TooltipProvider>
         </ThemeProvider>
       </AuthProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
+      {process.env.NODE_ENV === 'development' && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
     </QueryClientProvider>
   );
 }

--- a/components/letter/CoverLetterFromResume.tsx
+++ b/components/letter/CoverLetterFromResume.tsx
@@ -1,85 +1,85 @@
-\"use client\";
+"use client";
 
 import { useState } from "react";
 
 export default function CoverLetterFromResume() {
-  const [resume, setResume] = useState(\"\"");
-  const [jobDescription, setJobDescription] = useState(\"\"");
-  const [tone, setTone] = useState(\"professional\");
-  const [output, setOutput] = useState(\"\"");
+  const [resume, setResume] = useState("");
+  const [jobDescription, setJobDescription] = useState("");
+  const [tone, setTone] = useState("professional");
+  const [output, setOutput] = useState("");
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(\"\"");
+  const [error, setError] = useState("");
 
   async function generate() {
-    setError(\"\");
-    setOutput(\"\"");
+    setError("");
+    setOutput("");
     if (!resume.trim() || !jobDescription.trim()) {
-      setError(\"Please provide both resume and job description\");
+      setError("Please provide both resume and job description");
       return;
     }
     setLoading(true);
     try {
-      const res = await fetch(\"/api/generate/cover-letter-from-resume\", {
-        method: \"POST\",
-        headers: { \"Content-Type\": \"application/json\" },
+      const res = await fetch("/api/generate/cover-letter-from-resume", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ resume, jobDescription, tone }),
       });
       const data = await res.json();
       if (!res.ok) {
-        setError(data?.error || \"Failed to generate cover letter\");
+        setError(data?.error || "Failed to generate cover letter");
       } else {
-        setOutput(data?.text || \"\");
+        setOutput(data?.text || "");
       }
     } catch (e: any) {
-      setError(e?.message || \"Failed to generate cover letter\");
+      setError(e?.message || "Failed to generate cover letter");
     } finally {
       setLoading(false);
     }
   }
 
   return (
-    <div style={{ display: \"grid\", gap: 16 }}>
-      <div style={{ display: \"grid\", gap: 8 }}>
+    <div style={{ display: "grid", gap: 16 }}>
+      <div style={{ display: "grid", gap: 8 }}>
         <label>Resume</label>
         <textarea
           value={resume}
           onChange={(e) => setResume(e.target.value)}
           rows={10}
-          placeholder=\"Paste your resume content\"
-          style={{ width: \"100%\" }}
+          placeholder="Paste your resume content"
+          style={{ width: "100%" }}
         />
       </div>
-      <div style={{ display: \"grid\", gap: 8 }}>
+      <div style={{ display: "grid", gap: 8 }}>
         <label>Job Description</label>
         <textarea
           value={jobDescription}
           onChange={(e) => setJobDescription(e.target.value)}
           rows={10}
-          placeholder=\"Paste the job description\"
-          style={{ width: \"100%\" }}
+          placeholder="Paste the job description"
+          style={{ width: "100%" }}
         />
       </div>
-      <div style={{ display: \"grid\", gap: 8 }}>
+      <div style={{ display: "grid", gap: 8 }}>
         <label>Tone</label>
         <input
           value={tone}
           onChange={(e) => setTone(e.target.value)}
-          placeholder=\"e.g., professional, friendly\"
-          style={{ width: \"100%\" }}
+          placeholder="e.g., professional, friendly"
+          style={{ width: "100%" }}
         />
       </div>
       <button onClick={generate} disabled={loading} style={{ padding: 10 }}>
-        {loading ? \"Generating...\" : \"Generate Cover Letter\"}
+        {loading ? "Generating..." : "Generate Cover Letter"}
       </button>
-      {error ? <div style={{ color: \"red\" }}>{error}</div> : null}
-      <div style={{ display: \"grid\", gap: 8 }}>
+      {error ? <div style={{ color: "red" }}>{error}</div> : null}
+      <div style={{ display: "grid", gap: 8 }}>
         <label>Output</label>
         <textarea
           value={output}
           readOnly
           rows={16}
-          placeholder=\"The generated cover letter will appear here\"
-          style={{ width: \"100%\" }}
+          placeholder="The generated cover letter will appear here"
+          style={{ width: "100%" }}
         />
       </div>
     </div>


### PR DESCRIPTION
### Description
This PR resolves two key issues:
1. **Unconditional Devtools rendering**: Conditionally renders `ReactQueryDevtools` in `app/providers.tsx` only when `process.env.NODE_ENV === 'development'`. This allows Next.js to safely tree-shake the package out of production builds, improving bundle size and security.
2. **Production compile syntax fix**: Resolves a pre-existing syntax error in `components/letter/CoverLetterFromResume.tsx` caused by unescaped double quotes on client-side state hooks which blocked `npm run build` from succeeding.

### Related Issue
Closes #601 with an additional issue

### How Has This Been Tested?
- Verified compilation and production build by successfully running `npm run build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Development tools initialization now restricted to development environments.

* **Style**
  * Code formatting updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->