### PR TITLE
feat: add inline experience bullet AI Enhance and dev auth mock

### DIFF
--- a/components/resume-templates/EditableResume.tsx
+++ b/components/resume-templates/EditableResume.tsx
@@ -42,6 +42,9 @@ export default function EditableResume({ data, onUpdate }: EditableResumeProps) 
     const requestKey = `${experienceIndex}-${pointIndex}`;
     setEnhancingPoint(requestKey);
 
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), 15000);
+
     try {
       const experience = data.experience[experienceIndex];
       const response = await fetch('/api/resume/enhance-bullet', {
@@ -57,6 +60,7 @@ export default function EditableResume({ data, onUpdate }: EditableResumeProps) 
             data.skills.tools,
           ].filter(Boolean).join(', '),
         }),
+        signal: controller.signal,
       });
 
       const result = await response.json();
@@ -64,18 +68,29 @@ export default function EditableResume({ data, onUpdate }: EditableResumeProps) 
         throw new Error(result.error || 'Failed to enhance bullet point');
       }
 
-      const latestData = latestDataRef.current;
-      const newExp = [...latestData.experience];
-      newExp[experienceIndex] = {
-        ...newExp[experienceIndex],
-        points: [...newExp[experienceIndex].points],
-      };
-      newExp[experienceIndex].points[pointIndex] = result.enhancedBullet;
-      onUpdate({ ...latestData, experience: newExp });
-      toast.success('Bullet point enhanced');
+      const enhancedBullet = typeof result?.enhancedBullet === 'string' ? result.enhancedBullet.trim() : '';
+
+      if (enhancedBullet) {
+        const latestData = latestDataRef.current;
+        const newExp = [...latestData.experience];
+        newExp[experienceIndex] = {
+          ...newExp[experienceIndex],
+          points: [...newExp[experienceIndex].points],
+        };
+        newExp[experienceIndex].points[pointIndex] = enhancedBullet;
+        onUpdate({ ...latestData, experience: newExp });
+        toast.success('Bullet point enhanced');
+      } else {
+        throw new Error('AI did not return a valid enhanced bullet');
+      }
     } catch (error: any) {
-      toast.error(error?.message || 'Failed to enhance bullet point');
+      if (error?.name === 'AbortError') {
+        toast.error('Enhancement timed out (15s limit reached). Please try again.');
+      } else {
+        toast.error(error?.message || 'Failed to enhance bullet point');
+      }
     } finally {
+      window.clearTimeout(timeoutId);
       setEnhancingPoint(null);
     }
   };

--- a/components/resume/resume-preview.tsx
+++ b/components/resume/resume-preview.tsx
@@ -167,19 +167,23 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
     onChange,
     className,
     multiline,
