### PR TITLE
feat: implement API versioning with v1/v2 support and RFC 8594   deprecation headers  #539

### DIFF
--- a/__tests__/api-versioning/deprecation.test.ts
+++ b/__tests__/api-versioning/deprecation.test.ts
@@ -129,6 +129,10 @@ describe('addDeprecationHeaders — v2 response (no-op)', () => {
     expect(response.headers.get('Warning')).toBeNull();
   });
 
+  it('does not add Link header', () => {
+    expect(response.headers.get('Link')).toBeNull();
+  });
+
   it('does not add X-API-Deprecated header', () => {
     expect(response.headers.get('X-API-Deprecated')).toBeNull();
   });

--- a/__tests__/api-versioning/deprecation.test.ts
+++ b/__tests__/api-versioning/deprecation.test.ts
@@ -1,0 +1,139 @@
+/** @jest-environment node */
+// NextResponse requires the Web Fetch API (Response global). Node 18+ provides it; jsdom does not.
+import { NextResponse } from 'next/server';
+import { addDeprecationHeaders, getDeprecationHeaderMap } from '@/lib/api-versioning';
+import { VERSION_CONFIGS } from '@/lib/api-versioning';
+
+function makeResponse(): NextResponse {
+  return NextResponse.json({ ok: true });
+}
+
+// ---------------------------------------------------------------------------
+// getDeprecationHeaderMap — plain object, no Response needed
+// ---------------------------------------------------------------------------
+describe('getDeprecationHeaderMap — v1', () => {
+  const headers = getDeprecationHeaderMap('v1');
+
+  it('sets Deprecation: true', () => {
+    expect(headers['Deprecation']).toBe('true');
+  });
+
+  it('sets Sunset to the configured sunset date at end-of-day UTC', () => {
+    const expected = `${VERSION_CONFIGS.v1.sunsetDate}T23:59:59Z`;
+    expect(headers['Sunset']).toBe(expected);
+  });
+
+  it('sets Warning with 299 code and migration URL', () => {
+    expect(headers['Warning']).toMatch(/^299 /);
+    expect(headers['Warning']).toContain(VERSION_CONFIGS.v1.migrationGuideUrl);
+  });
+
+  it('sets Link with rel="deprecation" pointing to migration guide', () => {
+    expect(headers['Link']).toContain('rel="deprecation"');
+    expect(headers['Link']).toContain(VERSION_CONFIGS.v1.migrationGuideUrl);
+  });
+
+  it('sets X-API-Version: v1', () => {
+    expect(headers['X-API-Version']).toBe('v1');
+  });
+
+  it('sets X-API-Deprecated: true', () => {
+    expect(headers['X-API-Deprecated']).toBe('true');
+  });
+
+  it('sets X-API-Sunset to the plain date', () => {
+    expect(headers['X-API-Sunset']).toBe(VERSION_CONFIGS.v1.sunsetDate);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addDeprecationHeaders — mutates a real NextResponse
+// ---------------------------------------------------------------------------
+describe('addDeprecationHeaders — v1 response', () => {
+  let response: NextResponse;
+
+  beforeEach(() => {
+    response = addDeprecationHeaders(makeResponse(), 'v1');
+  });
+
+  it('returns the same response object (mutates in place)', () => {
+    const original = makeResponse();
+    const returned = addDeprecationHeaders(original, 'v1');
+    expect(returned).toBe(original);
+  });
+
+  it('adds Deprecation header', () => {
+    expect(response.headers.get('Deprecation')).toBe('true');
+  });
+
+  it('adds Sunset header', () => {
+    expect(response.headers.get('Sunset')).toBe(`${VERSION_CONFIGS.v1.sunsetDate}T23:59:59Z`);
+  });
+
+  it('adds Warning header with 299 code', () => {
+    expect(response.headers.get('Warning')).toMatch(/^299 /);
+  });
+
+  it('adds Link header with rel="deprecation"', () => {
+    expect(response.headers.get('Link')).toContain('rel="deprecation"');
+  });
+
+  it('adds X-API-Version: v1', () => {
+    expect(response.headers.get('X-API-Version')).toBe('v1');
+  });
+
+  it('adds X-API-Deprecated: true', () => {
+    expect(response.headers.get('X-API-Deprecated')).toBe('true');
+  });
+
+  it('adds X-API-Sunset header', () => {
+    expect(response.headers.get('X-API-Sunset')).toBe(VERSION_CONFIGS.v1.sunsetDate);
+  });
+
+  it('preserves the original response status and body', async () => {
+    const res = addDeprecationHeaders(NextResponse.json({ data: 'test' }, { status: 201 }), 'v1');
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual({ data: 'test' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDeprecationHeaderMap — v2 returns empty object
+// ---------------------------------------------------------------------------
+describe('getDeprecationHeaderMap — v2', () => {
+  it('returns an empty object for non-deprecated versions', () => {
+    expect(getDeprecationHeaderMap('v2')).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addDeprecationHeaders — v2 must NOT receive deprecation headers
+// ---------------------------------------------------------------------------
+describe('addDeprecationHeaders — v2 response (no-op)', () => {
+  let response: NextResponse;
+
+  beforeEach(() => {
+    response = addDeprecationHeaders(makeResponse(), 'v2');
+  });
+
+  it('does not add Deprecation header', () => {
+    expect(response.headers.get('Deprecation')).toBeNull();
+  });
+
+  it('does not add Sunset header', () => {
+    expect(response.headers.get('Sunset')).toBeNull();
+  });
+
+  it('does not add Warning header', () => {
+    expect(response.headers.get('Warning')).toBeNull();
+  });
+
+  it('does not add X-API-Deprecated header', () => {
+    expect(response.headers.get('X-API-Deprecated')).toBeNull();
+  });
+
+  it('does not add X-API-Sunset header', () => {
+    expect(response.headers.get('X-API-Sunset')).toBeNull();
+  });
+});

--- a/__tests__/api-versioning/version-router.test.ts
+++ b/__tests__/api-versioning/version-router.test.ts
@@ -1,0 +1,186 @@
+/** @jest-environment node */
+// NextRequest requires the Web Fetch API (Request global). Node 18+ provides it; jsdom does not.
+import { NextRequest } from 'next/server';
+import {
+  detectVersion,
+  isSupported,
+  isDeprecated,
+  convertV1ResumeToV2,
+  convertV1DocumentToV2,
+} from '@/lib/api-versioning';
+
+function req(url: string, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest(url, { headers });
+}
+
+// ---------------------------------------------------------------------------
+// detectVersion — URL path (highest priority)
+// ---------------------------------------------------------------------------
+describe('detectVersion — URL path', () => {
+  it('returns v1 for /api/v1/ prefix', () => {
+    expect(detectVersion(req('http://localhost/api/v1/health'))).toBe('v1');
+  });
+
+  it('returns v2 for /api/v2/ prefix', () => {
+    expect(detectVersion(req('http://localhost/api/v2/documents'))).toBe('v2');
+  });
+
+  it('returns v2 (default) for unversioned path', () => {
+    expect(detectVersion(req('http://localhost/api/health'))).toBe('v2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectVersion — API-Version header (second priority)
+// ---------------------------------------------------------------------------
+describe('detectVersion — API-Version header', () => {
+  it('reads bare number "1"', () => {
+    expect(detectVersion(req('http://localhost/api/health', { 'API-Version': '1' }))).toBe('v1');
+  });
+
+  it('reads "v1" with prefix', () => {
+    expect(detectVersion(req('http://localhost/api/health', { 'API-Version': 'v1' }))).toBe('v1');
+  });
+
+  it('reads "2" as v2', () => {
+    expect(detectVersion(req('http://localhost/api/health', { 'API-Version': '2' }))).toBe('v2');
+  });
+
+  it('falls back to v2 for unsupported header value', () => {
+    expect(detectVersion(req('http://localhost/api/health', { 'API-Version': '99' }))).toBe('v2');
+  });
+
+  it('URL path takes priority over header', () => {
+    // Path says v1, header says v2 → path wins
+    expect(
+      detectVersion(req('http://localhost/api/v1/health', { 'API-Version': '2' }))
+    ).toBe('v1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectVersion — query param (third priority)
+// ---------------------------------------------------------------------------
+describe('detectVersion — query param', () => {
+  it('reads ?api_version=1', () => {
+    expect(detectVersion(req('http://localhost/api/health?api_version=1'))).toBe('v1');
+  });
+
+  it('reads ?api_version=v2', () => {
+    expect(detectVersion(req('http://localhost/api/health?api_version=v2'))).toBe('v2');
+  });
+
+  it('header takes priority over query param', () => {
+    expect(
+      detectVersion(req('http://localhost/api/health?api_version=1', { 'API-Version': '2' }))
+    ).toBe('v2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSupported / isDeprecated
+// ---------------------------------------------------------------------------
+describe('isSupported', () => {
+  it('returns true for v1', () => expect(isSupported('v1')).toBe(true));
+  it('returns true for v2', () => expect(isSupported('v2')).toBe(true));
+  it('returns false for v3 (unknown)', () => expect(isSupported('v3')).toBe(false));
+  it('returns false for empty string', () => expect(isSupported('')).toBe(false));
+});
+
+describe('isDeprecated', () => {
+  it('v1 is deprecated', () => expect(isDeprecated('v1')).toBe(true));
+  it('v2 is not deprecated', () => expect(isDeprecated('v2')).toBe(false));
+});
+
+// ---------------------------------------------------------------------------
+// convertV1ResumeToV2 — pure function, no I/O
+// ---------------------------------------------------------------------------
+describe('convertV1ResumeToV2', () => {
+  it('maps personalInfo fields to flat name/email', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada Lovelace', email: 'ada@example.com' },
+      jobTitle: 'Software Engineer',
+    });
+    expect(result.name).toBe('Ada Lovelace');
+    expect(result.email).toBe('ada@example.com');
+  });
+
+  it('builds prompt from jobTitle', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada', email: 'ada@example.com' },
+      jobTitle: 'Data Scientist',
+    });
+    expect(result.prompt).toContain('Data Scientist');
+  });
+
+  it('includes years of experience in prompt', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada', email: 'ada@example.com' },
+      jobTitle: 'Engineer',
+      yearsOfExperience: 5,
+    });
+    expect(result.prompt).toContain('5 years');
+  });
+
+  it('converts comma-separated skills string into prompt text', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada', email: 'ada@example.com' },
+      jobTitle: 'Engineer',
+      skills: 'TypeScript, React, Node.js',
+    });
+    expect(result.prompt).toContain('TypeScript');
+    expect(result.prompt).toContain('React');
+    expect(result.prompt).toContain('Node.js');
+  });
+
+  it('appends additionalContext at the end of the prompt', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada', email: 'ada@example.com' },
+      jobTitle: 'Engineer',
+      additionalContext: 'Focus on backend systems.',
+    });
+    expect(result.prompt).toContain('Focus on backend systems.');
+  });
+
+  it('omits empty skills gracefully', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada', email: 'ada@example.com' },
+      jobTitle: 'Engineer',
+      skills: '',
+    });
+    expect(result.prompt).not.toContain('Key skills');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// convertV1DocumentToV2 — pure function, no I/O
+// ---------------------------------------------------------------------------
+describe('convertV1DocumentToV2', () => {
+  it('renames name → title and type → documentType', () => {
+    const result = convertV1DocumentToV2({ name: 'My Doc', type: 'resume' });
+    expect(result.title).toBe('My Doc');
+    expect(result.documentType).toBe('resume');
+  });
+
+  it('renames data → content when present', () => {
+    const result = convertV1DocumentToV2({ name: 'X', type: 'y', data: { foo: 'bar' } });
+    expect(result.content).toEqual({ foo: 'bar' });
+  });
+
+  it('renames tags → metadata when present', () => {
+    const result = convertV1DocumentToV2({ name: 'X', type: 'y', tags: { env: 'prod' } });
+    expect(result.metadata).toEqual({ env: 'prod' });
+  });
+
+  it('renames parts → sections when present', () => {
+    const result = convertV1DocumentToV2({ name: 'X', type: 'y', parts: [1, 2] });
+    expect(result.sections).toEqual([1, 2]);
+  });
+
+  it('does not include undefined optional fields in output', () => {
+    const result = convertV1DocumentToV2({ name: 'X', type: 'y' });
+    expect(result).not.toHaveProperty('content');
+    expect(result).not.toHaveProperty('metadata');
+    expect(result).not.toHaveProperty('sections');
+  });
+});

--- a/__tests__/api-versioning/version-router.test.ts
+++ b/__tests__/api-versioning/version-router.test.ts
@@ -201,6 +201,14 @@ describe('convertV1ResumeToV2', () => {
       convertV1ResumeToV2({ personalInfo: null as never, jobTitle: 'Engineer' })
     ).toThrow();
   });
+
+  it('passes through numeric name/email (isNonEmptyString guard in route catches non-strings before converter)', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 42 as never, email: 'ada@example.com' },
+      jobTitle: 'Engineer',
+    });
+    expect(result.name).toBe(42);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -249,5 +257,10 @@ describe('convertV1DocumentToV2', () => {
 
   it('throws when body is null (route layer prevents this reaching the converter)', () => {
     expect(() => convertV1DocumentToV2(null as never)).toThrow();
+  });
+
+  it('passes through numeric name (isNonEmptyString guard in route catches non-strings before converter)', () => {
+    const result = convertV1DocumentToV2({ name: 99 as never, type: 'resume' });
+    expect(result.title).toBe(99);
   });
 });

--- a/__tests__/api-versioning/version-router.test.ts
+++ b/__tests__/api-versioning/version-router.test.ts
@@ -202,6 +202,24 @@ describe('convertV1ResumeToV2', () => {
     ).toThrow();
   });
 
+  it('ignores non-string skills value without throwing', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada', email: 'ada@example.com' },
+      jobTitle: 'Engineer',
+      skills: 123 as never,
+    });
+    expect(result.prompt).not.toContain('Key skills');
+  });
+
+  it('ignores non-string additionalContext value without throwing', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada', email: 'ada@example.com' },
+      jobTitle: 'Engineer',
+      additionalContext: { note: 'x' } as never,
+    });
+    expect(result.prompt).toBe('Create a professional resume for an Engineer position.');
+  });
+
   it('passes through numeric name/email (isNonEmptyString guard in route catches non-strings before converter)', () => {
     const result = convertV1ResumeToV2({
       personalInfo: { name: 42 as never, email: 'ada@example.com' },

--- a/__tests__/api-versioning/version-router.test.ts
+++ b/__tests__/api-versioning/version-router.test.ts
@@ -174,7 +174,32 @@ describe('convertV1ResumeToV2', () => {
       jobTitle: 'Engineer',
       additionalContext: '   ',
     });
-    expect(result.prompt).toBe('Create a professional resume for a Engineer position.');
+    expect(result.prompt).toBe('Create a professional resume for an Engineer position.');
+  });
+
+  it('passes through empty name and email strings (route layer enforces non-empty)', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: '', email: '' },
+      jobTitle: 'Engineer',
+    });
+    expect(result.name).toBe('');
+    expect(result.email).toBe('');
+  });
+
+  it('passes through empty jobTitle string (route layer enforces non-empty)', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada', email: 'ada@example.com' },
+      jobTitle: '',
+    });
+    expect(result.prompt).toContain('Create a professional resume for a');
+    expect(result.name).toBe('Ada');
+    expect(result.email).toBe('ada@example.com');
+  });
+
+  it('throws when personalInfo is null (route layer prevents this reaching the converter)', () => {
+    expect(() =>
+      convertV1ResumeToV2({ personalInfo: null as never, jobTitle: 'Engineer' })
+    ).toThrow();
   });
 });
 
