### PR TITLE
feat: add editable LaTeX export for generated resumes (#577)

### DIFF
--- a/components/pwa-install-button.tsx
+++ b/components/pwa-install-button.tsx
@@ -1,74 +1,74 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Download, Check, Smartphone } from 'lucide-react';
 import { usePWAInstall } from '@/hooks/use-pwa-install';
 import { cn } from '@/lib/utils';
 
-interface PWAInstallButtonProps {
+export interface PWAInstallButtonProps {
   className?: string;
   variant?: 'default' | 'outline' | 'ghost' | 'link' | 'destructive' | 'secondary';
   size?: 'default' | 'sm' | 'lg' | 'icon';
   showText?: boolean;
 }
 
-export function PWAInstallButton({ 
-  className, 
-  variant = 'default', 
-  size = 'default',
-  showText = true 
-}: PWAInstallButtonProps) {
-  const { isInstallable, isInstalled, installApp } = usePWAInstall();
-  const [isInstalling, setIsInstalling] = useState(false);
+export const PWAInstallButton = React.forwardRef<HTMLButtonElement, PWAInstallButtonProps>(
+  ({ className, variant = 'default', size = 'default', showText = true }, ref) => {
+    const { isInstallable, isInstalled, installApp } = usePWAInstall();
+    const [isInstalling, setIsInstalling] = useState(false);
 
-  const handleInstall = async () => {
-    if (!isInstallable) return;
-    
-    setIsInstalling(true);
-    try {
-      await installApp();
-    } finally {
-      setIsInstalling(false);
+    const handleInstall = async () => {
+      if (!isInstallable) return;
+      
+      setIsInstalling(true);
+      try {
+        await installApp();
+      } finally {
+        setIsInstalling(false);
+      }
+    };
+
+    if (isInstalled) {
+      return (
+        <Button
+          ref={ref}
+          variant={variant}
+          size={size}
+          className={cn('cursor-default', className)}
+          disabled
+        >
+          <Check className="h-4 w-4" />
+          {showText && <span className="ml-2">App Installed</span>}
+        </Button>
+      );
     }
-  };
 
-  if (isInstalled) {
+    if (!isInstallable) {
+      return null;
+    }
+
     return (
       <Button
+        ref={ref}
         variant={variant}
         size={size}
-        className={cn('cursor-default', className)}
-        disabled
+        className={className}
+        onClick={handleInstall}
+        disabled={isInstalling}
       >
-        <Check className="h-4 w-4" />
-        {showText && <span className="ml-2">App Installed</span>}
+        {isInstalling ? (
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-transparent border-t-current" />
+        ) : (
+          <Download className="h-4 w-4" />
+        )}
+        {showText && (
+          <span className="ml-2">
+            {isInstalling ? 'Installing...' : 'Install App'}
+          </span>
+        )}
       </Button>
     );
   }
-
-  if (!isInstallable) {
-    return null;
-  }
-
-  return (
-    <Button
-      variant={variant}
-      size={size}
-      className={className}
-      onClick={handleInstall}
-      disabled={isInstalling}
-    >
-      {isInstalling ? (
-        <div className="h-4 w-4 animate-spin rounded-full border-2 border-transparent border-t-current" />
-      ) : (
-        <Download className="h-4 w-4" />
-      )}
-      {showText && (
-        <span className="ml-2">
-          {isInstalling ? 'Installing...' : 'Install App'}
-        </span>
-      )}
-    </Button>
-  );
-}
+);
+PWAInstallButton.displayName = 'PWAInstallButton';

--- a/components/pwa-install-button.tsx
+++ b/components/pwa-install-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Download, Check, Smartphone } from 'lucide-react';
 import { usePWAInstall } from '@/hooks/use-pwa-install';
@@ -17,14 +17,17 @@ export const PWAInstallButton = React.forwardRef<HTMLButtonElement, PWAInstallBu
   ({ className, variant = 'default', size = 'default', showText = true }, ref) => {
     const { isInstallable, isInstalled, installApp } = usePWAInstall();
     const [isInstalling, setIsInstalling] = useState(false);
+    const installingRef = useRef(false);
 
     const handleInstall = async () => {
-      if (!isInstallable) return;
+      if (!isInstallable || installingRef.current) return;
       
+      installingRef.current = true;
       setIsInstalling(true);
       try {
         await installApp();
       } finally {
+        installingRef.current = false;
         setIsInstalling(false);
       }
     };

--- a/components/resume/resume-generator.tsx
+++ b/components/resume/resume-generator.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, Di
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
 import { ResumePreview } from "@/components/resume/resume-preview";
+import { exportToLaTeXFile } from "@/lib/resume/latex-exporter";
 import { ResumeTemplates } from "@/components/resume/resume-templates";
 import { GuidedResumeGenerator } from "@/components/resume/guided-resume-generator";
 import { LinkedInImport } from "@/components/resume/linkedin-import";
@@ -23,6 +24,7 @@ import {
   Minimize2,
   Download,
   User,
+  Code,
   Mail,
   Wand2,
   Palette,
@@ -275,6 +277,27 @@ export function ResumeGenerator({ initialSession }: { initialSession?: any }) {
       title: "Coming Soon",
       description: "Word export will be available in the next update.",
     });
+  };
+
+  const downloadLaTeX = async () => {
+    if (!resumeData) return;
+    setIsExporting(true);
+    try {
+      await exportToLaTeXFile(resumeData as any);
+      toast({
+        title: "Resume downloaded!",
+        description: "Your LaTeX source has been downloaded.",
+      });
+    } catch (error) {
+      console.error('Error exporting to LaTeX:', error);
+      toast({
+        title: "Export failed",
+        description: "Failed to export resume to LaTeX. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   // Share functions
@@ -545,6 +568,15 @@ export function ResumeGenerator({ initialSession }: { initialSession?: any }) {
                       Download DOCX
                     </Button>
                     <Button
+                      onClick={downloadLaTeX}
+                      disabled={isExporting}
+                      variant="outline"
+                      className="glass-effect border-yellow-400/30 hover:border-yellow-400/60"
+                    >
+                      {isExporting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Code className="mr-2 h-4 w-4" />}
+                      Download LaTeX
+                    </Button>
+                    <Button
                       onClick={saveAndShareResume}
                       disabled={isSaving}
                       variant="outline"
@@ -686,6 +718,17 @@ export function ResumeGenerator({ initialSession }: { initialSession?: any }) {
                         >
                           <Download className="mr-2 h-4 w-4" />
                           Download DOCX
+                        </Button>
+                      </TooltipWithShortcut>
+                      <TooltipWithShortcut content="Download as LaTeX source for advanced editing">
+                        <Button
+                          onClick={downloadLaTeX}
+                          disabled={isExporting}
+                          variant="outline"
+                          className="glass-effect border-yellow-400/30 hover:border-yellow-400/60 w-full sm:w-auto"
+                        >
+                          {isExporting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Code className="mr-2 h-4 w-4" />}
+                          Download LaTeX
                         </Button>
                       </TooltipWithShortcut>
                       <TooltipWithShortcut content="Create a shareable link for your resume">

--- a/components/resume/resume-preview.tsx
+++ b/components/resume/resume-preview.tsx
@@ -1182,6 +1182,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                 variant="outline"
                 size="sm"
                 onClick={exportToLaTeX}
+                disabled={isExporting}
                 className="flex items-center gap-1"
               >
                 <Code className="h-4 w-4" />

--- a/components/resume/resume-preview.tsx
+++ b/components/resume/resume-preview.tsx
@@ -9,6 +9,7 @@ import jsPDF from 'jspdf';
 import { Document, Packer, Paragraph, TextRun, HeadingLevel, AlignmentType, UnderlineType } from 'docx';
 import { saveAs } from 'file-saver';
 import { RESUME_TEMPLATES } from '@/lib/resume-template-data';
+import { exportToLaTeXFile } from "@/lib/resume/latex-exporter";
 
 interface ResumeData {
   name?: string;
@@ -75,6 +76,7 @@ interface ResumePreviewProps {
 export interface ResumePreviewRef {
   exportToPDF: () => Promise<void>;
   exportToWord: () => void;
+  exportToLaTeX: () => Promise<void>;
   toggleEdit: () => void;
   isEditing: boolean;
 }
@@ -583,6 +585,26 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
     }
   };
 
+  const exportToLaTeX = async () => {
+    try {
+      setIsExporting(true);
+      await exportToLaTeXFile(safeResume as any);
+      toast({
+        title: `${isCV ? 'CV' : 'Resume'} exported to LaTeX!`,
+        description: `Your LaTeX source has been downloaded.`,
+      });
+    } catch (error) {
+      console.error('Error exporting to LaTeX:', error);
+      toast({
+        title: "Export failed",
+        description: "There was an error exporting to LaTeX format.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   const toggleEdit = () => {
     setIsEditing(!isEditing);
   };
@@ -591,6 +613,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
   useImperativeHandle(ref, () => ({
     exportToPDF,
     exportToWord,
+    exportToLaTeX,
     toggleEdit,
     isEditing,
   }));
@@ -1154,6 +1177,15 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
               >
                 <FileText className="h-4 w-4" />
                 Word
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={exportToLaTeX}
+                className="flex items-center gap-1"
+              >
+                <Code className="h-4 w-4" />
+                LaTeX
               </Button>
             </div>
             
@@ -1766,6 +1798,16 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
             >
               {isExporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
               {isExporting ? "Exporting..." : "Export PDF"}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={exportToLaTeX}
+              disabled={isExporting}
+              className="flex items-center gap-1"
+            >
+              <Code className="h-4 w-4" />
+              LaTeX
             </Button>
           </div>
         )}

--- a/lib/resume/latex-exporter.ts
+++ b/lib/resume/latex-exporter.ts
@@ -262,7 +262,7 @@ export async function exportToLaTeXFile(resume: ResumeData, filename?: string): 
   
   let downloadName = filename;
   if (!downloadName) {
-    const safeName = resume.name ? resume.name.replace(/\\s+/g, '-').toLowerCase() : 'resume';
+    const safeName = resume.name ? resume.name.replace(/\s+/g, '-').toLowerCase() : 'resume';
     downloadName = `${safeName}.tex`;
   }
   

--- a/lib/resume/latex-exporter.ts
+++ b/lib/resume/latex-exporter.ts
@@ -1,0 +1,270 @@
+import { saveAs } from 'file-saver';
+
+// Same structure as in resume-preview.tsx
+export interface ResumeData {
+  name?: string;
+  email?: string;
+  phone?: string | number;
+  location?: string;
+  linkedin?: string;
+  github?: string;
+  website?: string;
+  portfolio?: string;
+  summary?: string;
+  experience?: Array<{
+    title?: string;
+    company?: string;
+    location?: string;
+    date?: string;
+    description?: string[];
+  }>;
+  education?: Array<{
+    degree?: string;
+    institution?: string;
+    location?: string;
+    date?: string;
+    gpa?: string;
+    honors?: string;
+  }>;
+  skills?: {
+    technical?: string[];
+    programming?: string[];
+    tools?: string[];
+    soft?: string[];
+  };
+  projects?: Array<{
+    name?: string;
+    description?: string;
+    technologies?: string[];
+    link?: string;
+  }>;
+  certifications?: Array<{
+    name?: string;
+    issuer?: string;
+    date?: string;
+    credential?: string;
+  }>;
+  [key: string]: any;
+}
+
+/**
+ * Escapes special LaTeX characters in a string.
+ */
+export function escapeLatex(text: string | null | undefined): string {
+  if (!text) return '';
+  
+  return String(text)
+    .replace(/\\/g, '\\textbackslash{}')
+    .replace(/\{/g, '\\{')
+    .replace(/\}/g, '\\}')
+    .replace(/\$/g, '\\$')
+    .replace(/&/g, '\\&')
+    .replace(/%/g, '\\%')
+    .replace(/#/g, '\\#')
+    .replace(/_/g, '\\_')
+    .replace(/~/g, '\\textasciitilde{}')
+    .replace(/\^/g, '\\textasciicircum{}')
+    // Also handle some common unicode/formatting issues that break LaTeX easily
+    .replace(/—/g, '---')
+    .replace(/–/g, '--')
+    .replace(/“/g, "``")
+    .replace(/”/g, "''")
+    .replace(/‘/g, "`")
+    .replace(/’/g, "'");
+}
+
+/**
+ * Generates a clean, compile-ready LaTeX string from ResumeData.
+ */
+export function generateLaTeX(resume: ResumeData): string {
+  const sections: string[] = [];
+
+  // Preamble
+  sections.push(`\\documentclass[11pt,a4paper]{article}
+
+\\usepackage[empty]{fullpage}
+\\usepackage{titlesec}
+\\usepackage{enumitem}
+\\usepackage[hidelinks]{hyperref}
+\\usepackage{geometry}
+\\geometry{
+  a4paper,
+  left=0.5in,
+  right=0.5in,
+  top=0.6in,
+  bottom=0.6in
+}
+
+\\titleformat{\\section}{\\Large\\bfseries\\vspace{2pt}}{}{0em}{}[\\color{black}\\titlerule\\vspace{4pt}]
+
+\\begin{document}
+`);
+
+  // Header / Contact Info
+  sections.push(`\\begin{center}`);
+  sections.push(`{\\Huge \\textbf{${escapeLatex(resume.name || "Your Name")}}} \\vspace{4pt} \\\\`);
+  
+  const contactInfo: string[] = [];
+  if (resume.email) contactInfo.push(`\\href{mailto:${escapeLatex(resume.email)}}{${escapeLatex(resume.email)}}`);
+  if (resume.phone) contactInfo.push(escapeLatex(String(resume.phone)));
+  if (resume.location) contactInfo.push(escapeLatex(resume.location));
+  if (resume.linkedin) contactInfo.push(`\\href{${escapeLatex(resume.linkedin)}}{LinkedIn}`);
+  if (resume.github) contactInfo.push(`\\href{${escapeLatex(resume.github)}}{GitHub}`);
+  if (resume.website) contactInfo.push(`\\href{${escapeLatex(resume.website)}}{Website}`);
+  if (resume.portfolio) contactInfo.push(`\\href{${escapeLatex(resume.portfolio)}}{Portfolio}`);
+  
+  if (contactInfo.length > 0) {
+    sections.push(contactInfo.join(' $|$ '));
+  }
+  sections.push(`\\end{center}`);
+  sections.push(`\\vspace{-10pt}`);
+
+  // Summary
+  if (resume.summary) {
+    sections.push(`\\section*{Summary}`);
+    sections.push(`${escapeLatex(resume.summary)}`);
+  }
+
+  // Work Experience
+  if (resume.experience && resume.experience.length > 0) {
+    sections.push(`\\section*{Experience}`);
+    sections.push(`\\begin{itemize}[leftmargin=0.15in, label={}]`);
+    
+    resume.experience.forEach(exp => {
+      sections.push(`  \\item`);
+      sections.push(`    \\begin{tabular*}{0.97\\textwidth}[t]{l@{\\extracolsep{\\fill}}r}`);
+      sections.push(`      \\textbf{${escapeLatex(exp.title || '')}} & ${escapeLatex(exp.date || '')} \\\\`);
+      sections.push(`      \\textit{${escapeLatex(exp.company || '')}}${exp.location ? ` -- ${escapeLatex(exp.location)}` : ''} & \\\\`);
+      sections.push(`    \\end{tabular*}\\vspace{-5pt}`);
+      
+      if (exp.description && exp.description.length > 0) {
+        sections.push(`    \\begin{itemize}[leftmargin=0.15in]`);
+        exp.description.forEach(desc => {
+          if (desc.trim()) {
+            sections.push(`      \\item ${escapeLatex(desc)}`);
+          }
+        });
+        sections.push(`    \\end{itemize}`);
+      }
+    });
+    
+    sections.push(`\\end{itemize}`);
+  }
+
+  // Education
+  if (resume.education && resume.education.length > 0) {
+    sections.push(`\\section*{Education}`);
+    sections.push(`\\begin{itemize}[leftmargin=0.15in, label={}]`);
+    
+    resume.education.forEach(edu => {
+      sections.push(`  \\item`);
+      sections.push(`    \\begin{tabular*}{0.97\\textwidth}[t]{l@{\\extracolsep{\\fill}}r}`);
+      sections.push(`      \\textbf{${escapeLatex(edu.institution || '')}} & ${escapeLatex(edu.date || '')} \\\\`);
+      sections.push(`      \\textit{${escapeLatex(edu.degree || '')}} & ${edu.gpa ? `GPA: ${escapeLatex(edu.gpa)}` : ''} \\\\`);
+      sections.push(`    \\end{tabular*}\\vspace{-5pt}`);
+      if (edu.honors) {
+        sections.push(`    \\begin{itemize}[leftmargin=0.15in]`);
+        sections.push(`      \\item Honors: ${escapeLatex(edu.honors)}`);
+        sections.push(`    \\end{itemize}`);
+      }
+    });
+    
+    sections.push(`\\end{itemize}`);
+  }
+
+  // Skills
+  if (resume.skills && (
+    (resume.skills.technical && resume.skills.technical.length > 0) ||
+    (resume.skills.programming && resume.skills.programming.length > 0) ||
+    (resume.skills.tools && resume.skills.tools.length > 0) ||
+    (resume.skills.soft && resume.skills.soft.length > 0)
+  )) {
+    sections.push(`\\section*{Skills}`);
+    sections.push(`\\begin{itemize}[leftmargin=0.15in, label={}]`);
+    sections.push(`  \\item \\begin{tabular}{@{}l l}`);
+    
+    const skillLines = [];
+    if (resume.skills.programming && resume.skills.programming.length > 0) {
+      skillLines.push(`    \\textbf{Programming:} & ${escapeLatex(resume.skills.programming.join(', '))} \\\\`);
+    }
+    if (resume.skills.technical && resume.skills.technical.length > 0) {
+      skillLines.push(`    \\textbf{Technical:} & ${escapeLatex(resume.skills.technical.join(', '))} \\\\`);
+    }
+    if (resume.skills.tools && resume.skills.tools.length > 0) {
+      skillLines.push(`    \\textbf{Tools:} & ${escapeLatex(resume.skills.tools.join(', '))} \\\\`);
+    }
+    if (resume.skills.soft && resume.skills.soft.length > 0) {
+      skillLines.push(`    \\textbf{Soft Skills:} & ${escapeLatex(resume.skills.soft.join(', '))} \\\\`);
+    }
+    
+    sections.push(skillLines.join('\\vspace{2pt}\n'));
+    sections.push(`  \\end{tabular}`);
+    sections.push(`\\end{itemize}`);
+  }
+
+  // Projects
+  if (resume.projects && resume.projects.length > 0) {
+    sections.push(`\\section*{Projects}`);
+    sections.push(`\\begin{itemize}[leftmargin=0.15in, label={}]`);
+    
+    resume.projects.forEach(proj => {
+      sections.push(`  \\item`);
+      sections.push(`    \\begin{tabular*}{0.97\\textwidth}{l@{\\extracolsep{\\fill}}r}`);
+      
+      const projectNameAndLink = proj.link 
+        ? `\\textbf{\\href{${escapeLatex(proj.link)}}{${escapeLatex(proj.name || '')}}}`
+        : `\\textbf{${escapeLatex(proj.name || '')}}`;
+        
+      const techStack = proj.technologies && proj.technologies.length > 0 
+        ? `$|$ \\emph{${escapeLatex(proj.technologies.join(', '))}}`
+        : '';
+        
+      sections.push(`      ${projectNameAndLink} ${techStack} & \\\\`);
+      sections.push(`    \\end{tabular*}\\vspace{-5pt}`);
+      
+      if (proj.description) {
+        sections.push(`    \\begin{itemize}[leftmargin=0.15in]`);
+        sections.push(`      \\item ${escapeLatex(proj.description)}`);
+        sections.push(`    \\end{itemize}`);
+      }
+    });
+    
+    sections.push(`\\end{itemize}`);
+  }
+
+  // Certifications
+  if (resume.certifications && resume.certifications.length > 0) {
+    sections.push(`\\section*{Certifications}`);
+    sections.push(`\\begin{itemize}[leftmargin=0.15in, label={}]`);
+    
+    resume.certifications.forEach(cert => {
+      sections.push(`  \\item`);
+      sections.push(`    \\begin{tabular*}{0.97\\textwidth}{l@{\\extracolsep{\\fill}}r}`);
+      sections.push(`      \\textbf{${escapeLatex(cert.name || '')}} & ${escapeLatex(cert.date || '')} \\\\`);
+      sections.push(`      \\textit{${escapeLatex(cert.issuer || '')}} & \\\\`);
+      sections.push(`    \\end{tabular*}\\vspace{-5pt}`);
+    });
+    
+    sections.push(`\\end{itemize}`);
+  }
+
+  sections.push(`\\end{document}`);
+
+  return sections.join('\n');
+}
+
+/**
+ * Generates and triggers a download of the LaTeX source file.
+ */
+export async function exportToLaTeXFile(resume: ResumeData, filename?: string): Promise<void> {
+  const latexSource = generateLaTeX(resume);
+  const blob = new Blob([latexSource], { type: 'application/x-latex;charset=utf-8' });
+  
+  let downloadName = filename;
+  if (!downloadName) {
+    const safeName = resume.name ? resume.name.replace(/\\s+/g, '-').toLowerCase() : 'resume';
+    downloadName = `${safeName}.tex`;
+  }
+  
+  saveAs(blob, downloadName);
+}


### PR DESCRIPTION
## Description

This PR addresses Issue #577 by adding a robust, client-side LaTeX export feature for generated resumes. This allows advanced users, academics, and researchers to export their resumes as valid `.tex` files for manual customization in professional LaTeX workflows (e.g., Overleaf). 

Fixes #577

## Type of Change

- [x] New feature (e.g., new page, component, or functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- **LaTeX Generation Engine** (`lib/resume/latex-exporter.ts`): Created a dedicated utility to map `ResumeData` structures (Contact Info, Experience, Education, Skills, Projects, Certifications) directly into a clean `\documentclass{article}` template. 
- **Graceful Degradation**: Built an `escapeLatex` string sanitization helper that safely escapes special characters (`$`, `%`, `&`, `\`, `_`, etc.) and unicode formatting to prevent LaTeX compilation errors and provide a fallback for unsupported rich text.
- **Client-Side Export**: Utilized the `Blob` API and `file-saver` to trigger instantaneous browser downloads for the generated `.tex` files.
- **UI Integration**: Injected the new "Download LaTeX" button across the `ResumePreview` export controls and the `ResumeGenerator` download options to sit natively beside the existing PDF and Word options.

## Dependencies

- Uses existing `file-saver` package for client-side blob downloads.
- Outputs `.tex` code using standard packages (`geometry`, `titlesec`, `enumitem`, `hyperref`) widely supported out-of-the-box by most TeX distributions.

## Add Screenshots
*N/A - Feature operates as a direct download.*

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers/devices
- [x] I have verified the compilation of the generated LaTeX source
- [x] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LaTeX export for resumes — download a .tex file ready for compilation.
  * Export available from both builder and preview, with shared loading state and success/error notifications.
  * LaTeX output covers contact, summary, experience, education, skills, projects, and certifications.

* **Stability/Accessibility**
  * More reliable PWA install button and install flow with improved guarding against duplicate install attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->