### PR TITLE
fix ( #598) : Fix Inconsistent Credit Reset Logic Between API Route and Credits Service

### DIFF
--- a/app/api/credits/route.ts
+++ b/app/api/credits/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { TIER_LIMITS, ACTION_COSTS, TIER_NAMES, TIER_FEATURES, hasUnlimitedDeveloperCredits, type Tier, type ActionType } from '@/lib/credits-service';
+import { TIER_LIMITS, ACTION_COSTS, TIER_NAMES, TIER_FEATURES, hasUnlimitedDeveloperCredits, getCreditsResetDate, shouldResetCredits, type Tier, type ActionType } from '@/lib/credits-service';
 import { reserveCredits } from '@/lib/credit-operations';
 
 const supabase = createClient(
@@ -41,8 +41,7 @@ export async function GET(request: Request) {
 
     // If no credits record, create one
     if (error?.code === 'PGRST116' || !credits) {
-      const resetDate = new Date();
-      resetDate.setDate(resetDate.getDate() + 30);
+      const resetDate = getCreditsResetDate();
 
       const { data: newCredits, error: insertError } = await supabase
         .from('user_credits')
@@ -51,7 +50,7 @@ export async function GET(request: Request) {
           tier: 'free',
           credits_total: TIER_LIMITS.free,
           credits_used: 0,
-          credits_reset_at: resetDate.toISOString(),
+          credits_reset_at: resetDate,
         })
         .select()
         .single();
@@ -66,7 +65,7 @@ export async function GET(request: Request) {
           creditsUsed: 0,
           creditsRemaining: TIER_LIMITS.free,
           features: TIER_FEATURES.free,
-          resetDate: resetDate.toISOString(),
+          resetDate: resetDate,
           actionCosts: ACTION_COSTS,
         });
       }
@@ -75,15 +74,14 @@ export async function GET(request: Request) {
     }
 
     // Check if credits need reset
-    if (credits && new Date(credits.credits_reset_at) < new Date()) {
-      const resetDate = new Date();
-      resetDate.setDate(resetDate.getDate() + 30);
+    if (credits && shouldResetCredits(credits.credits_reset_at)) {
+      const resetDate = getCreditsResetDate();
 
       const { data: updatedCredits } = await supabase
         .from('user_credits')
         .update({
           credits_used: 0,
-          credits_reset_at: resetDate.toISOString(),
+          credits_reset_at: resetDate,
         })
         .eq('user_id', user.id)
         .select()
@@ -165,8 +163,7 @@ export async function POST(request: Request) {
 
     // If no credits record, create one
     if (error?.code === 'PGRST116' || !credits) {
-      const resetDate = new Date();
-      resetDate.setDate(resetDate.getDate() + 30);
+      const resetDate = getCreditsResetDate();
 
       const { data: newCredits, error: insertError } = await supabase
         .from('user_credits')
@@ -175,7 +172,7 @@ export async function POST(request: Request) {
           tier: 'free',
           credits_total: TIER_LIMITS.free,
           credits_used: 0,
-          credits_reset_at: resetDate.toISOString(),
+          credits_reset_at: resetDate,
         })
         .select()
         .single();
@@ -191,15 +188,14 @@ export async function POST(request: Request) {
     }
 
     // Check if credits need reset
-    if (credits && new Date(credits.credits_reset_at) < new Date()) {
-      const resetDate = new Date();
-      resetDate.setDate(resetDate.getDate() + 30);
+    if (credits && shouldResetCredits(credits.credits_reset_at)) {
+      const resetDate = getCreditsResetDate();
 
       const { data: updatedCredits } = await supabase
         .from('user_credits')
         .update({
           credits_used: 0,
-          credits_reset_at: resetDate.toISOString(),
+          credits_reset_at: resetDate,
         })
         .eq('user_id', user.id)
         .select()


### PR DESCRIPTION
# fix  #598 : align credit reset logic with monthly cycle helper

## Description

This PR resolves inconsistent credit reset behavior in the application. Currently, the endpoint `app/api/credits/route.ts` resets credits using a manual rolling `30-day` calculation (`setDate(getDate() + 30)`). Meanwhile, other endpoints (such as `analyze-ats` and `generate-presentation-stream`) correctly use the monthly reset helpers in `lib/credits-service.ts` to reset credits on the 1st day of the next month.

We aligned the credits API route by replacing the manual calculations with `getCreditsResetDate()` and `shouldResetCredits()`.

Fixes #<ISSUE_NUMBER> (replace with the actual issue number)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **Credits API Handler (`app/api/credits/route.ts`)**:
  - Imported `getCreditsResetDate` and `shouldResetCredits` from `@/lib/credits-service`.
  - Replaced all manual rolling 30-day calculation blocks with `getCreditsResetDate()`.
  - Replaced manual Date comparison checks with `shouldResetCredits()`.
  - Directly persisted the returned ISO-string `resetDate` to the database.

## Dependencies

- None (uses existing helpers from `lib/credits-service.ts`).

## Add Screenshots
*(No UI changes were made in this PR)*

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes in development mode (`npm run dev`).
- [x] This is already assigned Issue to me, not an unassigned issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to credit management system for better code organization and maintainability. No changes to user-facing functionality or API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->