@@ -208,5 +233,21 @@ describe('convertV1DocumentToV2', () => {
     expect(result).not.toHaveProperty('content');
     expect(result).not.toHaveProperty('metadata');
     expect(result).not.toHaveProperty('sections');
+  });
+
+  it('passes through empty name string (route layer enforces non-empty)', () => {
+    const result = convertV1DocumentToV2({ name: '', type: 'resume' });
+    expect(result.title).toBe('');
+    expect(result.documentType).toBe('resume');
+  });
+
+  it('passes through empty type string (route layer enforces non-empty)', () => {
+    const result = convertV1DocumentToV2({ name: 'My Doc', type: '' });
+    expect(result.title).toBe('My Doc');
+    expect(result.documentType).toBe('');
+  });
+
+  it('throws when body is null (route layer prevents this reaching the converter)', () => {
+    expect(() => convertV1DocumentToV2(null as never)).toThrow();
   });
 });

--- a/__tests__/api-versioning/version-router.test.ts
+++ b/__tests__/api-versioning/version-router.test.ts
@@ -21,8 +21,16 @@ describe('detectVersion — URL path', () => {
     expect(detectVersion(req('http://localhost/api/v1/health'))).toBe('v1');
   });
 
+  it('returns v1 for /api/v1 without trailing slash', () => {
+    expect(detectVersion(req('http://localhost/api/v1'))).toBe('v1');
+  });
+
   it('returns v2 for /api/v2/ prefix', () => {
     expect(detectVersion(req('http://localhost/api/v2/documents'))).toBe('v2');
+  });
+
+  it('returns v2 for /api/v2 without trailing slash', () => {
+    expect(detectVersion(req('http://localhost/api/v2'))).toBe('v2');
   });
 
   it('returns v2 (default) for unversioned path', () => {
@@ -149,6 +157,24 @@ describe('convertV1ResumeToV2', () => {
       skills: '',
     });
     expect(result.prompt).not.toContain('Key skills');
+  });
+
+  it('omits whitespace-only skills without appending "Key skills: ."', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada', email: 'ada@example.com' },
+      jobTitle: 'Engineer',
+      skills: '   ,  ,  ',
+    });
+    expect(result.prompt).not.toContain('Key skills');
+  });
+
+  it('omits whitespace-only additionalContext', () => {
+    const result = convertV1ResumeToV2({
+      personalInfo: { name: 'Ada', email: 'ada@example.com' },
+      jobTitle: 'Engineer',
+      additionalContext: '   ',
+    });
+    expect(result.prompt).toBe('Create a professional resume for a Engineer position.');
   });
 });
 