+    disabled,
   }: {
     value: string;
     onChange: (val: string) => void;
     className?: string;
     multiline?: boolean;
+    disabled?: boolean;
   }) => {
     if (multiline) {
       return (
         <textarea
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
           className={cn(
             "w-full resize-none bg-transparent border-none p-0 m-0 font-sans text-gray-900 focus:outline-none focus:ring-0",
+            disabled && "text-gray-400 cursor-not-allowed",
             className
           )}
           rows={3}
@@ -191,8 +195,10 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
         className={cn(
           "bg-transparent border-none p-0 m-0 font-sans text-gray-900 focus:outline-none focus:ring-0 w-full",
+          disabled && "text-gray-400 cursor-not-allowed",
           className
         )}
       />
@@ -213,14 +219,17 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
     const [enhancingIdx, setEnhancingIdx] = useState<number | null>(null);
 
     function updateItem(idx: number, val: string) {
+      if (enhancingIdx !== null) return;
       const newItems = [...items];
       newItems[idx] = val;
       onChange(newItems);
     }
     function addItem() {
+      if (enhancingIdx !== null) return;
       onChange([...items, ""]);
     }
     function removeItem(idx: number) {
+      if (enhancingIdx !== null) return;
       const newItems = items.filter((_, i) => i !== idx);
       onChange(newItems);
     }
@@ -237,6 +246,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
         return;
       }
 
+      const originalBullet = items[idx];
       setEnhancingIdx(idx);
       try {
         const response = await fetch("/api/resume/enhance-bullet", {
@@ -259,13 +269,15 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
 
         const data = await response.json();
         if (data.enhancedBullet) {
-          const newItems = [...items];
-          newItems[idx] = data.enhancedBullet;
-          onChange(newItems);
-          toast({
-            title: "Enhancement successful",
-            description: "Your bullet point has been enhanced with action-oriented metrics!",
-          });
+          if (items[idx] === originalBullet) {
+            const newItems = [...items];
+            newItems[idx] = data.enhancedBullet;
+            onChange(newItems);
+            toast({
+              title: "Enhancement successful",
+              description: "Your bullet point has been enhanced with action-oriented metrics!",
+            });
+          }
         } else {
           throw new Error("AI did not return an enhanced bullet");
         }
@@ -287,6 +299,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
             <EditableText
               value={item}
               onChange={(val) => updateItem(i, val)}
+              disabled={enhancingIdx !== null}
               className="flex-grow"
             />
             {aiContext && (
@@ -298,7 +311,8 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                   "flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-semibold shadow-sm transition-all duration-200 shrink-0",
                   enhancingIdx === i
                     ? "bg-purple-100 text-purple-700 animate-pulse border border-purple-200 cursor-not-allowed"
-                    : "bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-700 hover:to-indigo-700 text-white hover:scale-105 active:scale-95 hover:shadow-md hover:shadow-indigo-500/20"
+                    : "bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-700 hover:to-indigo-700 text-white hover:scale-105 active:scale-95 hover:shadow-md hover:shadow-indigo-500/20",
+                  enhancingIdx !== null && enhancingIdx !== i && "opacity-50 cursor-not-allowed"
                 )}
                 title="AI Enhance bullet point with action-oriented metrics"
               >
@@ -318,7 +332,11 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
             <button
               type="button"
               onClick={() => removeItem(i)}
-              className="text-red-500 font-bold hover:text-red-700 px-2 shrink-0"
+              disabled={enhancingIdx !== null}
+              className={cn(
+                "text-red-500 font-bold hover:text-red-700 px-2 shrink-0",
+                enhancingIdx !== null && "opacity-50 cursor-not-allowed"
+              )}
             >
               &times;
             </button>
@@ -327,7 +345,11 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
         <button
           type="button"
           onClick={addItem}
-          className="text-blue-600 underline text-sm mt-1 hover:text-blue-800"
+          disabled={enhancingIdx !== null}
+          className={cn(
+            "text-blue-600 underline text-sm mt-1 hover:text-blue-800",
+            enhancingIdx !== null && "opacity-50 cursor-not-allowed"
+          )}
         >
           + Add
         </button>

--- a/components/resume/resume-preview.tsx
+++ b/components/resume/resume-preview.tsx
@@ -250,6 +250,10 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
 
       const originalBullet = items[idx];
       setEnhancingIdx(idx);
+
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), 15000);
+
       try {
         const response = await fetch("/api/resume/enhance-bullet", {
           method: "POST",
@@ -262,6 +266,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
             company: aiContext?.company,
             skills: aiContext?.skills,
           }),
+          signal: controller.signal,
         });
 
         if (!response.ok) {
@@ -270,10 +275,12 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
         }
 
         const data = await response.json();
-        if (data.enhancedBullet) {
+        const enhancedBullet = typeof data?.enhancedBullet === "string" ? data.enhancedBullet.trim() : "";
+
+        if (enhancedBullet) {
           if (itemsRef.current[idx] === originalBullet) {
             const newItems = [...itemsRef.current];
-            newItems[idx] = data.enhancedBullet;
+            newItems[idx] = enhancedBullet;
             onChange(newItems);
             toast({
               title: "Enhancement successful",
@@ -287,15 +294,24 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
             });
           }
         } else {
-          throw new Error("AI did not return an enhanced bullet");
+          throw new Error("AI did not return a valid enhanced bullet");
         }
       } catch (error: any) {
-        toast({
-          title: "Enhancement failed",
-          description: error.message || "Something went wrong while enhancing the bullet.",
-          variant: "destructive",
-        });
+        if (error?.name === "AbortError") {
+          toast({
+            title: "Enhancement timed out",
+            description: "The request took too long to respond (15s limit reached). Please try again.",
+            variant: "destructive",
+          });
+        } else {
+          toast({
+            title: "Enhancement failed",
+            description: error.message || "Something went wrong while enhancing the bullet.",
+            variant: "destructive",
+          });
+        }
       } finally {
+        window.clearTimeout(timeoutId);
         setEnhancingIdx(null);
       }
     }

--- a/components/resume/resume-preview.tsx
+++ b/components/resume/resume-preview.tsx
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef, useImperativeHandle, useRef, useEffect } from "react";
+import React, { useState, forwardRef, useImperativeHandle, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Linkedin, Github, Globe, Mail, Phone, MapPin, Download, Edit, Check, X, Sparkles, FileText, Briefcase, GraduationCap, Code, Award, Link as LinkIcon, Loader2 } from "lucide-react";
@@ -218,10 +218,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
   }) => {
     const [enhancingIdx, setEnhancingIdx] = useState<number | null>(null);
     const itemsRef = useRef(items);
-
-    useEffect(() => {
-      itemsRef.current = items;
-    }, [items]);
+    itemsRef.current = items;
 
     function updateItem(idx: number, val: string) {
       if (enhancingIdx !== null) return;

--- a/components/resume/resume-preview.tsx
+++ b/components/resume/resume-preview.tsx
@@ -151,6 +151,17 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
     });
   }
 
