### PR TITLE
feat: add resume profile photo upload

### DIFF
--- a/components/resume/mobile-resume-builder.tsx
+++ b/components/resume/mobile-resume-builder.tsx
@@ -65,8 +65,19 @@ export function MobileResumeBuilder({ templateId, resumeId }: MobileResumeBuilde
   const [viewMode, setViewMode] = useState<'fit' | 'actual' | 'mobile'>('mobile');
   const [uploadedPdfFile, setUploadedPdfFile] = useState<File | null>(null); // Track uploaded PDF file
   const containerRef = useRef<HTMLDivElement>(null);
+  const [profilePhoto, setProfilePhoto] = useState<string | undefined>();
+  const [showPhotoModal, setShowPhotoModal] = useState(false);
+  const preflight = useCreditPreflight();
 
   const supabase = createClient();
+
+  const updateProfilePhoto = (photo?: string, photoMeta?: { x: number; y: number; scale: number }) => {
+    setResumeData((prev: any) => ({
+      ...(prev || {}),
+      photo,
+      photoMeta,
+    }));
+  };
 
   // Load template data if templateId is provided
   useEffect(() => {
@@ -2410,6 +2421,36 @@ Certified AWS Solutions Architect
                       />
                     </div>
 
+
+                    {/* Profile Photo — only for templates that declare supportsPhoto */}
+                    {RESUME_TEMPLATES.find(t => t.id === selectedTemplate)?.supportsPhoto && (
+                      <div className="p-4 bg-gray-50 dark:bg-gray-800/40 rounded-lg border border-gray-200 dark:border-gray-700">
+                        <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-200 flex items-center gap-2 mb-3">
+                          <Camera className="w-4 h-4" />
+                          Profile Photo <span className="font-normal text-gray-500">(optional)</span>
+                        </h4>
+                        {profilePhoto ? (
+                          <div className="flex items-center gap-3">
+                            <img src={profilePhoto} alt="Profile" className="w-14 h-14 rounded-full object-cover border-2 border-gray-300" />
+                            <Button variant="outline" size="sm" onClick={() => setShowPhotoModal(true)}>Change</Button>
+                            <Button variant="ghost" size="sm" onClick={() => setProfilePhoto(undefined)} className="text-red-500 hover:text-red-700 hover:bg-red-50 flex items-center gap-1">
+                              <XIcon className="w-3 h-3" /> Remove
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button variant="outline" size="sm" onClick={() => setShowPhotoModal(true)} className="flex items-center gap-2">
+                            <Camera className="w-4 h-4" /> Upload Photo
+                          </Button>
+                        )}
+                        <PhotoUploadModal
+                          open={showPhotoModal}
+                          onClose={() => setShowPhotoModal(false)}
+                          currentPhoto={profilePhoto}
+                          onSave={(dataUrl) => { setProfilePhoto(dataUrl); setShowPhotoModal(false); }}
+                          onRemove={() => { setProfilePhoto(undefined); setShowPhotoModal(false); }}
+                        />
+                      </div>
+                    )}
 
                     {/* Resume Preview */}
                     {/* View Mode Toggle - Only show on desktop/tablet */}

--- a/components/resume/photo-upload-modal.tsx
+++ b/components/resume/photo-upload-modal.tsx
@@ -106,6 +106,13 @@ export function PhotoUploadModal({
       return;
     }
     const reader = new FileReader();
+    reader.onerror = () => {
+      console.error("Failed to read profile photo file", reader.error);
+      setImgSrc("");
+      imgRef.current = null;
+      setMeta(DEFAULT_META);
+      setError("Failed to read image. Please try a different file.");
+    };
     reader.onload = (ev) => {
       const dataUrl = ev.target?.result as string;
       const newMeta = DEFAULT_META;

--- a/components/resume/photo-upload-modal.tsx
+++ b/components/resume/photo-upload-modal.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Upload, ZoomIn, ZoomOut, Move, Trash2 } from "lucide-react";
+
+const MAX_SIZE_BYTES = 2 * 1024 * 1024; // 2 MB
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const CROP_PX = 200; // canvas output size (square, rendered as circle via CSS)
+
+export interface PhotoMeta {
+  x: number;
+  y: number;
+  scale: number;
+}
+
+const DEFAULT_META: PhotoMeta = { x: 0, y: 0, scale: 1 };
+
+export interface PhotoUploadModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Called with a square PNG data-URL (cropped) and the transform metadata */
+  onSave: (dataUrl: string, meta: PhotoMeta) => void;
+  /** Called when the user wants to remove the existing photo */
+  onRemove: () => void;
+  currentPhoto?: string;
+  currentMeta?: PhotoMeta;
+}
+
+export function PhotoUploadModal({
+  open,
+  onClose,
+  onSave,
+  onRemove,
+  currentPhoto,
+  currentMeta,
+}: PhotoUploadModalProps) {
+  const [imgSrc, setImgSrc] = useState<string>("");
+  const [meta, setMeta] = useState<PhotoMeta>({ x: 0, y: 0, scale: 1 });
+  const [error, setError] = useState("");
+  const [isDragging, setIsDragging] = useState(false);
+
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dragStart = useRef<{ mx: number; my: number; ix: number; iy: number } | null>(null);
+
+  // Initialise state whenever the modal opens
+  useEffect(() => {
+    if (!open) return;
+    const photo = currentPhoto ?? "";
+    const m = currentMeta
+      ? { x: currentMeta.x * CROP_PX, y: currentMeta.y * CROP_PX, scale: currentMeta.scale }
+      : DEFAULT_META;
+    setImgSrc(photo);
+    setMeta(m);
+    setError("");
+    if (photo) {
+      const img = new Image();
+      img.onload = () => {
+        imgRef.current = img;
+        drawCanvas(img, m);
+      };
+      img.src = photo;
+    } else {
+      imgRef.current = null;
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  function drawCanvas(img: HTMLImageElement, m: PhotoMeta) {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const coverScale = Math.max(CROP_PX / img.naturalWidth, CROP_PX / img.naturalHeight);
+    const dw = img.naturalWidth * coverScale * m.scale;
+    const dh = img.naturalHeight * coverScale * m.scale;
+    const dx = (CROP_PX - dw) / 2 + m.x;
+    const dy = (CROP_PX - dh) / 2 + m.y;
+    ctx.clearRect(0, 0, CROP_PX, CROP_PX);
+    ctx.drawImage(img, dx, dy, dw, dh);
+  }
+
+  // Redraw canvas on every meta / imgSrc change
+  useEffect(() => {
+    if (imgRef.current) drawCanvas(imgRef.current, meta);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [meta, imgSrc]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setError("");
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setError("Only JPG, PNG, or WebP images are allowed.");
+      return;
+    }
+    if (file.size > MAX_SIZE_BYTES) {
+      setError("Image must be under 2 MB.");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const dataUrl = ev.target?.result as string;
+      const newMeta = DEFAULT_META;
+      setImgSrc(dataUrl);
+      setMeta(newMeta);
+      const img = new Image();
+      img.onload = () => {
+        imgRef.current = img;
+        drawCanvas(img, newMeta);
+      };
+      img.src = dataUrl;
+    };
+    reader.readAsDataURL(file);
+    e.target.value = "";
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!imgSrc) return;
+    e.preventDefault();
+    setIsDragging(true);
+    dragStart.current = { mx: e.clientX, my: e.clientY, ix: meta.x, iy: meta.y };
+  };
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent) => {
+      if (!isDragging || !dragStart.current) return;
+      setMeta((prev) => ({
+        ...prev,
+        x: dragStart.current!.ix + (e.clientX - dragStart.current!.mx),
+        y: dragStart.current!.iy + (e.clientY - dragStart.current!.my),
+      }));
+    },
+    [isDragging]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    setIsDragging(false);
+    dragStart.current = null;
+  }, []);
+
+  useEffect(() => {
+    if (isDragging) {
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerUp);
+    }
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+    };
+  }, [isDragging, handlePointerMove, handlePointerUp]);
+
+  const handleSave = () => {
+    const img = imgRef.current;
+    if (!img) return;
+    const offscreen = document.createElement("canvas");
+    offscreen.width = CROP_PX;
+    offscreen.height = CROP_PX;
+    const ctx = offscreen.getContext("2d");
+    if (!ctx) return;
+    // Circular clip for the saved image
+    ctx.beginPath();
+    ctx.arc(CROP_PX / 2, CROP_PX / 2, CROP_PX / 2, 0, Math.PI * 2);
+    ctx.clip();
+    const coverScale = Math.max(CROP_PX / img.naturalWidth, CROP_PX / img.naturalHeight);
+    const dw = img.naturalWidth * coverScale * meta.scale;
+    const dh = img.naturalHeight * coverScale * meta.scale;
+    const dx = (CROP_PX - dw) / 2 + meta.x;
+    const dy = (CROP_PX - dh) / 2 + meta.y;
+    ctx.drawImage(img, dx, dy, dw, dh);
+    onSave(offscreen.toDataURL("image/png"), {
+      x: meta.x / CROP_PX,
+      y: meta.y / CROP_PX,
+      scale: meta.scale,
+    });
+  };
+
+  const handleRemove = () => {
+    setImgSrc("");
+    setMeta(DEFAULT_META);
+    imgRef.current = null;
+    if (currentPhoto) {
+      onRemove();
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Profile Photo</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Upload button */}
+          <label className="flex items-center justify-center gap-2 border-2 border-dashed border-gray-300 rounded-lg p-3 cursor-pointer hover:bg-gray-50 transition-colors">
+            <Upload className="w-4 h-4 text-gray-500" />
+            <span className="text-sm text-gray-600">
+              {imgSrc ? "Change photo" : "Upload photo (JPG, PNG, WebP - max 2 MB)"}
+            </span>
+            <input
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              className="hidden"
+              onChange={handleFileChange}
+            />
+          </label>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          {imgSrc && (
+            <>
+              {/* Live crop preview */}
+              <div className="flex flex-col items-center gap-2">
+                <p className="text-xs text-gray-500 flex items-center gap-1">
+                  <Move className="w-3 h-3" /> Drag to reposition
+                </p>
+                <canvas
+                  ref={canvasRef}
+                  width={CROP_PX}
+                  height={CROP_PX}
+                  aria-label="Profile photo crop preview. Drag to reposition."
+                  className="rounded-full border-2 border-gray-300 select-none"
+                  style={{
+                    cursor: isDragging ? "grabbing" : "grab",
+                    touchAction: "none",
+                    width: CROP_PX,
+                    height: CROP_PX,
+                  }}
+                  onPointerDown={handlePointerDown}
+                />
+              </div>
+
+              {/* Zoom slider */}
+              <div className="flex items-center gap-3">
+                <ZoomOut className="w-4 h-4 text-gray-400 flex-shrink-0" />
+                <input
+                  type="range"
+                  min="0.5"
+                  max="3"
+                  step="0.05"
+                  value={meta.scale}
+                  onChange={(e) =>
+                    setMeta((prev) => ({ ...prev, scale: parseFloat(e.target.value) }))
+                  }
+                  className="flex-1 accent-blue-600"
+                />
+                <ZoomIn className="w-4 h-4 text-gray-400 flex-shrink-0" />
+              </div>
+            </>
+          )}
+
+          <div className="flex justify-between pt-1">
+            {imgSrc ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleRemove}
+                className="text-red-600 hover:text-red-700 hover:bg-red-50 flex items-center gap-1"
+              >
+                <Trash2 className="w-4 h-4" />
+                Remove
+              </Button>
+            ) : (
+              <span />
+            )}
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" onClick={onClose}>
+                Cancel
+              </Button>
+              {imgSrc && (
+                <Button size="sm" onClick={handleSave}>
+                  Save Photo
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/resume/resume-preview.tsx
+++ b/components/resume/resume-preview.tsx
@@ -1,7 +1,7 @@
 import React, { useState, forwardRef, useImperativeHandle } from "react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { Linkedin, Github, Globe, Mail, Phone, MapPin, Download, Edit, Check, X, Sparkles, FileText, Briefcase, GraduationCap, Code, Award, Link as LinkIcon, Loader2 } from "lucide-react";
+import { Linkedin, Github, Globe, Mail, Phone, MapPin, Download, Edit, Check, X, Sparkles, FileText, Briefcase, GraduationCap, Code, Award, Link as LinkIcon, Loader2, Camera } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import html2canvas from 'html2canvas';
@@ -9,6 +9,7 @@ import jsPDF from 'jspdf';
 import { Document, Packer, Paragraph, TextRun, HeadingLevel, AlignmentType, UnderlineType } from 'docx';
 import { saveAs } from 'file-saver';
 import { RESUME_TEMPLATES } from '@/lib/resume-template-data';
+import { PhotoUploadModal } from './photo-upload-modal';
 
 interface ResumeData {
   name?: string;
@@ -59,6 +60,14 @@ interface ResumeData {
     includedKeywords?: string[];
     density?: string;
   };
+  /** Base64 PNG data-URL of the cropped circular profile photo (optional) */
+  photo?: string;
+  /** Normalized crop metadata for the optional profile photo */
+  photoMeta?: {
+    x: number;
+    y: number;
+    scale: number;
+  };
 }
 
 interface ResumePreviewProps {
@@ -104,6 +113,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
   
   const [isEditing, setIsEditing] = useState(enableEditing);
   const [isExporting, setIsExporting] = useState(false);
+  const [showPhotoModal, setShowPhotoModal] = useState(false);
   const { toast } = useToast();
   const [editableResume, setEditableResume] = useState<ResumeData>({
     ...safeResume,
@@ -2160,16 +2170,55 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
       <div className="w-full md:max-w-[794px] mx-auto font-sans print:w-[794px] min-h-[1123px] bg-white shadow-lg print:shadow-none">
         {/* Header */}
         <div className="text-white p-8 md:p-12" style={{ backgroundColor: primaryColor }}>
-          {isEditing ? (
-            <EditableText value={editableResume.name || ""} onChange={v => updateField(["name"], v)} className="text-4xl md:text-5xl font-bold mb-4 text-white" />
-          ) : (
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">{safeResume.name}</h1>
-          )}
-          <div className="text-lg mb-6" style={{ color: 'rgba(255,255,255,0.8)' }}>{safeResume.experience?.[0]?.title || "Professional"}</div>
-          <div className="flex flex-wrap gap-6 text-sm" style={{ color: 'rgba(255,255,255,0.7)' }}>
-            <div className="flex items-center gap-2"><Mail className="w-4 h-4" /> {safeResume.email}</div>
-            <div className="flex items-center gap-2"><Phone className="w-4 h-4" /> {safeResume.phone}</div>
-            <div className="flex items-center gap-2"><MapPin className="w-4 h-4" /> {safeResume.location}</div>
+          <div className="flex items-center gap-6">
+            {/* Profile photo slot — only for templates that declare supportsPhoto */}
+            {currentTemplate.supportsPhoto && (
+              <div className="flex-shrink-0">
+                {(editableResume.photo || safeResume.photo) ? (
+                  <div className="relative group">
+                    <img
+                      src={editableResume.photo || safeResume.photo}
+                      alt={safeResume.name || "Profile photo"}
+                      className="w-24 h-24 rounded-full object-cover border-4 border-white/30 print:block"
+                    />
+                    {isEditing && (
+                      <button
+                        type="button"
+                        onClick={() => setShowPhotoModal(true)}
+                        className="absolute inset-0 rounded-full bg-black/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                        aria-label="Change photo"
+                      >
+                        <Camera className="w-6 h-6 text-white" />
+                      </button>
+                    )}
+                  </div>
+                ) : isEditing ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowPhotoModal(true)}
+                    className="w-24 h-24 rounded-full border-2 border-dashed border-white/40 flex items-center justify-center hover:bg-white/10 transition-colors"
+                    aria-label="Add profile photo"
+                  >
+                    <Camera className="w-8 h-8 text-white/70" />
+                  </button>
+                ) : null}
+              </div>
+            )}
+
+            {/* Name and contact info */}
+            <div className="flex-1 min-w-0">
+              {isEditing ? (
+                <EditableText value={editableResume.name || ""} onChange={v => updateField(["name"], v)} className="text-4xl md:text-5xl font-bold mb-4 text-white" />
+              ) : (
+                <h1 className="text-4xl md:text-5xl font-bold mb-4">{safeResume.name}</h1>
+              )}
+              <div className="text-lg mb-6" style={{ color: 'rgba(255,255,255,0.8)' }}>{safeResume.experience?.[0]?.title || "Professional"}</div>
+              <div className="flex flex-wrap gap-6 text-sm" style={{ color: 'rgba(255,255,255,0.7)' }}>
+                <div className="flex items-center gap-2"><Mail className="w-4 h-4" /> {safeResume.email}</div>
+                <div className="flex items-center gap-2"><Phone className="w-4 h-4" /> {safeResume.phone}</div>
+                <div className="flex items-center gap-2"><MapPin className="w-4 h-4" /> {safeResume.location}</div>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -2593,46 +2642,66 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
     </div>
   );
 
+  // Photo upload modal (rendered once, shared across all templates)
+  const photoModal = currentTemplate.supportsPhoto ? (
+    <PhotoUploadModal
+      open={showPhotoModal}
+      onClose={() => setShowPhotoModal(false)}
+      currentPhoto={editableResume.photo}
+      currentMeta={editableResume.photoMeta}
+      onSave={(dataUrl, meta) => {
+        updateField(["photo"], dataUrl);
+        updateField(["photoMeta"], meta);
+        setShowPhotoModal(false);
+      }}
+      onRemove={() => {
+        updateField(["photo"], undefined);
+        updateField(["photoMeta"], undefined);
+      }}
+    />
+  ) : null;
+
   // Main Render Switch - Each template maps to ONE specific layout
   console.log('ResumePreview rendering template:', template);
-  
+
+  let templateContent: React.ReactNode;
   switch (true) {
-    // Tech/Engineering Templates - Clean single-column with skills at top
     case template === 'software-engineering-resume':
     case template === 'it-manager-cv':
-      return renderTechTemplate();
-
-    // Deedy Resume - Two-column with dark sidebar
+      templateContent = renderTechTemplate();
+      break;
     case template === 'deedy-resume':
-      return renderDeedyTemplate();
-
-    // Modern Templates - Sidebar with modern design  
+      templateContent = renderDeedyTemplate();
+      break;
     case template === 'blue-white-modern-professional':
     case template.includes('modern'):
-      return renderModernTemplate();
-
-    // Black & White Professional - Clean ATS-friendly
+      templateContent = renderModernTemplate();
+      break;
     case template === 'black-white-professional':
-      return renderBlackWhiteTemplate();
-    
-    // Academic Templates - Traditional academic format
+      templateContent = renderBlackWhiteTemplate();
+      break;
     case template === 'nit-patna-resume':
-      return renderNITPatnaTemplate();
-    
+      templateContent = renderNITPatnaTemplate();
+      break;
     case template === 'autocv-template':
     case template.includes('academic'):
-      return renderAcademicTemplate();
-
-    // Creative Templates - Bold creative design
+      templateContent = renderAcademicTemplate();
+      break;
     case template === 'altacv-template':
     case template === 'blue-black-geometric-creative':
     case template.includes('creative'):
-      return renderCreativeTemplate();
-
-    // Professional/Corporate Templates (Default) - Clean professional
+      templateContent = renderCreativeTemplate();
+      break;
     default:
-      return renderProfessionalTemplate();
+      templateContent = renderProfessionalTemplate();
   }
+
+  return (
+    <>
+      {templateContent}
+      {photoModal}
+    </>
+  );
 });
 
 ResumePreview.displayName = 'ResumePreview';

