### PR TITLE
feat(resume-editor): add Undo/Redo support in Resume Editor (#684)

### DIFF
--- a/app/resume-editor/resume-editor-content.tsx
+++ b/app/resume-editor/resume-editor-content.tsx
@@ -6,7 +6,8 @@ import { useUser } from '@/hooks/use-user';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { FileText, Loader2, Sparkles, Code, Edit3, Download, Save, Lock, Unlink } from 'lucide-react';
+import { FileText, Loader2, Sparkles, Code, Edit3, Download, Save, Lock, Unlink, Undo2, Redo2 } from 'lucide-react';
+import { useHistory } from '@/hooks/use-history';
 import { ResumeFormEditor } from '@/components/resume-editor/form-editor';
 import { ResumeLatexEditor, generateLatexFromData } from '@/components/resume-editor/latex-editor';
 import { ResumeAIEditor } from '@/components/resume-editor/ai-editor';
@@ -108,9 +109,51 @@ export default function ResumeEditorContent() {
   const [isLatexManualMode, setIsLatexManualMode] = useState(false);
   const [showLatexConfirmDialog, setShowLatexConfirmDialog] = useState(false);
 
-  // Resume state
+  // Resume state with Undo/Redo history
   const [resumeId, setResumeId] = useState<string | null>(null);
-  const [resumeData, setResumeData] = useState(defaultResumeData);
+  const {
+    value: resumeData,
+    setValue: setResumeData,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    reset: resetResumeData,
+  } = useHistory(defaultResumeData);
+
+  // Keyboard shortcuts for Undo/Redo (Ctrl+Z / Cmd+Z and Ctrl+Y / Cmd+Y)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Check if command/ctrl key is pressed
+      const isCmdOrCtrl = e.metaKey || e.ctrlKey;
+      
+      if (isCmdOrCtrl) {
+        // Z key
+        if (e.key.toLowerCase() === 'z') {
+          if (e.shiftKey) {
+            // Ctrl+Shift+Z / Cmd+Shift+Z (Redo)
+            e.preventDefault();
+            redo();
+          } else {
+            // Ctrl+Z / Cmd+Z (Undo)
+            e.preventDefault();
+            undo();
+          }
+        }
+        // Y key
+        else if (e.key.toLowerCase() === 'y') {
+          // Ctrl+Y / Cmd+Y (Redo)
+          e.preventDefault();
+          redo();
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [undo, redo]);
 
   // Initialize analytics tracking
   const { trackEvent } = useDocumentAnalytics(resumeId);
@@ -162,7 +205,7 @@ export default function ResumeEditorContent() {
 
         // Transform loaded data to resumeData format
         const personalInfo = loadedResumeData.personal_info || loadedResumeData.personalInfo || {};
-        setResumeData({
+        resetResumeData({
           name: personalInfo.name || personalInfo.fullName || '',
           email: personalInfo.email || '',
           phone: personalInfo.phone || '',
@@ -370,7 +413,32 @@ export default function ResumeEditorContent() {
             <p className="text-sm text-blue-100">Create professional resumes in minutes</p>
           </div>
         </div>
-        <div className="flex gap-3">
+        <div className="flex gap-3 items-center">
+          <div className="flex items-center bg-white/10 rounded-lg p-0.5 border border-white/10 mr-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-white hover:bg-white/20 hover:text-white disabled:opacity-40 disabled:hover:bg-transparent h-8 px-3"
+              onClick={undo}
+              disabled={!canUndo}
+              title="Undo (Ctrl+Z)"
+            >
+              <Undo2 className="w-4 h-4 mr-1.5" />
+              Undo
+            </Button>
+            <div className="w-[1px] h-4 bg-white/20" />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-white hover:bg-white/20 hover:text-white disabled:opacity-40 disabled:hover:bg-transparent h-8 px-3"
+              onClick={redo}
+              disabled={!canRedo}
+              title="Redo (Ctrl+Y)"
+            >
+              <Redo2 className="w-4 h-4 mr-1.5" />
+              Redo
+            </Button>
+          </div>
           <Button
             variant="outline"
             size="sm"

--- a/app/resume-editor/resume-editor-content.tsx
+++ b/app/resume-editor/resume-editor-content.tsx
@@ -121,7 +121,7 @@ export default function ResumeEditorContent() {
     reset: resetResumeData,
   } = useHistory(defaultResumeData);
 
-  // Keyboard shortcuts for Undo/Redo (Ctrl+Z / Cmd+Z and Ctrl+Y / Cmd+Y)
+  // Keyboard shortcuts for Undo/Redo (Ctrl+Z / Cmd+Z, Ctrl+Y / Cmd+Y, and Ctrl+Shift+Z / Cmd+Shift+Z)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Check if command/ctrl key is pressed
@@ -421,7 +421,7 @@ export default function ResumeEditorContent() {
               className="text-white hover:bg-white/20 hover:text-white disabled:opacity-40 disabled:hover:bg-transparent h-8 px-3"
               onClick={undo}
               disabled={!canUndo}
-              title="Undo (Ctrl+Z)"
+              title="Undo (Ctrl+Z / Cmd+Z)"
             >
               <Undo2 className="w-4 h-4 mr-1.5" />
               Undo
@@ -433,7 +433,7 @@ export default function ResumeEditorContent() {
               className="text-white hover:bg-white/20 hover:text-white disabled:opacity-40 disabled:hover:bg-transparent h-8 px-3"
               onClick={redo}
               disabled={!canRedo}
-              title="Redo (Ctrl+Y)"
+              title="Redo (Ctrl+Y / Ctrl+Shift+Z / Cmd+Shift+Z)"
             >
               <Redo2 className="w-4 h-4 mr-1.5" />
               Redo

--- a/hooks/use-history.ts
+++ b/hooks/use-history.ts
@@ -30,6 +30,9 @@ export function useHistory<T>(initialValue: T, maxDepth = 50, debounceMs = 500) 
       return;
     }
 
+    // Immediately clear future stack when a new change starts
+    setFuture([]);
+
     const timer = setTimeout(() => {
       const valToCommit = presentRef.current;
       setPast((prevPast) => {
@@ -39,7 +42,6 @@ export function useHistory<T>(initialValue: T, maxDepth = 50, debounceMs = 500) 
         }
         return newPast;
       });
-      setFuture([]);
       lastCommittedRef.current = valToCommit;
     }, debounceMs);
 
@@ -68,20 +70,28 @@ export function useHistory<T>(initialValue: T, maxDepth = 50, debounceMs = 500) 
     });
   }, [maxDepth]);
 
-  // Reverts the last state snapshot.
+  // Reverts the last state snapshot or uncommitted changes.
   const undo = useCallback(() => {
-    setPast((prevPast) => {
-      if (prevPast.length === 0) return prevPast;
-      
-      const previous = prevPast[prevPast.length - 1];
-      const newPast = prevPast.slice(0, -1);
-      
-      setFuture((prevFuture) => [presentRef.current, ...prevFuture]);
-      setPresent(previous);
-      lastCommittedRef.current = previous;
-      
-      return newPast;
-    });
+    const hasUncommitted = JSON.stringify(presentRef.current) !== JSON.stringify(lastCommittedRef.current);
+    
+    if (hasUncommitted) {
+      const currentPresent = presentRef.current;
+      setFuture((prevFuture) => [currentPresent, ...prevFuture]);
+      setPresent(lastCommittedRef.current);
+    } else {
+      setPast((prevPast) => {
+        if (prevPast.length === 0) return prevPast;
+        
+        const previous = prevPast[prevPast.length - 1];
+        const newPast = prevPast.slice(0, -1);
+        
+        setFuture((prevFuture) => [presentRef.current, ...prevFuture]);
+        setPresent(previous);
+        lastCommittedRef.current = previous;
+        
+        return newPast;
+      });
+    }
   }, []);
 
   // Re-applies an undone state snapshot.
@@ -108,12 +118,14 @@ export function useHistory<T>(initialValue: T, maxDepth = 50, debounceMs = 500) 
     lastCommittedRef.current = newValue;
   }, []);
 
+  const hasUncommitted = JSON.stringify(present) !== JSON.stringify(lastCommittedRef.current);
+
   return {
     value: present,
     setValue: updateValue,
     undo,
     redo,
-    canUndo: past.length > 0,
+    canUndo: past.length > 0 || hasUncommitted,
     canRedo: future.length > 0,
     reset,
   };

--- a/hooks/use-history.ts
+++ b/hooks/use-history.ts
@@ -1,0 +1,120 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+/**
+ * A custom hook to manage state history, supporting Undo and Redo operations.
+ * It uses a debounce mechanism to group quick successive changes (like keystrokes)
+ * into a single history snapshot.
+ * 
+ * @param initialValue The initial state value.
+ * @param maxDepth The maximum number of history snapshots to keep (default 50).
+ * @param debounceMs The debounce delay in milliseconds (default 500).
+ */
+export function useHistory<T>(initialValue: T, maxDepth = 50, debounceMs = 500) {
+  const [present, setPresent] = useState<T>(initialValue);
+  const [past, setPast] = useState<T[]>([]);
+  const [future, setFuture] = useState<T[]>([]);
+
+  // Ref to hold the latest present value so that our debounced timer and callbacks always have the freshest value.
+  const presentRef = useRef<T>(present);
+  useEffect(() => {
+    presentRef.current = present;
+  }, [present]);
+
+  // Ref to hold the last committed value to prevent duplicate snapshots or recording unchanged state.
+  const lastCommittedRef = useRef<T>(initialValue);
+
+  // Debounced effect to push present value into history after user stops typing/editing.
+  useEffect(() => {
+    // If the present value is identical to the last committed value, skip creating a history snapshot.
+    if (JSON.stringify(present) === JSON.stringify(lastCommittedRef.current)) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      const valToCommit = presentRef.current;
+      setPast((prevPast) => {
+        const newPast = [...prevPast, lastCommittedRef.current];
+        if (newPast.length > maxDepth) {
+          return newPast.slice(newPast.length - maxDepth);
+        }
+        return newPast;
+      });
+      setFuture([]);
+      lastCommittedRef.current = valToCommit;
+    }, debounceMs);
+
+    return () => clearTimeout(timer);
+  }, [present, maxDepth, debounceMs]);
+
+  // Function to set the value. Optionally commits to history immediately.
+  const updateValue = useCallback((newValue: T | ((prev: T) => T), commitImmediately = false) => {
+    setPresent((prev) => {
+      const resolved = typeof newValue === 'function' ? (newValue as Function)(prev) : newValue;
+      
+      if (commitImmediately) {
+        if (JSON.stringify(resolved) !== JSON.stringify(lastCommittedRef.current)) {
+          setPast((prevPast) => {
+            const newPast = [...prevPast, lastCommittedRef.current];
+            if (newPast.length > maxDepth) {
+              return newPast.slice(newPast.length - maxDepth);
+            }
+            return newPast;
+          });
+          setFuture([]);
+          lastCommittedRef.current = resolved;
+        }
+      }
+      return resolved;
+    });
+  }, [maxDepth]);
+
+  // Reverts the last state snapshot.
+  const undo = useCallback(() => {
+    setPast((prevPast) => {
+      if (prevPast.length === 0) return prevPast;
+      
+      const previous = prevPast[prevPast.length - 1];
+      const newPast = prevPast.slice(0, -1);
+      
+      setFuture((prevFuture) => [presentRef.current, ...prevFuture]);
+      setPresent(previous);
+      lastCommittedRef.current = previous;
+      
+      return newPast;
+    });
+  }, []);
+
+  // Re-applies an undone state snapshot.
+  const redo = useCallback(() => {
+    setFuture((prevFuture) => {
+      if (prevFuture.length === 0) return prevFuture;
+      
+      const next = prevFuture[0];
+      const newFuture = prevFuture.slice(1);
+      
+      setPast((prevPast) => [...prevPast, presentRef.current]);
+      setPresent(next);
+      lastCommittedRef.current = next;
+      
+      return newFuture;
+    });
+  }, []);
+
+  // Resets state and clears all history stacks.
+  const reset = useCallback((newValue: T) => {
+    setPresent(newValue);
+    setPast([]);
+    setFuture([]);
+    lastCommittedRef.current = newValue;
+  }, []);
+
+  return {
+    value: present,
+    setValue: updateValue,
+    undo,
+    redo,
+    canUndo: past.length > 0,
+    canRedo: future.length > 0,
+    reset,
+  };
+}

--- a/hooks/use-history.ts
+++ b/hooks/use-history.ts
@@ -30,9 +30,6 @@ export function useHistory<T>(initialValue: T, maxDepth = 50, debounceMs = 500) 
       return;
     }
 
