### PR TITLE
fix (#599) : Fix Stale creditsRemaining Value Returned After Credit Reservation

### DIFF
--- a/app/api/credits/route.ts
+++ b/app/api/credits/route.ts
@@ -271,7 +271,7 @@ export async function POST(request: Request) {
     return NextResponse.json({
       success: true,
       creditsUsed: creditsRequired,
-      creditsRemaining: creditsRemaining - creditsRequired,
+      creditsRemaining: reserved.credits_total - reserved.credits_used,
       tier: credits.tier,
     });
 


### PR DESCRIPTION
# fix #599  : return accurate creditsRemaining using updated database row values

## Description

This PR fixes a bug where the API response returned incorrect (stale) credit balance information immediately after a successful credit reservation. 

Previously, the endpoint `/api/credits` calculated the remaining credits using pre-reservation variables (`creditsRemaining - creditsRequired`), which did not accurately reflect the database state after the optimistic-lock update. We fixed this by using the updated values returned directly by the `reserveCredits()` atomic function (`reserved.credits_total - reserved.credits_used`).

Fixes #<ISSUE_NUMBER> (replace with the actual issue number)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **Credits API Route (`app/api/credits/route.ts`)**:
  - Replaced the stale mathematical calculation in the POST handler's JSON response with the exact `credits_total` and `credits_used` properties returned by the atomic `reserveCredits()` database update.

## Dependencies

- None.

## Add Screenshots
*(No UI changes were made in this PR)*

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes in development mode (`npm run dev`).
- [x] I have tested my changes with the integration test suite (`npm run test`).
- [x] This is already assigned Issue to me, not an unassigned issue.