+  const getSkillsString = () => {
+    const s = editableResume.skills || safeResume.skills || {};
+    const allSkills = [
+      ...(s.technical || []),
+      ...(s.programming || []),
+      ...(s.tools || []),
+      ...(s.soft || [])
+    ];
+    return allSkills.filter(Boolean).join(", ");
+  };
+
   const EditableText = ({
     value,
     onChange,
@@ -192,11 +203,15 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
     items,
     onChange,
     className,
+    aiContext,
   }: {
     items: string[];
     onChange: (newItems: string[]) => void;
     className?: string;
+    aiContext?: { title?: string; company?: string; skills?: string; };
   }) => {
+    const [enhancingIdx, setEnhancingIdx] = useState<number | null>(null);
+
     function updateItem(idx: number, val: string) {
       const newItems = [...items];
       newItems[idx] = val;
@@ -209,19 +224,101 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
       const newItems = items.filter((_, i) => i !== idx);
       onChange(newItems);
     }
+
+    async function handleEnhance(idx: number) {
+      if (enhancingIdx !== null) return;
+      const bulletText = items[idx];
+      if (!bulletText || !bulletText.trim()) {
+        toast({
+          title: "Empty bullet point",
+          description: "Please write some text before enhancing it.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      setEnhancingIdx(idx);
+      try {
+        const response = await fetch("/api/resume/enhance-bullet", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            bullet: bulletText,
+            title: aiContext?.title,
+            company: aiContext?.company,
+            skills: aiContext?.skills,
+          }),
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(errorData.error || "Failed to enhance bullet point");
+        }
+
+        const data = await response.json();
+        if (data.enhancedBullet) {
+          const newItems = [...items];
+          newItems[idx] = data.enhancedBullet;
+          onChange(newItems);
+          toast({
+            title: "Enhancement successful",
+            description: "Your bullet point has been enhanced with action-oriented metrics!",
+          });
+        } else {
+          throw new Error("AI did not return an enhanced bullet");
+        }
+      } catch (error: any) {
+        toast({
+          title: "Enhancement failed",
+          description: error.message || "Something went wrong while enhancing the bullet.",
+          variant: "destructive",
+        });
+      } finally {
+        setEnhancingIdx(null);
+      }
+    }
+
     return (
       <div className={className}>
         {items.map((item, i) => (
-          <div key={i} className="flex gap-2 items-center mb-1">
+          <div key={i} className="flex gap-2 items-center mb-1 w-full">
             <EditableText
               value={item}
               onChange={(val) => updateItem(i, val)}
               className="flex-grow"
             />
+            {aiContext && (
+              <button
+                type="button"
+                onClick={() => handleEnhance(i)}
+                disabled={enhancingIdx !== null}
+                className={cn(
+                  "flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-semibold shadow-sm transition-all duration-200 shrink-0",
+                  enhancingIdx === i
+                    ? "bg-purple-100 text-purple-700 animate-pulse border border-purple-200 cursor-not-allowed"
+                    : "bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-700 hover:to-indigo-700 text-white hover:scale-105 active:scale-95 hover:shadow-md hover:shadow-indigo-500/20"
+                )}
+                title="AI Enhance bullet point with action-oriented metrics"
+              >
+                {enhancingIdx === i ? (
+                  <>
+                    <Loader2 className="h-3 w-3 animate-spin text-purple-700" />
+                    <span>Enhancing...</span>
+                  </>
+                ) : (
+                  <>
+                    <Sparkles className="h-3 w-3 text-white" />
+                    <span>AI Enhance</span>
+                  </>
+                )}
+              </button>
+            )}
             <button
               type="button"
               onClick={() => removeItem(i)}
-              className="text-red-500 font-bold hover:text-red-700 px-2"
+              className="text-red-500 font-bold hover:text-red-700 px-2 shrink-0"
             >
               &times;
             </button>
@@ -801,6 +898,11 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                           onChange={(newDesc) =>
                             updateField(["experience", i.toString(), "description"], newDesc)
                           }
+                          aiContext={{
+                            title: exp.title,
+                            company: exp.company,
+                            skills: getSkillsString(),
+                          }}
                         />
                       ) : (
                         <ul className="list-disc text-sm text-gray-700 pl-5 mt-2 space-y-1 print:text-xs" style={{ color: '#374151' }}>
@@ -1528,7 +1630,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                       {isEditing ? (
                         <EditableText
                           value={exp.title || ""}
-                          onChange={(val) => updateField(["experience", idx, "title"], val)}
+                          onChange={(val) => updateField(["experience", idx.toString(), "title"], val)}
                           className="font-semibold text-gray-800 print:text-sm"
                         />
                       ) : (
@@ -1537,7 +1639,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                       {isEditing ? (
                         <EditableText
                           value={exp.company || ""}
-                          onChange={(val) => updateField(["experience", idx, "company"], val)}
+                          onChange={(val) => updateField(["experience", idx.toString(), "company"], val)}
                           className="text-sm print:text-xs text-gray-700"
                         />
                       ) : (
@@ -1548,7 +1650,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                       {isEditing ? (
                         <EditableText
                           value={exp.date || ""}
-                          onChange={(val) => updateField(["experience", idx, "date"], val)}
+                          onChange={(val) => updateField(["experience", idx.toString(), "date"], val)}
                           className="text-sm text-gray-600 print:text-xs"
                         />
                       ) : (
@@ -1560,7 +1662,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                           {isEditing ? (
                             <EditableText
                               value={exp.location || ""}
-                              onChange={(val) => updateField(["experience", idx, "location"], val)}
+                              onChange={(val) => updateField(["experience", idx.toString(), "location"], val)}
                               className="text-xs text-gray-500 print:text-xs"
                             />
                           ) : (
@@ -1575,8 +1677,13 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                       {isEditing ? (
                         <EditableList
                           items={exp.description}
-                          onChange={(newDesc) => updateField(["experience", idx, "description"], newDesc)}
+                          onChange={(newDesc) => updateField(["experience", idx.toString(), "description"], newDesc)}
                           className="list-disc list-inside space-y-1 text-sm text-gray-700 print:text-xs"
+                          aiContext={{
+                            title: exp.title,
+                            company: exp.company,
+                            skills: getSkillsString(),
+                          }}
                         />
                       ) : (
                         exp.description.map((desc: string, i: number) => (
@@ -1605,7 +1712,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                       {isEditing ? (
                         <EditableText
                           value={edu.degree || ""}
-                          onChange={(val) => updateField(["education", idx, "degree"], val)}
+                          onChange={(val) => updateField(["education", idx.toString(), "degree"], val)}
                           className="font-semibold text-gray-800 print:text-sm"
                         />
                       ) : (
@@ -1614,7 +1721,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                       {isEditing ? (
                         <EditableText
                           value={edu.institution || ""}
-                          onChange={(val) => updateField(["education", idx, "institution"], val)}
+                          onChange={(val) => updateField(["education", idx.toString(), "institution"], val)}
                           className="text-sm print:text-xs text-gray-700"
                         />
                       ) : (
@@ -1625,7 +1732,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                       {isEditing ? (
                         <EditableText
                           value={edu.date || ""}
-                          onChange={(val) => updateField(["education", idx, "date"], val)}
+                          onChange={(val) => updateField(["education", idx.toString(), "date"], val)}
                           className="text-sm text-gray-600 print:text-xs"
                         />
                       ) : (
@@ -1637,7 +1744,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                           {isEditing ? (
                             <EditableText
                               value={edu.location || ""}
-                              onChange={(val) => updateField(["education", idx, "location"], val)}
+                              onChange={(val) => updateField(["education", idx.toString(), "location"], val)}
                               className="text-xs text-gray-500 print:text-xs"
                             />
                           ) : (
@@ -2441,8 +2548,8 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                   <div className="flex-1">
                     {isEditing ? (
                       <>
-                        <EditableText value={edu.institution || ""} onChange={v => updateField(["education", i, "institution"], v)} className="font-bold" />
-                        <EditableText value={edu.location || ""} onChange={v => updateField(["education", i, "location"], v)} className="ml-2 text-gray-600" />
+                        <EditableText value={edu.institution || ""} onChange={v => updateField(["education", i.toString(), "institution"], v)} className="font-bold" />
+                        <EditableText value={edu.location || ""} onChange={v => updateField(["education", i.toString(), "location"], v)} className="ml-2 text-gray-600" />
                       </>
                     ) : (
                       <>
@@ -2453,7 +2560,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                   </div>
                   <div>
                     {isEditing ? (
-                      <EditableText value={edu.date || ""} onChange={v => updateField(["education", i, "date"], v)} className="font-semibold" />
+                      <EditableText value={edu.date || ""} onChange={v => updateField(["education", i.toString(), "date"], v)} className="font-semibold" />
                     ) : (
                       <span className="font-semibold">{edu.date}</span>
                     )}
@@ -2461,7 +2568,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                 </div>
                 <div className="text-xs italic">
                   {isEditing ? (
-                    <EditableText value={edu.degree || ""} onChange={v => updateField(["education", i, "degree"], v)} />
+                    <EditableText value={edu.degree || ""} onChange={v => updateField(["education", i.toString(), "degree"], v)} />
                   ) : (
                     edu.degree
                   )}
@@ -2469,7 +2576,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                 {(isEditing || edu.gpa) && (
                   <div className="text-xs">
                     {isEditing ? (
-                      <>CGPA: <EditableText value={edu.gpa || ""} onChange={v => updateField(["education", i, "gpa"], v)} className="inline-block w-20" /></>
+                      <>CGPA: <EditableText value={edu.gpa || ""} onChange={v => updateField(["education", i.toString(), "gpa"], v)} className="inline-block w-20" /></>
                     ) : (
                       <>CGPA: {edu.gpa}</>
                     )}
@@ -2490,9 +2597,9 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                   <div className="flex-1">
                     {isEditing ? (
                       <>
-                        <EditableText value={exp.title || ""} onChange={v => updateField(["experience", i, "title"], v)} className="font-bold" />
+                        <EditableText value={exp.title || ""} onChange={v => updateField(["experience", i.toString(), "title"], v)} className="font-bold" />
                         <span className="mx-1">|</span>
-                        <EditableText value={exp.company || ""} onChange={v => updateField(["experience", i, "company"], v)} className="italic" />
+                        <EditableText value={exp.company || ""} onChange={v => updateField(["experience", i.toString(), "company"], v)} className="italic" />
                       </>
                     ) : (
                       <>
@@ -2504,7 +2611,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                   </div>
                   <div>
                     {isEditing ? (
-                      <EditableText value={exp.date || ""} onChange={v => updateField(["experience", i, "date"], v)} className="font-semibold" />
+                      <EditableText value={exp.date || ""} onChange={v => updateField(["experience", i.toString(), "date"], v)} className="font-semibold" />
                     ) : (
                       <span className="font-semibold">{exp.date}</span>
                     )}
@@ -2514,7 +2621,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                   {exp.description?.map((desc, j) => (
                     <li key={j}>
                       {isEditing ? (
-                        <EditableText value={desc} onChange={v => updateField(["experience", i, "description", j], v)} multiline />
+                        <EditableText value={desc} onChange={v => updateField(["experience", i.toString(), "description", j.toString()], v)} multiline />
                       ) : (
                         desc
                       )}
@@ -2535,11 +2642,11 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                 <div className="text-xs">
                   {isEditing ? (
                     <>
-                      <EditableText value={proj.name || ""} onChange={v => updateField(["projects", i, "name"], v)} className="font-bold" />
+                      <EditableText value={proj.name || ""} onChange={v => updateField(["projects", i.toString(), "name"], v)} className="font-bold" />
                       {(isEditing || proj.link) && (
                         <>
                           <span className="mx-1">|</span>
-                          <EditableText value={proj.link || ""} onChange={v => updateField(["projects", i, "link"], v)} className="underline" />
+                          <EditableText value={proj.link || ""} onChange={v => updateField(["projects", i.toString(), "link"], v)} className="underline" />
                         </>
                       )}
                     </>
@@ -2557,7 +2664,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                 </div>
                 <div className="text-xs">
                   {isEditing ? (
-                    <EditableText value={proj.description || ""} onChange={v => updateField(["projects", i, "description"], v)} multiline />
+                    <EditableText value={proj.description || ""} onChange={v => updateField(["projects", i.toString(), "description"], v)} multiline />
                   ) : (
                     proj.description
                   )}
@@ -2565,7 +2672,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                 {(isEditing || proj.technologies) && (
                   <div className="text-xs italic">
                     {isEditing ? (
-                      <>Tech Stack: <EditableText value={proj.technologies?.join(", ") || ""} onChange={v => updateField(["projects", i, "technologies"], v.split(",").map(s => s.trim()))} /></>
+                      <>Tech Stack: <EditableText value={proj.technologies?.join(", ") || ""} onChange={v => updateField(["projects", i.toString(), "technologies"], v.split(",").map(s => s.trim()))} /></>
                     ) : (
                       <>Tech Stack: {proj.technologies?.join(", ")}</>
                     )}
@@ -2622,7 +2729,7 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
                 <li key={i} className={isEditing ? "border border-dashed border-blue-300 p-1 rounded hover:bg-blue-50" : ""}>
                   {isEditing ? (
                     <>
-                      <EditableText value={cert.name || ""} onChange={v => updateField(["certifications", i, "name"], v)} /> - <EditableText value={cert.issuer || ""} onChange={v => updateField(["certifications", i, "issuer"], v)} />
+                      <EditableText value={cert.name || ""} onChange={v => updateField(["certifications", i.toString(), "name"], v)} /> - <EditableText value={cert.issuer || ""} onChange={v => updateField(["certifications", i.toString(), "issuer"], v)} />
                     </>
                   ) : (
                     <>{cert.name} - {cert.issuer}</>

--- a/components/resume/resume-preview.tsx
+++ b/components/resume/resume-preview.tsx
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef, useImperativeHandle } from "react";
+import React, { useState, forwardRef, useImperativeHandle, useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Linkedin, Github, Globe, Mail, Phone, MapPin, Download, Edit, Check, X, Sparkles, FileText, Briefcase, GraduationCap, Code, Award, Link as LinkIcon, Loader2 } from "lucide-react";
@@ -217,6 +217,11 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
     aiContext?: { title?: string; company?: string; skills?: string; };
   }) => {
     const [enhancingIdx, setEnhancingIdx] = useState<number | null>(null);
+    const itemsRef = useRef(items);
+
+    useEffect(() => {
+      itemsRef.current = items;
+    }, [items]);
 
     function updateItem(idx: number, val: string) {
       if (enhancingIdx !== null) return;
@@ -269,13 +274,19 @@ export const ResumePreview = forwardRef<ResumePreviewRef, ResumePreviewProps>(
 
         const data = await response.json();
         if (data.enhancedBullet) {
-          if (items[idx] === originalBullet) {
-            const newItems = [...items];
+          if (itemsRef.current[idx] === originalBullet) {
+            const newItems = [...itemsRef.current];
             newItems[idx] = data.enhancedBullet;
             onChange(newItems);
             toast({
               title: "Enhancement successful",
               description: "Your bullet point has been enhanced with action-oriented metrics!",
+            });
+          } else {
+            toast({
+              title: "Bullet point was edited",
+              description: "The bullet was modified while enhancing. Enhancement result was discarded.",
+              variant: "destructive",
             });
           }
         } else {

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -12,6 +12,9 @@ if (!supabaseUrl || !supabaseAnonKey) {
 
 const isPlaceholder = supabaseUrl.includes("your-project-id") || supabaseUrl.includes("placeholder");
 
+// Global mock auth listeners shared across mock client instances
+let mockAuthListeners: Array<(event: string, session: any) => void> = [];
+
 // Export the Supabase client
 export const createClient = () => {
   if (isPlaceholder) {
@@ -33,8 +36,6 @@ export const createClient = () => {
       expires_at: Math.floor(Date.now() / 1000) + 3600,
     };
 
-    let authListeners: Array<(event: string, session: any) => void> = [];
-
     const getStoredSession = () => {
       if (typeof window === 'undefined') return null;
       try {
@@ -55,22 +56,28 @@ export const createClient = () => {
           const session = getStoredSession();
           return { data: { user: session?.user ?? null }, error: null };
         },
-        signInWithPassword: async ({ email }: { email: string }) => {
+        signInWithPassword: async ({ email, password }: { email: string; password?: string }) => {
+          if (!password || password.length < 6) {
+            return { data: null, error: { message: 'Password must be at least 6 characters' } } as any;
+          }
           const userObj = { ...mockUser, email: email || 'developer@example.com' };
           const sessionObj = { ...mockSession, user: userObj };
           if (typeof window !== 'undefined') {
             localStorage.setItem('sb-mock-session', JSON.stringify(sessionObj));
           }
-          authListeners.forEach(cb => cb('SIGNED_IN', sessionObj));
+          mockAuthListeners.forEach(cb => cb('SIGNED_IN', sessionObj));
           return { data: { user: userObj, session: sessionObj }, error: null };
         },
-        signUp: async ({ email }: { email: string }) => {
+        signUp: async ({ email, password }: { email: string; password?: string }) => {
+          if (!password || password.length < 6) {
+            return { data: null, error: { message: 'Password must be at least 6 characters' } } as any;
+          }
           const userObj = { ...mockUser, email: email || 'developer@example.com' };
           const sessionObj = { ...mockSession, user: userObj };
           if (typeof window !== 'undefined') {
             localStorage.setItem('sb-mock-session', JSON.stringify(sessionObj));
           }
-          authListeners.forEach(cb => cb('SIGNED_IN', sessionObj));
+          mockAuthListeners.forEach(cb => cb('SIGNED_IN', sessionObj));
           return { data: { user: userObj, session: sessionObj }, error: null };
         },
         signInWithOAuth: async ({ provider }: { provider: string }) => {
@@ -79,7 +86,7 @@ export const createClient = () => {
           if (typeof window !== 'undefined') {
             localStorage.setItem('sb-mock-session', JSON.stringify(sessionObj));
           }
-          authListeners.forEach(cb => cb('SIGNED_IN', sessionObj));
+          mockAuthListeners.forEach(cb => cb('SIGNED_IN', sessionObj));
           // Redirect home to simulate complete OAuth flow
           if (typeof window !== 'undefined') {
             window.location.href = '/';
@@ -90,11 +97,11 @@ export const createClient = () => {
           if (typeof window !== 'undefined') {
             localStorage.removeItem('sb-mock-session');
           }
-          authListeners.forEach(cb => cb('SIGNED_OUT', null));
+          mockAuthListeners.forEach(cb => cb('SIGNED_OUT', null));
           return { error: null };
         },
         onAuthStateChange: (callback: any) => {
-          authListeners.push(callback);
+          mockAuthListeners.push(callback);
           const session = getStoredSession();
           // Notify immediate session state on subscription
           setTimeout(() => {
@@ -104,7 +111,7 @@ export const createClient = () => {
             data: {
               subscription: {
                 unsubscribe: () => {
-                  authListeners = authListeners.filter(cb => cb !== callback);
+                  mockAuthListeners = mockAuthListeners.filter(cb => cb !== callback);
                 }
               }
             }

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -10,7 +10,125 @@ if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing required Supabase environment variables. Please check NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your environment configuration.');
 }
 
+const isPlaceholder = supabaseUrl.includes("your-project-id") || supabaseUrl.includes("placeholder");
+
 // Export the Supabase client
 export const createClient = () => {
+  if (isPlaceholder) {
+    const mockUser = {
+      id: 'dev-user-id',
+      email: 'developer@example.com',
+      user_metadata: { name: 'Local Developer' },
+      app_metadata: {},
+      aud: 'authenticated',
+      created_at: new Date().toISOString(),
+    };
+
+    const mockSession = {
+      access_token: 'mock-token',
+      token_type: 'bearer',
+      expires_in: 3600,
+      refresh_token: 'mock-refresh',
+      user: mockUser,
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    let authListeners: Array<(event: string, session: any) => void> = [];
+
+    const getStoredSession = () => {
+      if (typeof window === 'undefined') return null;
+      try {
+        const stored = localStorage.getItem('sb-mock-session');
+        return stored ? JSON.parse(stored) : null;
+      } catch {
+        return null;
+      }
+    };
+
+    return {
+      auth: {
+        getSession: async () => {
+          const session = getStoredSession();
+          return { data: { session }, error: null };
+        },
+        getUser: async () => {
+          const session = getStoredSession();
+          return { data: { user: session?.user ?? null }, error: null };
+        },
+        signInWithPassword: async ({ email }: { email: string }) => {
+          const userObj = { ...mockUser, email: email || 'developer@example.com' };
+          const sessionObj = { ...mockSession, user: userObj };
+          if (typeof window !== 'undefined') {
+            localStorage.setItem('sb-mock-session', JSON.stringify(sessionObj));
+          }
+          authListeners.forEach(cb => cb('SIGNED_IN', sessionObj));
+          return { data: { user: userObj, session: sessionObj }, error: null };
+        },
+        signUp: async ({ email }: { email: string }) => {
+          const userObj = { ...mockUser, email: email || 'developer@example.com' };
+          const sessionObj = { ...mockSession, user: userObj };
+          if (typeof window !== 'undefined') {
+            localStorage.setItem('sb-mock-session', JSON.stringify(sessionObj));
+          }
+          authListeners.forEach(cb => cb('SIGNED_IN', sessionObj));
+          return { data: { user: userObj, session: sessionObj }, error: null };
+        },
+        signInWithOAuth: async ({ provider }: { provider: string }) => {
+          const userObj = { ...mockUser, email: `oauth-${provider}@example.com` };
+          const sessionObj = { ...mockSession, user: userObj };
+          if (typeof window !== 'undefined') {
+            localStorage.setItem('sb-mock-session', JSON.stringify(sessionObj));
+          }
+          authListeners.forEach(cb => cb('SIGNED_IN', sessionObj));
+          // Redirect home to simulate complete OAuth flow
+          if (typeof window !== 'undefined') {
+            window.location.href = '/';
+          }
+          return { data: { user: userObj, session: sessionObj }, error: null };
+        },
+        signOut: async () => {
+          if (typeof window !== 'undefined') {
+            localStorage.removeItem('sb-mock-session');
+          }
+          authListeners.forEach(cb => cb('SIGNED_OUT', null));
+          return { error: null };
+        },
+        onAuthStateChange: (callback: any) => {
+          authListeners.push(callback);
+          const session = getStoredSession();
+          // Notify immediate session state on subscription
+          setTimeout(() => {
+            callback(session ? 'SIGNED_IN' : 'SIGNED_OUT', session);
+          }, 0);
+          return {
+            data: {
+              subscription: {
+                unsubscribe: () => {
+                  authListeners = authListeners.filter(cb => cb !== callback);
+                }
+              }
+            }
+          };
+        },
+        resend: async () => ({ data: {}, error: null }),
+      },
+      from: () => {
+        const queryChain = {
+          select: () => queryChain,
+          insert: () => queryChain,
+          update: () => queryChain,
+          delete: () => queryChain,
+          eq: () => queryChain,
+          order: () => queryChain,
+          limit: () => queryChain,
+          single: async () => ({ data: null, error: null }),
+          maybeSingle: async () => ({ data: null, error: null }),
+          then: (resolve: any) => resolve({ data: [], error: null }),
+        };
+        return queryChain;
+      },
+    } as any;
+  }
+
   return createBrowserClient<Database>(supabaseUrl, supabaseAnonKey);
-};
+};


### PR DESCRIPTION
## Description

Provide a brief summary of the changes made to the project and the motivation behind them. Include any relevant issues.

Fixes #524 

- ### 🎯 Overview
This PR implements the inline **AI Enhance** resume bullet-point rewriter to elevate work experience descriptions, alongside a **local developer auth bypass** to improve developer experience (DX) and prevent Supabase connection crashes in local-only environments.

---

### 🛠️ Changes Made

#### 1. Inline Experience "AI Enhance" Button
* Integrated a premium violet-to-indigo gradient button next to work experience bullet inputs in `components/resume/resume-preview.tsx`.
* Added automated fetching from `/api/resume/enhance-bullet` incorporating candidate job-roles, companies, and aggregated resume skills.
* Integrated micro-scale hover/active transitions (`hover:scale-105 active:scale-95`), loading spinners (`Loader2`), and sparkles icons (`Sparkles`).

#### 2. Local Developer Auth Bypass
* Configured `lib/supabase/client.ts` to check for placeholder credentials (`your-project-id` or `placeholder`).
* When placeholder credentials are active, the client automatically initiates a mock auth proxy to allow signing in/signing up with any email and password (minimum 6 characters) without needing a live Supabase backend.

#### 3. Legacy TypeScript Refactoring
* Resolved 24 pre-existing TypeScript compile errors inside custom and default templates of `resume-preview.tsx` where loop numbers were improperly typed for path key indexes.

---

### 🧪 How to Verify
1. Run `npm run dev` and navigate to `http://localhost:3000/auth/signin`.
2. Login using any developer email and a password of at least 6 characters (e.g. `developer@example.com` / `123456`).
3. Create a resume, toggle **Edit Mode**, and click the purple **AI Enhance** button next to any experience bullet point.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI enhancement for individual resume bullets with progress state, disabled editing while enhancing, validation for non-empty bullets, and success/error toasts.
  * AI enhancement wired into professional and LaTeX-style templates; skills auto-derived for AI context.
  * Editable fields now support a disabled state for both single-line and multiline inputs.
  * Demo/local auth mode added with a mocked sign-in flow and persistent mock session.

* **Bug Fixes**
  * Fixed indexing issues by normalizing indices to strings in editable handlers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->