-    // Immediately clear future stack when a new change starts
-    setFuture([]);
-
     const timer = setTimeout(() => {
       const valToCommit = presentRef.current;
       setPast((prevPast) => {
@@ -62,12 +59,19 @@ export function useHistory<T>(initialValue: T, maxDepth = 50, debounceMs = 500) 
             }
             return newPast;
           });
-          setFuture([]);
           lastCommittedRef.current = resolved;
         }
       }
       return resolved;
     });
+
+    const resolvedValue = typeof newValue === 'function' 
+      ? (newValue as Function)(presentRef.current) 
+      : newValue;
+
+    if (JSON.stringify(resolvedValue) !== JSON.stringify(presentRef.current)) {
+      setFuture((prevFuture) => (prevFuture.length > 0 ? [] : prevFuture));
+    }
   }, [maxDepth]);
 
   // Reverts the last state snapshot or uncommitted changes.


### PR DESCRIPTION
## Description

Add multi-step Undo and Redo operations to the dedicated Resume Editor (`/resume-editor`) to prevent accidental data loss during edits and reduce unnecessary credit consumption caused by having to re-generate documents.

This includes both keyboard shortcuts (`Ctrl+Z` / `Cmd+Z` for Undo; `Ctrl+Y` / `Cmd+Y` or `Ctrl+Shift+Z` for Redo) and visually cohesive Undo/Redo buttons in the editor's header toolbar.

