### PR TITLE
feat: add template capability matrix and compatibility guardrails (#586)

### DIFF
--- a/components/templates/capability-badge.tsx
+++ b/components/templates/capability-badge.tsx
@@ -1,0 +1,55 @@
+import { TemplateCapabilities } from "@/types/template";
+import { Badge } from "@/components/ui/badge";
+import { checkCompatibility, UserSelections } from "@/lib/templateCompatibility";
+import { AlertTriangle } from "lucide-react";
+
+interface CapabilityBadgeProps {
+  capabilities: TemplateCapabilities;
+  userSelections?: UserSelections;
+}
+
+export function CapabilityBadges({ capabilities, userSelections = {} }: CapabilityBadgeProps) {
+  return (
+    <div className="flex flex-wrap gap-1 mt-2">
+      <Badge variant={capabilities.supportsPhoto ? "default" : "outline"} className="text-xs">
+        {capabilities.supportsPhoto ? "✓ Photo" : "✗ No Photo"}
+      </Badge>
+      <Badge variant={capabilities.atsMode ? "default" : "outline"} className="text-xs">
+        {capabilities.atsMode ? "✓ ATS-Safe" : "✗ Not ATS"}
+      </Badge>
+      <Badge variant={capabilities.multiColumn ? "default" : "outline"} className="text-xs">
+        {capabilities.multiColumn ? "✓ Multi-col" : "Single-col"}
+      </Badge>
+      <Badge variant={capabilities.exportStable ? "default" : "outline"} className="text-xs">
+        {capabilities.exportStable ? "✓ Export Stable" : "⚠ Export Beta"}
+      </Badge>
+    </div>
+  );
+}
+
+interface CompatibilityWarningsProps {
+  capabilities: TemplateCapabilities;
+  userSelections: UserSelections;
+}
+
+export function CompatibilityWarnings({ capabilities, userSelections }: CompatibilityWarningsProps) {
+  const { warnings, suggestions } = checkCompatibility(capabilities, userSelections);
+
+  if (warnings.length === 0) return null;
+
+  return (
+    <div className="mt-2 rounded-md border border-yellow-300 bg-yellow-50 dark:bg-yellow-950 dark:border-yellow-700 p-2">
+      {warnings.map((warning, i) => (
+        <div key={i} className="flex items-start gap-1 text-xs text-yellow-800 dark:text-yellow-200">
+          <AlertTriangle className="h-3 w-3 mt-0.5 flex-shrink-0" />
+          <span>{warning}</span>
+        </div>
+      ))}
+      {suggestions.map((suggestion, i) => (
+        <div key={i} className="text-xs text-yellow-700 dark:text-yellow-300 mt-1 ml-4">
+          → {suggestion}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/templates/template-card.tsx
+++ b/components/templates/template-card.tsx
@@ -16,6 +16,8 @@ import { DeleteDialog } from "@/components/delete-dialog";
 import { TemplatePreviewModal } from "./template-preview-modal";
 import { Template } from "@/types/templates";
 import { AuthButton, EditTemplateButton } from "@/components/ui/auth-button";
+import { CapabilityBadges, CompatibilityWarnings } from "./capability-badge";
+import { TemplateCapabilities } from "@/types/template";
 
 type TemplateCardProps = {
   id: string;
@@ -36,6 +38,9 @@ type TemplateCardProps = {
   preview_image?: string;
   color_scheme?: string;
   industry?: string;
+  // Capability matrix
+  capabilities?: TemplateCapabilities;
+  userSelections?: { hasPhoto?: boolean; needsAts?: boolean; needsMultiColumn?: boolean };
 };
 
 export function TemplateCard({
@@ -56,6 +61,8 @@ export function TemplateCard({
   preview_image,
   color_scheme,
   industry,
+  capabilities,
+  userSelections = {},
 }: TemplateCardProps) {
   const router = useRouter();
   const [isShareOpen, setIsShareOpen] = useState(false);
@@ -105,14 +112,12 @@ export function TemplateCard({
   };
 
   // Create a template object for the preview modal
-  // If we have actual content, use it; otherwise create sample content
   const templateForPreview: Template = {
     id,
     title,
     description: description || '',
     type,
     content: content || {
-      // Add some sample content based on type if no content exists
       ...(type === 'resume' && {
         personalInfo: {
           name: '[Your Name]',
@@ -188,6 +193,15 @@ export function TemplateCard({
                     {description}
                   </p>
                 )}
+
+                {/* Capability Badges - list view */}
+                {capabilities && (
+                  <>
+                    <CapabilityBadges capabilities={capabilities} userSelections={userSelections} />
+                    <CompatibilityWarnings capabilities={capabilities} userSelections={userSelections} />
+                  </>
+                )}
+
                 {/* Stats for mobile */}
                 {(rating || usage_count) && (
                   <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground sm:hidden">
@@ -453,9 +467,17 @@ export function TemplateCard({
             </p>
           )}
 
+          {/* Capability Badges - grid view */}
+          {capabilities && (
+            <>
+              <CapabilityBadges capabilities={capabilities} userSelections={userSelections} />
+              <CompatibilityWarnings capabilities={capabilities} userSelections={userSelections} />
+            </>
+          )}
+
           {/* Tags */}
           {tags.length > 0 && (
-            <div className="flex flex-wrap gap-1 mb-3">
+            <div className="flex flex-wrap gap-1 mb-3 mt-2">
               {tags.slice(0, 3).map((tag) => (
                 <Badge key={tag} variant="secondary" className="text-xs px-2 py-0.5">
                   {tag}


### PR DESCRIPTION

Closes #586

This PR implements the Template Capability Matrix and Compatibility Guardrails feature to help users understand template compatibility before applying templates.

### Problem
Users could apply templates without knowing feature compatibility (photo support, multi-column behavior, ATS-safe mode, export stability), which could lead to broken previews or poor output quality.

### Changes made
- Added capability metadata support for templates
- Added capability badges to display template features visually
- Added compatibility warning component for invalid selections
- Integrated compatibility checks into TemplateCard
- Added suggestion support for better template recommendations
- Centralized compatibility logic for easier reuse and maintenance

### Acceptance Criteria Covered
- [x] Template cards display capability badges
- [x] Incompatible template/application combinations show warnings
- [x] Compatible alternatives can be suggested
- [x] Compatibility logic is centralized and reusable

Fixes #586

## Type of Change
- [x] New feature
- [x] UI enhancement
- [ ] Bug fix
- [ ] Breaking change

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template cards now display capability badges that summarize each template's features in list and grid views.
  * A compatibility warning panel highlights conflicts between template capabilities and current selections.
  * Warnings show a clear visual alert and actionable suggestions to help users choose compatible options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->