--- a/app/api/v1/documents/route.ts
+++ b/app/api/v1/documents/route.ts
@@ -1,16 +1,26 @@
-import { NextRequest, type NextResponse } from 'next/server';
+import { NextRequest, NextResponse, type NextResponse as NextResponseType } from 'next/server';
 import { addDeprecationHeaders, convertV1DocumentToV2, type V1DocumentInput } from '@/lib/api-versioning';
 import { POST as v2POST, GET as v2GET } from '@/app/api/documents/route';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
-  const response = await v2GET(request) as NextResponse;
+/** v1 list documents — proxies to v2 and injects deprecation headers. */
+export async function GET(request: NextRequest): Promise<NextResponseType> {
+  const response = await v2GET(request) as NextResponseType;
   return addDeprecationHeaders(response);
 }
 
-export async function POST(request: NextRequest): Promise<NextResponse> {
+/** v1 create document — validates required fields, converts legacy fields (name→title, type→documentType, data→content) then proxies to v2. */
+export async function POST(request: NextRequest): Promise<NextResponseType> {
   const legacyBody = await request.json() as V1DocumentInput;
+
+  if (!legacyBody?.name?.trim()) {
+    return NextResponse.json({ error: 'name is required' }, { status: 400 });
+  }
+  if (!legacyBody?.type?.trim()) {
+    return NextResponse.json({ error: 'type is required' }, { status: 400 });
+  }
+
   const v2Body = convertV1DocumentToV2(legacyBody);
 
   // Rebuild the request with the converted body so v2POST receives its expected shape
@@ -20,6 +30,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     body: JSON.stringify(v2Body),
   });
 
-  const response = await v2POST(v2Request) as NextResponse;
+  const response = await v2POST(v2Request) as NextResponseType;
   return addDeprecationHeaders(response);
 }

--- a/app/api/v1/documents/route.ts
+++ b/app/api/v1/documents/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, type NextResponse } from 'next/server';
+import { addDeprecationHeaders, convertV1DocumentToV2, type V1DocumentInput } from '@/lib/api-versioning';
+import { POST as v2POST, GET as v2GET } from '@/app/api/documents/route';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const response = await v2GET(request) as NextResponse;
+  return addDeprecationHeaders(response);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const legacyBody = await request.json() as V1DocumentInput;
+  const v2Body = convertV1DocumentToV2(legacyBody);
+
+  // Rebuild the request with the converted body so v2POST receives its expected shape
+  const v2Request = new NextRequest(request.url, {
+    method: 'POST',
+    headers: request.headers,
+    body: JSON.stringify(v2Body),
+  });
+
+  const response = await v2POST(v2Request) as NextResponse;
+  return addDeprecationHeaders(response);
+}

--- a/app/api/v1/documents/route.ts
+++ b/app/api/v1/documents/route.ts
@@ -12,13 +12,18 @@ export async function GET(request: NextRequest): Promise<NextResponseType> {
 
 /** v1 create document — validates required fields, converts legacy fields (name→title, type→documentType, data→content) then proxies to v2. */
 export async function POST(request: NextRequest): Promise<NextResponseType> {
-  const legacyBody = await request.json() as V1DocumentInput;
+  let legacyBody: V1DocumentInput;
+  try {
+    legacyBody = await request.json() as V1DocumentInput;
+  } catch {
+    return addDeprecationHeaders(NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }));
+  }
 
   if (!legacyBody?.name?.trim()) {
-    return NextResponse.json({ error: 'name is required' }, { status: 400 });
+    return addDeprecationHeaders(NextResponse.json({ error: 'name is required' }, { status: 400 }));
   }
   if (!legacyBody?.type?.trim()) {
-    return NextResponse.json({ error: 'type is required' }, { status: 400 });
+    return addDeprecationHeaders(NextResponse.json({ error: 'type is required' }, { status: 400 }));
   }
 
   const v2Body = convertV1DocumentToV2(legacyBody);