Fixes #684

## Type of Change

- [x] New feature (e.g., new page, component, or functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify): ____________________

## Changes Made

- **[NEW] `hooks/use-history.ts`:** Created a custom, reusable React history tracking hook (`useHistory`) utilizing `past`, `present`, and `future` stacks. It limits history depth to `50` steps and debounces successive keystrokes by `500ms` to group text entry into singular logical history entries.
- **`app/resume-editor/resume-editor-content.tsx`:** Integrated the `useHistory` hook to control centralized `resumeData` state, resetting the history stacks upon loading existing files.
- **Keyboard Event Listeners:** Added robust global keydown event handlers in the editor view to trigger undo/redo shortcuts seamlessly.
- **Header Toolbar Buttons:** Inserted stylish Undo/Redo button pairs utilizing `Undo2` and `Redo2` from `lucide-react` directly in the editor header, which reactively toggle disabled/enabled states based on the history stack availability.
- **Linter & Syntax Fixes:** Corrected two pre-existing syntax errors in `components/site-header.tsx` (nested opening `<Link>` tags and unclosed mobile drawer `<li>`/`<ul>` blocks) to achieve a successful ESLint compilation with `npm run lint`.

## Dependencies

- No new package dependencies or tools are required for this change.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers/devices.
- [x] I have tested my changes in development mode (`npm run dev`).
- [ ] I have written or updated related tests, if necessary.
- [x] This is already assigned Issue to me, not an unassigned issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added undo/redo to the resume editor with dedicated toolbar buttons.
  * Implemented keyboard shortcuts: Ctrl/Cmd+Z for undo, Ctrl/Cmd+Shift+Z or Ctrl/Cmd+Y for redo.
  * History is debounced and capped to limit snapshot growth for smoother editing.
  * Loading an existing resume now initializes the editor history so undo/redo reflect the loaded content.
* **Bug Fixes**
  * Undo/Redo buttons enable/disable correctly based on available history.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->