--- a/components/resume/resume-preview.tsx
+++ b/components/resume/resume-preview.tsx
@@ -2647,8 +2647,8 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
     <PhotoUploadModal
       open={showPhotoModal}
       onClose={() => setShowPhotoModal(false)}
-      currentPhoto={editableResume.photo}
-      currentMeta={editableResume.photoMeta}
+      currentPhoto={editableResume.photo ?? safeResume.photo}
+      currentMeta={editableResume.photoMeta ?? safeResume.photoMeta}
       onSave={(dataUrl, meta) => {
         updateField(["photo"], dataUrl);
         updateField(["photoMeta"], meta);
@@ -2657,6 +2657,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
       onRemove={() => {
         updateField(["photo"], undefined);
         updateField(["photoMeta"], undefined);
+        setShowPhotoModal(false);
       }}
     />
   ) : null;

--- a/lib/resume-template-data.ts
+++ b/lib/resume-template-data.ts
@@ -13,6 +13,7 @@ export interface ResumeTemplate {
   difficulty: 'beginner' | 'intermediate' | 'advanced' | 'professional';
   isPro: boolean;
   isFeatured: boolean;
+  supportsPhoto?: boolean;
   rating: number;
   downloads: number;
   author: {
@@ -116,6 +117,7 @@ export const RESUME_TEMPLATES: ResumeTemplate[] = [
     difficulty: 'intermediate',
     isPro: true,
     isFeatured: true,
+    supportsPhoto: true,
     rating: 4.8,
     downloads: 14200,
     author: {
@@ -176,6 +178,7 @@ export const RESUME_TEMPLATES: ResumeTemplate[] = [
     difficulty: 'intermediate',
     isPro: false,
     isFeatured: false,
+    supportsPhoto: true,
     rating: 4.7,
     downloads: 9560,
     author: {


### PR DESCRIPTION
## Description
This PR fixes #575 by adding optional profile photo support to the Resume Builder with safe template constraints.

Users can now upload, crop, zoom, reposition, save and remove a profile photo. Photo rendering is limited to templates that explicitly support profile photos, while unsupported templates ignore photo data gracefully to avoid broken layouts.

Fixes #575

## Type of Change
- [x] New feature (e.g., new page, component, or functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify): ____________________

## Changes Made
- Added `supportsPhoto?: boolean` to the resume template metadata.
- Enabled photo support only for selected creative/sidebar resume templates.
- Added optional `photo` and `photoMeta` fields to resume data.
- Added a new `PhotoUploadModal` component for the full photo workflow.
- Added upload validation for JPG, JPEG, PNG, and WebP files.
- Added a 2 MB max file size limit with clear error messages.
- Added crop, zoom and reposition controls before saving.
- Saved normalized crop metadata so the edit flow remains consistent.
- Added remove/reset support to clear both `photo` and `photoMeta`.
- Rendered the photo slot only when the selected template supports photos.
- Added pointer event handling for better mobile/touch support.
- Added accessibility labeling for the crop preview area.

## Dependencies
No new dependencies were added.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers/devices
- [x] I have tested my changes in development mode (`npm run dev`)
- [x] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.

## Notes
`npx tsc --noEmit --pretty false` currently fails due to existing unrelated project-wide TypeScript issues, including `NextResponse only refers to a type` errors and Supabase schema/type mismatches. These are outside the scope of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add profile photo upload and circular crop preview with drag-to-reposition and zoom controls
  * Image validation for JPG/PNG/WebP and 2 MB max; shows errors for invalid files
  * Save yields a cropped PNG and preserves position/scale metadata; supports cancel and remove
  * Photo support integrated into select resume templates with in-place change/add controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->