### PR TITLE
fix: resolve PDF imports via Webpack 5 Asset Modules and refactor tem…

### DIFF
--- a/app/api/templates/[id]/route.ts
+++ b/app/api/templates/[id]/route.ts
@@ -1,5 +1,4 @@
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
+import { createRoute } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server.js';
 
 export async function GET(
@@ -7,7 +6,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   const { id } = params;
-  const supabase = createRouteHandlerClient({ cookies });
+  const supabase = await createRoute();
   
   try {
     const { data: { user } } = await supabase.auth.getUser();
@@ -51,7 +50,7 @@ export async function PUT(
   { params }: { params: { id: string } }
 ) {
   const { id } = params;
-  const supabase = createRouteHandlerClient({ cookies });
+  const supabase = await createRoute();
   
   try {
     const { data: { user } } = await supabase.auth.getUser();
@@ -99,7 +98,7 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   const { id } = params;
-  const supabase = createRouteHandlerClient({ cookies });
+  const supabase = await createRoute();
   
   try {
     const { data: { user } } = await supabase.auth.getUser();

--- a/app/api/templates/[id]/shares/[shareId]/route.ts
+++ b/app/api/templates/[id]/shares/[shareId]/route.ts
@@ -1,5 +1,4 @@
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
+import { createRoute } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 
 export async function DELETE(
@@ -7,7 +6,7 @@ export async function DELETE(
   { params }: { params: { id: string; shareId: string } }
 ) {
   const { id, shareId } = params;
-  const supabase = createRouteHandlerClient({ cookies });
+  const supabase = await createRoute();
   
   try {
     const { data: { user } } = await supabase.auth.getUser();
@@ -51,7 +50,7 @@ export async function PATCH(
   { params }: { params: { id: string; shareId: string } }
 ) {
   const { id, shareId } = params;
-  const supabase = createRouteHandlerClient({ cookies });
+  const supabase = await createRoute();
   
   try {
     const { data: { user } } = await supabase.auth.getUser();

--- a/app/api/templates/[id]/shares/route.ts
+++ b/app/api/templates/[id]/shares/route.ts
@@ -1,5 +1,4 @@
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
+import { createRoute } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 
 export async function GET(
@@ -7,7 +6,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   const { id } = params;
-  const supabase = createRouteHandlerClient({ cookies });
+  const supabase = await createRoute();
   
   try {
     const { data: { user } } = await supabase.auth.getUser();
@@ -46,7 +45,7 @@ export async function POST(
   { params }: { params: { id: string } }
 ) {
   const { id } = params;
-  const supabase = createRouteHandlerClient({ cookies });
+  const supabase = await createRoute();
   
   try {
     const { data: { user } } = await supabase.auth.getUser();

--- a/next.config.js
+++ b/next.config.js
@@ -42,7 +42,6 @@ trailingSlash: false,
   experimental: {
     optimizeCss: process.env.NODE_ENV !== 'development', // Disable in dev to prevent critters module error
     scrollRestoration: true,
-    workerThreads: true,
   },
   compiler: {
     removeConsole: process.env.NODE_ENV === 'production',
@@ -75,16 +74,10 @@ trailingSlash: false,
 webpack: (config, { isServer }) => {
     config.module.rules.push({
       test: /\.pdf$/,
-      use: [
-        {
-          loader: 'file-loader',
-          options: {
-            publicPath: '/_next/static/files',
-            outputPath: 'static/files',
-            name: '[name].[ext]',
-          },
-        },
-      ],
+      type: 'asset/resource',
+      generator: {
+        filename: 'static/files/[name][ext]',
+      },
     });
     
     // Bundle size optimizations

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -16,6 +16,7 @@ declare module '*.jpg';
 declare module '*.jpeg';
 declare module '*.gif';
 declare module '*.webp';
+declare module '*.pdf';
 
 // Add global type extensions here
 interface Window {


### PR DESCRIPTION
# fix #597  : resolve PDF imports via Webpack 5 Asset Modules and refactor templates routes to supabase/server

## Description

This PR fixes a build crash that occurs when `.pdf` files are imported as modules in the project. Previously, `next.config.js` was configured to use `file-loader` for `.pdf` files, but the `file-loader` package was not installed in `package.json`, causing builds to fail. 

We resolved this cleanly by configuring Webpack 5's native **Asset Modules** (`type: 'asset/resource'`), which eliminates the need for the deprecated `file-loader` package entirely.

Additionally, this PR refactors three template-related API routes that were broken in production builds because they referenced the legacy and missing `@supabase/auth-helpers-nextjs` library. They have been updated to use the standard `@/lib/supabase/server` helper (powered by `@supabase/ssr`), aligned with the rest of the codebase.

Fixes #597

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify): ____________________

## Changes Made

- **Webpack Configuration (`next.config.js`)**: Updated the `.pdf` loader rule to use Webpack 5 Asset Modules (`type: 'asset/resource'`) and output files to `static/files/`.
- **TypeScript Definitions (`types/global.d.ts`)**: Added `declare module '*.pdf';` to support importing PDF files as module strings.
- **Supabase Route Handler Refactoring**: Refactored the template API routes to use `@/lib/supabase/server` client instead of the uninstalled `@supabase/auth-helpers-nextjs`:
  - `app/api/templates/[id]/route.ts`
  - `app/api/templates/[id]/shares/route.ts`
  - `app/api/templates/[id]/shares/[shareId]/route.ts`
- **Build Stabilization (`next.config.js`)**: Disabled the experimental `workerThreads` flag which caused a `DataCloneError` timeout crash during static page data collection (`next build`).

## Dependencies

- No new dependencies were added. Webpack 5 Asset Modules are built-in natively.

## Add Screenshots
*(No UI changes were made in this PR)*

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers/devices.
- [x] I have tested my changes in development mode (`npm run dev`).
- [x] I have written or updated related tests, if necessary.
- [x] This is already assigned Issue to me, not an unassigned issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Supabase client initialization across template API routes to streamline authentication handling.

* **Chores**
  * Removed experimental worker threads configuration flag.
  * Enhanced PDF file asset handling for improved compatibility.
  * Added TypeScript support for PDF file imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->