--- a/app/api/v1/documents/route.ts
+++ b/app/api/v1/documents/route.ts
@@ -4,6 +4,10 @@ import { POST as v2POST, GET as v2GET } from '@/app/api/documents/route';
 
 export const dynamic = 'force-dynamic';
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 /** v1 list documents — proxies to v2 and injects deprecation headers. */
 export async function GET(request: NextRequest): Promise<NextResponseType> {
   const response = await v2GET(request) as NextResponseType;
@@ -19,10 +23,10 @@ export async function POST(request: NextRequest): Promise<NextResponseType> {
     return addDeprecationHeaders(NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }));
   }
 
-  if (!legacyBody?.name?.trim()) {
+  if (!isNonEmptyString(legacyBody?.name)) {
     return addDeprecationHeaders(NextResponse.json({ error: 'name is required' }, { status: 400 }));
   }
-  if (!legacyBody?.type?.trim()) {
+  if (!isNonEmptyString(legacyBody?.type)) {
     return addDeprecationHeaders(NextResponse.json({ error: 'type is required' }, { status: 400 }));
   }
 

--- a/app/api/v1/generate/resume/route.ts
+++ b/app/api/v1/generate/resume/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, type NextResponse } from 'next/server';
+import { addDeprecationHeaders, convertV1ResumeToV2, type V1ResumeInput } from '@/lib/api-versioning';
+import { POST as v2POST } from '@/app/api/generate/resume/route';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const legacyBody = await request.json() as V1ResumeInput;
+  const v2Body = convertV1ResumeToV2(legacyBody);
+
+  // Rebuild the request with the converted body so v2POST receives its expected shape
+  const v2Request = new NextRequest(request.url, {
+    method: 'POST',
+    headers: request.headers,
+    body: JSON.stringify(v2Body),
+  });
+
+  const response = await v2POST(v2Request) as NextResponse;
+  return addDeprecationHeaders(response);
+}

--- a/app/api/v1/generate/resume/route.ts
+++ b/app/api/v1/generate/resume/route.ts
@@ -5,6 +5,10 @@ import { POST as v2POST } from '@/app/api/generate/resume/route';
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 /** v1 resume generation — validates required fields, converts legacy shape (personalInfo, jobTitle, skills CSV) to v2 prompt, then proxies to v2. */
 export async function POST(request: NextRequest): Promise<NextResponseType> {
   let legacyBody: V1ResumeInput;
@@ -14,13 +18,13 @@ export async function POST(request: NextRequest): Promise<NextResponseType> {
     return addDeprecationHeaders(NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }));
   }
 
-  if (!legacyBody?.personalInfo?.name?.trim()) {
+  if (!isNonEmptyString(legacyBody?.personalInfo?.name)) {
     return addDeprecationHeaders(NextResponse.json({ error: 'personalInfo.name is required' }, { status: 400 }));
   }
-  if (!legacyBody?.personalInfo?.email?.trim()) {
+  if (!isNonEmptyString(legacyBody?.personalInfo?.email)) {
     return addDeprecationHeaders(NextResponse.json({ error: 'personalInfo.email is required' }, { status: 400 }));
   }
-  if (!legacyBody?.jobTitle?.trim()) {
+  if (!isNonEmptyString(legacyBody?.jobTitle)) {
     return addDeprecationHeaders(NextResponse.json({ error: 'jobTitle is required' }, { status: 400 }));
   }
 

--- a/app/api/v1/generate/resume/route.ts
+++ b/app/api/v1/generate/resume/route.ts
@@ -1,12 +1,24 @@
-import { NextRequest, type NextResponse } from 'next/server';
+import { NextRequest, NextResponse, type NextResponse as NextResponseType } from 'next/server';
 import { addDeprecationHeaders, convertV1ResumeToV2, type V1ResumeInput } from '@/lib/api-versioning';
 import { POST as v2POST } from '@/app/api/generate/resume/route';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-export async function POST(request: NextRequest): Promise<NextResponse> {
+/** v1 resume generation — validates required fields, converts legacy shape (personalInfo, jobTitle, skills CSV) to v2 prompt, then proxies to v2. */
+export async function POST(request: NextRequest): Promise<NextResponseType> {
   const legacyBody = await request.json() as V1ResumeInput;
+
+  if (!legacyBody?.personalInfo?.name?.trim()) {
+    return NextResponse.json({ error: 'personalInfo.name is required' }, { status: 400 });
+  }
+  if (!legacyBody?.personalInfo?.email?.trim()) {
+    return NextResponse.json({ error: 'personalInfo.email is required' }, { status: 400 });
+  }
+  if (!legacyBody?.jobTitle?.trim()) {
+    return NextResponse.json({ error: 'jobTitle is required' }, { status: 400 });
+  }
+
   const v2Body = convertV1ResumeToV2(legacyBody);
 
   // Rebuild the request with the converted body so v2POST receives its expected shape
@@ -16,6 +28,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     body: JSON.stringify(v2Body),
   });
 
-  const response = await v2POST(v2Request) as NextResponse;
+  const response = await v2POST(v2Request) as NextResponseType;
   return addDeprecationHeaders(response);
 }

--- a/app/api/v1/generate/resume/route.ts
+++ b/app/api/v1/generate/resume/route.ts
@@ -7,16 +7,21 @@ export const runtime = 'nodejs';
 
 /** v1 resume generation — validates required fields, converts legacy shape (personalInfo, jobTitle, skills CSV) to v2 prompt, then proxies to v2. */
 export async function POST(request: NextRequest): Promise<NextResponseType> {
-  const legacyBody = await request.json() as V1ResumeInput;
+  let legacyBody: V1ResumeInput;
+  try {
+    legacyBody = await request.json() as V1ResumeInput;
+  } catch {
+    return addDeprecationHeaders(NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }));
+  }
 
   if (!legacyBody?.personalInfo?.name?.trim()) {
-    return NextResponse.json({ error: 'personalInfo.name is required' }, { status: 400 });
+    return addDeprecationHeaders(NextResponse.json({ error: 'personalInfo.name is required' }, { status: 400 }));
   }
   if (!legacyBody?.personalInfo?.email?.trim()) {
-    return NextResponse.json({ error: 'personalInfo.email is required' }, { status: 400 });
+    return addDeprecationHeaders(NextResponse.json({ error: 'personalInfo.email is required' }, { status: 400 }));
   }
   if (!legacyBody?.jobTitle?.trim()) {
-    return NextResponse.json({ error: 'jobTitle is required' }, { status: 400 });
+    return addDeprecationHeaders(NextResponse.json({ error: 'jobTitle is required' }, { status: 400 }));
   }
 
   const v2Body = convertV1ResumeToV2(legacyBody);

--- a/app/api/v1/health/route.ts
+++ b/app/api/v1/health/route.ts
@@ -1,0 +1,10 @@
+import { type NextResponse } from 'next/server';
+import { addDeprecationHeaders } from '@/lib/api-versioning';
+import { GET as v2GET } from '@/app/api/health/route';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<NextResponse> {
+  const response = await v2GET() as NextResponse;
+  return addDeprecationHeaders(response);
+}

--- a/app/api/v2/documents/route.ts
+++ b/app/api/v2/documents/route.ts
@@ -1,0 +1,2 @@
+// v2 canonical URL for /api/documents — re-exports current handlers unchanged.
+export { GET, POST } from '@/app/api/documents/route';

--- a/app/api/v2/generate/resume/route.ts
+++ b/app/api/v2/generate/resume/route.ts
@@ -1,0 +1,2 @@
+// v2 canonical URL for /api/generate/resume — re-exports current handler unchanged.
+export { dynamic, runtime, POST } from '@/app/api/generate/resume/route';

--- a/app/api/v2/health/route.ts
+++ b/app/api/v2/health/route.ts
@@ -1,0 +1,3 @@
+// v2 canonical URL for /api/health — re-exports the current handler unchanged.
+// Clients that pin to /api/v2/health are future-proof when v3 is introduced.
+export { GET } from '@/app/api/health/route';

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -23,7 +23,7 @@ Three mechanisms are supported, evaluated in this priority order:
 
 ### 1. URL path (recommended)
 
-```
+```http
 GET  /api/v2/health
 POST /api/v2/documents
 POST /api/v2/generate/resume
@@ -35,7 +35,7 @@ POST /api/v1/generate/resume ← deprecated
 
 ### 2. Request header
 
-```
+```http
 API-Version: 2
 ```
 
@@ -43,7 +43,7 @@ Accepts bare numbers (`1`, `2`) or prefixed (`v1`, `v2`). Case-insensitive.
 
 ### 3. Query parameter (avoid in production — pollutes logs and caches)
 
-```
+```http
 GET /api/health?api_version=2
 ```
 
@@ -62,7 +62,7 @@ Every response from a v1 endpoint includes these headers:
 | `Deprecation`     | `true`                                               | RFC 8594       |
 | `Sunset`          | `2026-12-31T23:59:59Z`                               | RFC 8594       |
 | `Warning`         | `299 - "API v1 is deprecated..."`                    | RFC 7234 §5.5  |
-| `Link`            | `</docs/migration-v1-v2>; rel="deprecation"`         | RFC 8594       |
+| `Link`            | `<https://draftdeckai.com/docs/migration-v1-v2>; rel="deprecation"` | RFC 8594 |
 | `X-API-Version`   | `v1`                                                 | Custom         |
 | `X-API-Deprecated`| `true`                                               | Custom         |
 | `X-API-Sunset`    | `2026-12-31`                                         | Custom         |
@@ -99,7 +99,7 @@ as `/api/generate/resume`.
 
 ## Version Lifecycle
 
-```
+```text
 Introduced → Stable → Deprecated (Sunset header set) → Removed (after sunset date)
 ```
 

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,118 @@
+# API Versioning — DraftDeckAI
+
+## Overview
+
+DraftDeckAI uses **URL path versioning** as the primary versioning mechanism.
+All API versions run in parallel — no breaking changes are made to existing clients
+when a new version is introduced.
+
+---
+
+## Version Support Matrix
+
+| Version | Status     | Introduced | Sunset Date | Notes                          |
+|---------|------------|------------|-------------|--------------------------------|
+| v1      | Deprecated | Launch     | 2026-12-31  | Legacy param shapes supported  |
+| v2      | Stable     | 2026-05-21 | —           | Current canonical version      |
+
+---
+
+## How to Specify a Version
+
+Three mechanisms are supported, evaluated in this priority order:
+
+### 1. URL path (recommended)
+
+```
+GET  /api/v2/health
+POST /api/v2/documents
+POST /api/v2/generate/resume
+
+GET  /api/v1/health          ← deprecated
+POST /api/v1/documents       ← deprecated
+POST /api/v1/generate/resume ← deprecated
+```
+
+### 2. Request header
+
+```
+API-Version: 2
+```
+
+Accepts bare numbers (`1`, `2`) or prefixed (`v1`, `v2`). Case-insensitive.
+
+### 3. Query parameter (avoid in production — pollutes logs and caches)
+
+```
+GET /api/health?api_version=2
+```
+
+### Default
+
+Requests that do not specify a version are treated as **v2**.
+
+---
+
+## Deprecation Headers
+
+Every response from a v1 endpoint includes these headers:
+
+| Header            | Example value                                        | Standard       |
+|-------------------|------------------------------------------------------|----------------|
+| `Deprecation`     | `true`                                               | RFC 8594       |
+| `Sunset`          | `2026-12-31T23:59:59Z`                               | RFC 8594       |
+| `Warning`         | `299 - "API v1 is deprecated..."`                    | RFC 7234 §5.5  |
+| `Link`            | `</docs/migration-v1-v2>; rel="deprecation"`         | RFC 8594       |
+| `X-API-Version`   | `v1`                                                 | Custom         |
+| `X-API-Deprecated`| `true`                                               | Custom         |
+| `X-API-Sunset`    | `2026-12-31`                                         | Custom         |
+
+v2 responses carry **none** of these headers.
+
+---
+
+## Versioned Endpoints
+
+### Currently versioned
+
+| Endpoint                    | v1 path                        | v2 path                        |
+|-----------------------------|--------------------------------|--------------------------------|
+| Health check                | `GET /api/v1/health`           | `GET /api/v2/health`           |
+| Documents                   | `GET/POST /api/v1/documents`   | `GET/POST /api/v2/documents`   |
+| Resume generation           | `POST /api/v1/generate/resume` | `POST /api/v2/generate/resume` |
+
+### Unversioned routes
+
+All other routes (e.g. `/api/generate/presentation`, `/api/credits`) remain
+at their current paths and behave as v2. They will receive explicit v2 aliases
+in a follow-up PR.
+
+---
+
+## Rate Limiting
+
+Versioned paths share the same rate-limit bucket as their unversioned equivalents.
+`/api/v1/generate/resume` counts against the same GENERATE bucket (20 req / 5 min)
+as `/api/generate/resume`.
+
+---
+
+## Version Lifecycle
+
+```
+Introduced → Stable → Deprecated (Sunset header set) → Removed (after sunset date)
+```
+
+- A version is **deprecated** when a stable successor exists and a sunset date is announced.
+- A version is **removed** no earlier than its published sunset date.
+- Clients receive at least **6 months notice** before removal.
+
+---
+
+## Adding a New Version (for maintainers)
+
+1. Add the new version to `ApiVersion` in `lib/api-versioning/types.ts`
+2. Add its config to `VERSION_CONFIGS` (set `deprecated: false`, leave `sunsetDate` empty)
+3. Mark the previous version as `deprecated: true` and set a `sunsetDate`
+4. Create `app/api/v3/` route files (re-exports or new handlers)
+5. Update this document and `docs/migration-v1-v2.md` with the new migration guide

--- a/docs/migration-v1-v2.md
+++ b/docs/migration-v1-v2.md
@@ -1,0 +1,191 @@
+# Migration Guide: v1 → v2
+
+**v1 sunset date: 2026-12-31.** After this date, v1 endpoints will return `410 Gone`.
+Migrate before then to avoid service disruption.
+
+---
+
+## What Changed
+
+v2 standardises on flat request bodies with consistent field names.
+v1 used nested objects (`personalInfo`) and inconsistent naming (`name` vs `title`).
+
+---
+
+## Endpoint Changes
+
+### POST /api/generate/resume
+
+#### v1 request body (deprecated)
+
+```json
+{
+  "personalInfo": {
+    "name": "Ada Lovelace",
+    "email": "ada@example.com",
+    "phone": "+1 555 000 0000"
+  },
+  "jobTitle": "Software Engineer",
+  "yearsOfExperience": 5,
+  "skills": "TypeScript, React, Node.js",
+  "additionalContext": "Focus on backend systems."
+}
+```
+
+#### v2 request body (current)
+
+```json
+{
+  "name": "Ada Lovelace",
+  "email": "ada@example.com",
+  "prompt": "Create a professional resume for a Software Engineer position. The candidate has 5 years of experience. Key skills: TypeScript, React, Node.js. Focus on backend systems."
+}
+```
+
+#### Field mapping
+
+| v1 field                    | v2 field  | Notes                                              |
+|-----------------------------|-----------|----------------------------------------------------|
+| `personalInfo.name`         | `name`    | Moved to top level                                 |
+| `personalInfo.email`        | `email`   | Moved to top level                                 |
+| `personalInfo.phone`        | *(in prompt)* | Include in `prompt` if needed                  |
+| `jobTitle`                  | `prompt`  | Becomes the opening sentence of `prompt`           |
+| `yearsOfExperience`         | `prompt`  | Appended to `prompt` automatically by v1 adapter   |
+| `skills` *(comma string)*   | `prompt`  | Split and included in `prompt` as a list           |
+| `additionalContext`         | `prompt`  | Appended at the end of `prompt`                    |
+
+#### curl examples
+
+**v1 (deprecated):**
+```bash
+curl -X POST https://draftdeckai.com/api/v1/generate/resume \
+  -H "Content-Type: application/json" \
+  -d '{
+    "personalInfo": { "name": "Ada Lovelace", "email": "ada@example.com" },
+    "jobTitle": "Software Engineer",
+    "skills": "TypeScript, React"
+  }'
+```
+
+**v2 (current):**
+```bash
+curl -X POST https://draftdeckai.com/api/v2/generate/resume \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Ada Lovelace",
+    "email": "ada@example.com",
+    "prompt": "Create a professional resume for a Software Engineer. Key skills: TypeScript, React."
+  }'
+```
+
+---
+
+### GET/POST /api/documents
+
+#### v1 POST request body (deprecated)
+
+```json
+{
+  "name": "My Resume",
+  "type": "resume",
+  "data": { "sections": [] },
+  "tags": { "template": "modern" },
+  "parts": ["summary", "experience"]
+}
+```
+
+#### v2 POST request body (current)
+
+```json
+{
+  "title": "My Resume",
+  "documentType": "resume",
+  "content": { "sections": [] },
+  "metadata": { "template": "modern" },
+  "sections": ["summary", "experience"]
+}
+```
+
+#### Field mapping
+
+| v1 field | v2 field       | Notes                    |
+|----------|----------------|--------------------------|
+| `name`   | `title`        | Required                 |
+| `type`   | `documentType` | Required                 |
+| `data`   | `content`      | Optional                 |
+| `tags`   | `metadata`     | Optional                 |
+| `parts`  | `sections`     | Optional                 |
+
+#### curl examples
+
+**v1 (deprecated):**
+```bash
+curl -X POST https://draftdeckai.com/api/v1/documents \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{ "name": "My Resume", "type": "resume" }'
+```
+
+**v2 (current):**
+```bash
+curl -X POST https://draftdeckai.com/api/v2/documents \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{ "title": "My Resume", "documentType": "resume" }'
+```
+
+---
+
+### GET /api/health
+
+No request body changes. The only difference is the response includes v1
+deprecation headers when called via `/api/v1/health`.
+
+```bash
+# v2 — no deprecation headers
+curl https://draftdeckai.com/api/v2/health
+
+# v1 — includes Deprecation, Sunset, Warning headers
+curl https://draftdeckai.com/api/v1/health
+```
+
+---
+
+## Recognising Deprecation Headers
+
+Update your client to log or alert when it receives these headers on any response:
+
+```
+Deprecation: true
+Sunset: 2026-12-31T23:59:59Z
+Warning: 299 - "API v1 is deprecated..."
+```
+
+JavaScript example:
+
+```js
+const res = await fetch('/api/v1/generate/resume', { ... });
+
+if (res.headers.get('Deprecation') === 'true') {
+  const sunset = res.headers.get('X-API-Sunset');
+  console.warn(`[DraftDeckAI] This endpoint is deprecated. Migrate before ${sunset}.`);
+}
+```
+
+---
+
+## Migration Checklist
+
+- [ ] Replace `/api/v1/` URL prefix with `/api/v2/` across all API calls
+- [ ] Flatten `personalInfo.name/email` to top-level `name`/`email` in resume requests
+- [ ] Replace `jobTitle` + `skills` + `yearsOfExperience` with a single `prompt` string
+- [ ] Rename document fields: `name→title`, `type→documentType`, `data→content`, `tags→metadata`, `parts→sections`
+- [ ] Remove any client-side handling of the legacy fields
+- [ ] Add deprecation header detection to surface warnings early (see above)
+- [ ] Test with both endpoints before cutting over
+
+---
+
+## Support
+
+Open an issue on GitHub if you encounter problems during migration.

--- a/docs/migration-v1-v2.md
+++ b/docs/migration-v1-v2.md
@@ -155,7 +155,7 @@ curl https://draftdeckai.com/api/v1/health
 
 Update your client to log or alert when it receives these headers on any response:
 
-```
+```http
 Deprecation: true
 Sunset: 2026-12-31T23:59:59Z
 Warning: 299 - "API v1 is deprecated..."

--- a/lib/api-versioning/deprecation.ts
+++ b/lib/api-versioning/deprecation.ts
@@ -1,0 +1,54 @@
+import { type NextResponse } from 'next/server';
+import { type ApiVersion, VERSION_CONFIGS } from './types';
+
+/**
+ * Injects RFC 8594-compliant deprecation headers into a v1 response.
+ *
+ * Headers added:
+ *   Deprecation       — signals the endpoint is deprecated (RFC 8594)
+ *   Sunset            — ISO 8601 datetime after which the endpoint may be removed
+ *   Warning           — 299 warning with human-readable message (RFC 7234 §5.5)
+ *   Link              — points to the migration guide (rel="deprecation")
+ *   X-API-Version     — echoes back which version was served
+ *   X-API-Deprecated  — machine-readable boolean for clients
+ *   X-API-Sunset      — plain date string for clients that skip the Sunset header
+ */
+export function addDeprecationHeaders(response: NextResponse, version: ApiVersion = 'v1'): NextResponse {
+  const config = VERSION_CONFIGS[version];
+
+  if (!config.deprecated) return response;
+
+  const sunsetDatetime = `${config.sunsetDate}T23:59:59Z`;
+
+  response.headers.set('Deprecation', 'true');
+  response.headers.set('Sunset', sunsetDatetime);
+  response.headers.set(
+    'Warning',
+    `299 - "API ${version} is deprecated and will be removed on ${config.sunsetDate}. Migrate to v2: ${config.migrationGuideUrl}"`
+  );
+  response.headers.set('Link', `<${config.migrationGuideUrl}>; rel="deprecation"`);
+  response.headers.set('X-API-Version', version);
+  response.headers.set('X-API-Deprecated', 'true');
+  response.headers.set('X-API-Sunset', config.sunsetDate);
+
+  return response;
+}
+
+/** Returns the deprecation headers as a plain object (useful in tests). Returns {} for non-deprecated versions. */
+export function getDeprecationHeaderMap(version: ApiVersion = 'v1'): Record<string, string> {
+  const config = VERSION_CONFIGS[version];
+
+  if (!config.deprecated) return {};
+
+  const sunsetDatetime = `${config.sunsetDate}T23:59:59Z`;
+
+  return {
+    Deprecation: 'true',
+    Sunset: sunsetDatetime,
+    Warning: `299 - "API ${version} is deprecated and will be removed on ${config.sunsetDate}. Migrate to v2: ${config.migrationGuideUrl}"`,
+    Link: `<${config.migrationGuideUrl}>; rel="deprecation"`,
+    'X-API-Version': version,
+    'X-API-Deprecated': 'true',
+    'X-API-Sunset': config.sunsetDate,
+  };
+}

--- a/lib/api-versioning/index.ts
+++ b/lib/api-versioning/index.ts
@@ -24,7 +24,7 @@ export function convertV1ResumeToV2(body: V1ResumeInput): V2ResumeInput {
     promptParts.push(`The candidate has ${yearsOfExperience} years of experience.`);
   }
 
-  if (skills) {
+  if (typeof skills === 'string' && skills) {
     const skillList = skills
       .split(',')
       .map((s) => s.trim())
@@ -34,7 +34,7 @@ export function convertV1ResumeToV2(body: V1ResumeInput): V2ResumeInput {
     if (skillList) promptParts.push(`Key skills: ${skillList}.`);
   }
 
-  const trimmedContext = additionalContext?.trim();
+  const trimmedContext = typeof additionalContext === 'string' ? additionalContext.trim() : undefined;
   if (trimmedContext) {
     promptParts.push(trimmedContext);
   }

--- a/lib/api-versioning/index.ts
+++ b/lib/api-versioning/index.ts
@@ -29,11 +29,13 @@ export function convertV1ResumeToV2(body: V1ResumeInput): V2ResumeInput {
       .map((s) => s.trim())
       .filter(Boolean)
       .join(', ');
-    promptParts.push(`Key skills: ${skillList}.`);
+    // Guard against whitespace-only input producing "Key skills: ."
+    if (skillList) promptParts.push(`Key skills: ${skillList}.`);
   }
 
-  if (additionalContext) {
-    promptParts.push(additionalContext.trim());
+  const trimmedContext = additionalContext?.trim();
+  if (trimmedContext) {
+    promptParts.push(trimmedContext);
   }
 
   return {

--- a/lib/api-versioning/index.ts
+++ b/lib/api-versioning/index.ts
@@ -1,0 +1,65 @@
+export { detectVersion, isSupported, isDeprecated } from './version-router';
+export { addDeprecationHeaders, getDeprecationHeaderMap } from './deprecation';
+export type { ApiVersion, VersionConfig, V1ResumeInput, V2ResumeInput, V1DocumentInput, V2DocumentInput } from './types';
+export { VERSION_CONFIGS } from './types';
+
+import type { V1ResumeInput, V2ResumeInput, V1DocumentInput, V2DocumentInput } from './types';
+
+/**
+ * Converts a v1 resume request body to the v2 shape expected by
+ * app/api/generate/resume/route.ts.
+ *
+ * v1 → v2 field mapping:
+ *   personalInfo.name  → name
+ *   personalInfo.email → email
+ *   jobTitle + yearsOfExperience + skills + additionalContext → prompt (constructed)
+ */
+export function convertV1ResumeToV2(body: V1ResumeInput): V2ResumeInput {
+  const { personalInfo, jobTitle, yearsOfExperience, skills, additionalContext } = body;
+
+  const promptParts: string[] = [`Create a professional resume for a ${jobTitle} position.`];
+
+  if (yearsOfExperience !== undefined) {
+    promptParts.push(`The candidate has ${yearsOfExperience} years of experience.`);
+  }
+
+  if (skills) {
+    const skillList = skills
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .join(', ');
+    promptParts.push(`Key skills: ${skillList}.`);
+  }
+
+  if (additionalContext) {
+    promptParts.push(additionalContext.trim());
+  }
+
+  return {
+    name: personalInfo.name,
+    email: personalInfo.email,
+    prompt: promptParts.join(' '),
+  };
+}
+
+/**
+ * Converts a v1 document request body to the v2 shape expected by
+ * app/api/documents/route.ts.
+ *
+ * v1 → v2 field mapping:
+ *   name  → title
+ *   type  → documentType
+ *   data  → content
+ *   tags  → metadata
+ *   parts → sections
+ */
+export function convertV1DocumentToV2(body: V1DocumentInput): V2DocumentInput {
+  return {
+    title: body.name,
+    documentType: body.type,
+    ...(body.data !== undefined && { content: body.data }),
+    ...(body.tags !== undefined && { metadata: body.tags }),
+    ...(body.parts !== undefined && { sections: body.parts }),
+  };
+}

--- a/lib/api-versioning/index.ts
+++ b/lib/api-versioning/index.ts
@@ -17,7 +17,8 @@ import type { V1ResumeInput, V2ResumeInput, V1DocumentInput, V2DocumentInput } f
 export function convertV1ResumeToV2(body: V1ResumeInput): V2ResumeInput {
   const { personalInfo, jobTitle, yearsOfExperience, skills, additionalContext } = body;
 
-  const promptParts: string[] = [`Create a professional resume for a ${jobTitle} position.`];
+  const article = /^[aeiou]/i.test(jobTitle) ? 'an' : 'a';
+  const promptParts: string[] = [`Create a professional resume for ${article} ${jobTitle} position.`];
 
   if (yearsOfExperience !== undefined) {
     promptParts.push(`The candidate has ${yearsOfExperience} years of experience.`);

--- a/lib/api-versioning/types.ts
+++ b/lib/api-versioning/types.ts
@@ -7,7 +7,7 @@ export interface VersionConfig {
   migrationGuideUrl: string;
 }
 
-const SITE_ORIGIN = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ?? '';
+const SITE_ORIGIN = (process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000').replace(/\/$/, '');
 
 export const VERSION_CONFIGS: Record<ApiVersion, VersionConfig> = {
   v1: {

--- a/lib/api-versioning/types.ts
+++ b/lib/api-versioning/types.ts
@@ -7,12 +7,14 @@ export interface VersionConfig {
   migrationGuideUrl: string;
 }
 
+const SITE_ORIGIN = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ?? '';
+
 export const VERSION_CONFIGS: Record<ApiVersion, VersionConfig> = {
   v1: {
     version: 'v1',
     deprecated: true,
     sunsetDate: '2026-12-31',
-    migrationGuideUrl: '/docs/migration-v1-v2',
+    migrationGuideUrl: `${SITE_ORIGIN}/docs/migration-v1-v2`,
   },
   v2: {
     version: 'v2',

--- a/lib/api-versioning/types.ts
+++ b/lib/api-versioning/types.ts
@@ -1,0 +1,61 @@
+export type ApiVersion = 'v1' | 'v2';
+
+export interface VersionConfig {
+  version: ApiVersion;
+  deprecated: boolean;
+  sunsetDate: string; // ISO 8601 date string e.g. "2026-12-31"
+  migrationGuideUrl: string;
+}
+
+export const VERSION_CONFIGS: Record<ApiVersion, VersionConfig> = {
+  v1: {
+    version: 'v1',
+    deprecated: true,
+    sunsetDate: '2026-12-31',
+    migrationGuideUrl: '/docs/migration-v1-v2',
+  },
+  v2: {
+    version: 'v2',
+    deprecated: false,
+    sunsetDate: '',
+    migrationGuideUrl: '',
+  },
+};
+
+// V1 legacy input shapes (camelCase, flat personalInfo)
+export interface V1ResumeInput {
+  personalInfo: {
+    name: string;
+    email: string;
+    phone?: string;
+  };
+  jobTitle: string;
+  yearsOfExperience?: number;
+  skills?: string; // comma-separated string in v1
+  additionalContext?: string;
+}
+
+// V2 current input shapes
+export interface V2ResumeInput {
+  name: string;
+  email: string;
+  prompt: string;
+}
+
+// V1 legacy document input
+export interface V1DocumentInput {
+  name: string;          // was "title" in v2
+  type: string;          // was "documentType" in v2
+  data?: Record<string, unknown>;    // was "content" in v2
+  tags?: Record<string, unknown>;    // was "metadata" in v2
+  parts?: unknown[];     // was "sections" in v2
+}
+
+// V2 current document input
+export interface V2DocumentInput {
+  title: string;
+  documentType: string;
+  content?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  sections?: unknown[];
+}

--- a/lib/api-versioning/version-router.ts
+++ b/lib/api-versioning/version-router.ts
@@ -1,0 +1,56 @@
+import type { NextRequest } from 'next/server';
+import { type ApiVersion, VERSION_CONFIGS } from './types';
+
+const SUPPORTED_VERSIONS: ApiVersion[] = ['v1', 'v2'];
+
+/**
+ * Detects the requested API version from a NextRequest.
+ *
+ * Priority order:
+ *   1. URL path prefix  — /api/v1/... or /api/v2/...
+ *   2. Request header   — API-Version: 1  (or "v1")
+ *   3. Query parameter  — ?api_version=1  (or "v1")
+ *   4. Default          — v2 (current stable)
+ */
+export function detectVersion(request: NextRequest): ApiVersion {
+  const { pathname, searchParams } = request.nextUrl;
+
+  // 1. URL path — most explicit, highest priority
+  const pathMatch = pathname.match(/^\/api\/(v\d+)\//);
+  if (pathMatch) {
+    const candidate = pathMatch[1] as ApiVersion;
+    if (isSupported(candidate)) return candidate;
+  }
+
+  // 2. Header — API-Version: 1 or API-Version: v1
+  const headerValue = request.headers.get('API-Version') ?? request.headers.get('X-API-Version');
+  if (headerValue) {
+    const candidate = normalise(headerValue);
+    if (isSupported(candidate)) return candidate;
+  }
+
+  // 3. Query param — ?api_version=1 or ?api_version=v1
+  const queryValue = searchParams.get('api_version');
+  if (queryValue) {
+    const candidate = normalise(queryValue);
+    if (isSupported(candidate)) return candidate;
+  }
+
+  return 'v2';
+}
+
+/** Returns true when the version is both known and configured. */
+export function isSupported(version: string): version is ApiVersion {
+  return SUPPORTED_VERSIONS.includes(version as ApiVersion) && version in VERSION_CONFIGS;
+}
+
+/** Returns true when the version is marked deprecated in VERSION_CONFIGS. */
+export function isDeprecated(version: ApiVersion): boolean {
+  return VERSION_CONFIGS[version].deprecated;
+}
+
+/** Normalises bare numbers ("1", "2") to the "v1" / "v2" form. */
+function normalise(raw: string): string {
+  const trimmed = raw.trim().toLowerCase();
+  return trimmed.startsWith('v') ? trimmed : `v${trimmed}`;
+}

--- a/lib/api-versioning/version-router.ts
+++ b/lib/api-versioning/version-router.ts
@@ -1,8 +1,6 @@
 import type { NextRequest } from 'next/server';
 import { type ApiVersion, VERSION_CONFIGS } from './types';
 
-const SUPPORTED_VERSIONS: ApiVersion[] = ['v1', 'v2'];
-
 /**
  * Detects the requested API version from a NextRequest.
  *
@@ -40,9 +38,9 @@ export function detectVersion(request: NextRequest): ApiVersion {
   return 'v2';
 }
 
-/** Returns true when the version is both known and configured. */
+/** Returns true when the version is known — derived from VERSION_CONFIGS keys, single source of truth. */
 export function isSupported(version: string): version is ApiVersion {
-  return SUPPORTED_VERSIONS.includes(version as ApiVersion) && version in VERSION_CONFIGS;
+  return version in VERSION_CONFIGS;
 }
 
 /** Returns true when the version is marked deprecated in VERSION_CONFIGS. */

--- a/lib/api-versioning/version-router.ts
+++ b/lib/api-versioning/version-router.ts
@@ -16,7 +16,8 @@ export function detectVersion(request: NextRequest): ApiVersion {
   const { pathname, searchParams } = request.nextUrl;
 
   // 1. URL path — most explicit, highest priority
-  const pathMatch = pathname.match(/^\/api\/(v\d+)\//);
+  // (?:\/|$) matches both /api/v1/health and /api/v1 (no trailing slash)
+  const pathMatch = pathname.match(/^\/api\/(v\d+)(?:\/|$)/);
   if (pathMatch) {
     const candidate = pathMatch[1] as ApiVersion;
     if (isSupported(candidate)) return candidate;

--- a/middleware.ts
+++ b/middleware.ts
@@ -32,8 +32,10 @@ setInterval(() => {
 }, 60_000);
 
 function rlKey(p: string): RLKey {
-  if (p.startsWith('/api/auth/'))     return 'AUTH';
-  if (p.startsWith('/api/generate/')) return 'GENERATE';
+  // Strip version prefix so /api/v1/generate/... and /api/generate/... share the same bucket
+  const norm = p.replace(/^\/api\/v\d+(?:\/|$)/, '/api/');
+  if (norm.startsWith('/api/auth/'))     return 'AUTH';
+  if (norm.startsWith('/api/generate/')) return 'GENERATE';
   return 'API';
 }
 
@@ -106,6 +108,11 @@ export function middleware(req: NextRequest) {
     r.headers.set('X-RateLimit-Limit', String(rl.limit));
     r.headers.set('X-RateLimit-Remaining', String(rl.remaining));
     r.headers.set('X-RateLimit-Reset', String(Math.ceil(rl.reset / 1000)));
+
+    // Stamp which API version was routed so clients always know what they got
+    const versionMatch = pathname.match(/^\/api\/(v\d+)(?:\/|$)/);
+    r.headers.set('X-API-Version', versionMatch ? versionMatch[1] : 'v2');
+
     return r;
   }
 


### PR DESCRIPTION
Fixes #539

  ## Description
  Implements API versioning and backward compatibility strategy. Adds
   v1 and v2
  versioned routes, RFC 8594 deprecation headers on all v1 responses,
   param
  conversion from legacy v1 shapes to v2, and comprehensive tests for
   both versions.

  ## Type of Change
  - [x] New feature

  ## Changes Made
  - lib/api-versioning/ — version detection, deprecation headers,
  param converters
  - app/api/v1/ — backward-compatible routes (health, documents,
  generate/resume)
  - app/api/v2/ — canonical versioned aliases of current routes
  - middleware.ts — versioned rate-limit buckets + X-API-Version
  stamp on all responses
  - __tests__/api-versioning/ — 50 tests covering both versions
  - docs/api-versioning.md + docs/migration-v1-v2.md — reference +
  migration guide

  ## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have tested my changes in development mode
  - [x] I have written related tests
  - [x] This is an issue assigned to me

  GSSoC #539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallel API versioning: v1 (deprecated) and v2 (stable). v1 responses include RFC-style deprecation headers and X-API-Version; middleware sets X-API-Version and rate-limit buckets are shared between versioned/unversioned routes.
  * v1 endpoints proxy to v2, auto-convert legacy v1 payloads to v2 shapes, validate legacy required fields, and preserve v2 responses/statuses.
  * Canonical v2 routes added for health, resume, and documents.

* **Documentation**
  * Added API versioning guide and v1→v2 migration guide (sunset date, header handling, field mappings, examples).

* **Tests**
  * Added tests for version detection precedence, conversion helpers, and deprecation header behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->