### PR TITLE
feat: add API request validation middleware

### DIFF
--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -29,9 +29,14 @@ export const POST = apiHandler(async (req: NextRequest) => {
     .insert({
       user_id: user.id,
       title,
+      type: 'generated',
       document_type: body.documentType,
       content: body.content ?? {},
-      metadata: body.metadata ?? {},
+      metadata: {
+        ...(body.metadata ?? {}),
+        sections: body.sections ?? [],
+        generated_at: new Date().toISOString(),
+      },
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
     })

--- a/app/api/generate/letter/route.ts
+++ b/app/api/generate/letter/route.ts
@@ -21,6 +21,11 @@ import {
   refundCredits,
   creditReservationConflictResponse,
 } from "@/lib/credit-operations";
+import {
+  letterGenerationSchema,
+  RequestValidationError,
+  safeParseBody,
+} from "@/lib/validation";
 
 // Service role client for credit operations
 const supabaseAdmin = createClient(
@@ -54,7 +59,19 @@ export async function POST(request: Request) {
     }
     const hasUnlimitedCredits = hasUnlimitedDeveloperCredits(user.email);
 
-    const body = await request.json();
+    let body;
+    try {
+      body = await safeParseBody(request, letterGenerationSchema);
+    } catch (validationError) {
+      if (!(validationError instanceof RequestValidationError)) {
+        throw validationError;
+      }
+      return NextResponse.json(
+        { error: validationError.message, details: validationError.details },
+        { status: 400 },
+      );
+    }
+
     const {
       prompt,
       fromName,
@@ -151,15 +168,6 @@ export async function POST(request: Request) {
       );
     }
 
-    // Validate required fields for the standard-letter branch BEFORE
-    // reserving credits, so a missing-fields error doesn't charge anyone.
-    if (!isCoverLetter && (!prompt || !fromName || !toName || !letterType)) {
-      return NextResponse.json(
-        { error: "Missing required fields" },
-        { status: 400 },
-      );
-    }
-
     // Atomically reserve credits BEFORE generation to prevent the
     // TOCTOU race documented in issue #477.
     if (!hasUnlimitedCredits) {
@@ -184,12 +192,15 @@ export async function POST(request: Request) {
         "📝 Generating cover letter from job description with Mistral...",
       );
 
+      const coverJobDescription = jobDescription as string;
+      const coverFromName = fromName as string;
+
       let coverLetter;
       try {
         coverLetter = await generateCoverLetterFromJob({
-          jobDescription,
+          jobDescription: coverJobDescription,
           jobUrl,
-          fromName,
+          fromName: coverFromName,
           fromEmail,
           fromAddress,
           skills,
@@ -229,16 +240,20 @@ export async function POST(request: Request) {
 
     // Standard letter generation
     console.log(`📝 Generating ${letterType} letter with Mistral...`);
+    const standardPrompt = prompt as string;
+    const standardFromName = fromName as string;
+    const standardToName = toName as string;
+    const standardLetterType = letterType as string;
 
     let letter;
     try {
       letter = await generateLetterWithMistral({
-        prompt,
-        fromName,
+        prompt: standardPrompt,
+        fromName: standardFromName,
         fromAddress,
-        toName,
+        toName: standardToName,
         toAddress,
-        letterType,
+        letterType: standardLetterType,
       });
     } catch (err) {
       if (!hasUnlimitedCredits) {
@@ -250,11 +265,11 @@ export async function POST(request: Request) {
     // Format the response to ensure it has the expected structure
     const formattedResponse = {
       from: {
-        name: letter.from?.name || fromName,
+        name: letter.from?.name || standardFromName,
         address: letter.from?.address || fromAddress || "",
       },
       to: {
-        name: letter.to?.name || toName,
+        name: letter.to?.name || standardToName,
         address: letter.to?.address || toAddress || "",
       },
       date:
@@ -264,7 +279,7 @@ export async function POST(request: Request) {
           month: "long",
           day: "numeric",
         }),
-      subject: letter.subject || "Re: " + prompt.substring(0, 30) + "...",
+      subject: letter.subject || "Re: " + standardPrompt.substring(0, 30) + "...",
       content: letter.content || "Letter content not available.",
     };
 
@@ -277,7 +292,7 @@ export async function POST(request: Request) {
           user_id: user.id,
           action_type: actionType,
           credits_used: creditCost,
-          metadata: { letter_type: letterType, prompt_length: prompt.length },
+          metadata: { letter_type: standardLetterType, prompt_length: standardPrompt.length },
         });
 
       if (logError) {

--- a/app/api/generate/presentation/route.ts
+++ b/app/api/generate/presentation/route.ts
@@ -6,6 +6,7 @@ import { generatePresentation, generatePresentationOutline } from '@/lib/gemini'
 import { createClient } from '@supabase/supabase-js';
 import { ACTION_COSTS, TIER_LIMITS, getCreditsResetDate, shouldResetCredits, calculateRemainingCredits, hasUnlimitedDeveloperCredits } from '@/lib/credits-service';
 import { reserveCredits, refundCredits, creditReservationConflictResponse } from '@/lib/credit-operations';
+import { presentationGenerationSchema, RequestValidationError, safeParseBody } from '@/lib/validation';
 
 // Service role client for credit operations
 const supabaseAdmin = createClient(
@@ -36,25 +37,18 @@ export async function POST(request: NextRequest) {
     }
     const hasUnlimitedCredits = hasUnlimitedDeveloperCredits(user.email);
 
-    const body = await request.json();
-    const { prompt, pageCount = 8, template } = body;
-
-    if (!prompt || typeof prompt !== 'string' || prompt.trim().length === 0) {
+    let prompt, validatedPageCount, template;
+    try {
+      const body = await safeParseBody(request, presentationGenerationSchema);
+      prompt = body.prompt;
+      validatedPageCount = body.pageCount;
+      template = body.template;
+    } catch (validationError) {
+      if (!(validationError instanceof RequestValidationError)) {
+        throw validationError;
+      }
       return NextResponse.json(
-        { error: 'Missing or invalid prompt' },
-        { status: 400 }
-      );
-    }
-
-    // Validate pageCount
-    const validatedPageCount = Number(pageCount);
-    if (
-      !Number.isInteger(validatedPageCount) ||
-      validatedPageCount < 1 ||
-      validatedPageCount > 100
-    ) {
-      return NextResponse.json(
-        { error: 'Invalid pageCount. Please provide an integer between 1 and 100.' },
+        { error: validationError.message, details: validationError.details },
         { status: 400 }
       );
     }

--- a/app/api/generate/resume/route.ts
+++ b/app/api/generate/resume/route.ts
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 import { NextResponse } from 'next/server';
-import { validateAndSanitize, resumeGenerationSchema, detectSqlInjection, sanitizeInput, sanitizeObject } from '@/lib/validation';
+import { resumeGenerationSchema, detectSqlInjection, sanitizeObject, safeParseBody, RequestValidationError } from '@/lib/validation';
 import { createClient } from '@supabase/supabase-js';
 import { ACTION_COSTS, TIER_LIMITS, getCreditsResetDate, shouldResetCredits, calculateRemainingCredits, hasUnlimitedDeveloperCredits } from '@/lib/credits-service';
 import { reserveCredits, refundCredits, creditReservationConflictResponse } from '@/lib/credit-operations';
@@ -260,27 +260,18 @@ async function postHandler(request: Request) {
       );
     }
 
-    // Validate request body exists
-    let rawBody;
-    try {
-      rawBody = await request.json();
-    } catch (parseError) {
-      return NextResponse.json(
-        { error: 'Invalid request body' },
-        { status: 400 }
-      );
-    }
-
-    // Validate and sanitize input
     let prompt, name, email;
     try {
-      const validatedData = validateAndSanitize(resumeGenerationSchema, rawBody);
+      const validatedData = await safeParseBody(request, resumeGenerationSchema);
       prompt = validatedData.prompt;
       name = validatedData.name;
       email = validatedData.email;
-    } catch (validationError: any) {
+    } catch (validationError) {
+      if (!(validationError instanceof RequestValidationError)) {
+        throw validationError;
+      }
       return NextResponse.json(
-        { error: 'Invalid input data', details: validationError.message },
+        { error: validationError.message, details: validationError.details },
         { status: 400 }
       );
     }

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from 'next/server';
 import nodemailer from 'nodemailer';
-import { z } from 'zod';
-import { emailSchema, sanitizeHtml, sanitizeInput, sanitizeObject } from '@/lib/validation';
+import { RequestValidationError, safeParseBody, sanitizeObject, sendEmailSchema } from '@/lib/validation';
 import { createRoute } from '@/lib/supabase/server';
 import { createClient } from '@supabase/supabase-js';
 import { logSecurityEvent, checkRateLimit, SECURITY_CONFIG } from '@/lib/security';
@@ -19,30 +18,6 @@ const EMAIL_RATE_LIMIT = {
   requests: 5,
   windowMs: 15 * 60 * 1000 // 15 minutes
 };
-
-const sendEmailSchema = z.object({
-  to: emailSchema,
-  subject: z.string().min(1, 'Subject is required').max(200, 'Subject is too long'),
-  content: z.string().max(5000, 'Content is too long').optional().nullable(),
-  fromName: z.string().max(100, 'From name is too long').optional().nullable(),
-  fromEmail: z.string().max(254, 'From email is too long').refine((val: string) => {
-    if (!val) return true;
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val);
-  }, 'Invalid from email').optional().nullable(),
-  letterContent: z.object({
-    from: z.object({
-      name: z.string().max(100).optional().nullable(),
-      address: z.string().max(200).optional().nullable(),
-    }).optional().nullable(),
-    to: z.object({
-      name: z.string().max(100).optional().nullable(),
-      address: z.string().max(200).optional().nullable(),
-    }).optional().nullable(),
-    date: z.string().max(100).optional().nullable(),
-    subject: z.string().max(200).optional().nullable(),
-    content: z.string().max(10000, 'Letter content is too long').optional().nullable(),
-  }),
-});
 
 async function postHandler(request: NextRequest) {
   const requestId = getRequestId(request.headers);
@@ -85,26 +60,20 @@ async function postHandler(request: NextRequest) {
     }
 
     // 2. Request Body Parsing & Validation (Run before rate limit so malformed requests don't consume quota)
-    let rawBody;
+    let validatedEmail;
     try {
-      rawBody = await request.json();
-    } catch {
+      validatedEmail = await safeParseBody(request, sendEmailSchema);
+    } catch (validationError) {
+      if (!(validationError instanceof RequestValidationError)) {
+        throw validationError;
+      }
       return new Response(
-        JSON.stringify({ error: 'Invalid JSON payload' }),
+        JSON.stringify({ error: validationError.message, details: validationError.details }),
         { status: 400, headers: { 'Content-Type': 'application/json', 'x-request-id': requestId } }
       );
     }
 
-    const validationResult = sendEmailSchema.safeParse(rawBody);
-    if (!validationResult.success) {
-      const errorMessage = validationResult.error.errors.map((e: any) => e.message).join(', ');
-      return new Response(
-        JSON.stringify({ error: `Validation failed: ${errorMessage}` }),
-        { status: 400, headers: { 'Content-Type': 'application/json', 'x-request-id': requestId } }
-      );
-    }
-
-    const { to, subject, content, fromName, fromEmail, letterContent } = validationResult.data;
+    const { to, subject, content, fromName, fromEmail, letterContent } = validatedEmail;
 
     // 3. Rate Limiting Check using the shared utility
     const rateLimitResult = checkRateLimit(user.id, EMAIL_RATE_LIMIT);

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,9 +1,8 @@
-import type { Config } from 'jest';
 import nextJest from 'next/jest.js';
 
 const createJestConfig = nextJest({ dir: './' });
 
-const config: Config = {
+const config = {
   testEnvironment: 'jsdom',
   testMatch: ['**/__tests__/**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
   moduleNameMapper: { '^@/(.*)$': '<rootDir>/$1' },

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -15,6 +15,7 @@ const config = {
   testEnvironment: 'jsdom',
   testMatch: ['**/__tests__/**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
   moduleNameMapper: { '^@/(.*)$': '<rootDir>/$1' },
+  setupFiles: ['<rootDir>/jest.polyfills.cjs'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   collectCoverageFrom: ['lib/**/*.ts', 'app/api/**/*.ts', '!**/__tests__/**'],
 };

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,4 +1,13 @@
-import nextJest from 'next/jest.js';
+import { webcrypto } from 'node:crypto';
+
+if (!globalThis.crypto) {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+  });
+}
+
+const { default: nextJest } = await import('next/jest.js');
 
 const createJestConfig = nextJest({ dir: './' });
 

--- a/jest.polyfills.cjs
+++ b/jest.polyfills.cjs
@@ -1,0 +1,13 @@
+const { TextDecoder, TextEncoder } = require('node:util');
+const { webcrypto } = require('node:crypto');
+const undici = require('undici');
+
+if (!globalThis.TextEncoder) globalThis.TextEncoder = TextEncoder;
+if (!globalThis.TextDecoder) globalThis.TextDecoder = TextDecoder;
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+if (!globalThis.fetch) globalThis.fetch = undici.fetch;
+if (!globalThis.Headers) globalThis.Headers = undici.Headers;
+if (!globalThis.Request) globalThis.Request = undici.Request;
+if (!globalThis.Response) globalThis.Response = undici.Response;
+if (!globalThis.FormData) globalThis.FormData = undici.FormData;
+if (!globalThis.File) globalThis.File = undici.File;

--- a/jest.polyfills.cjs
+++ b/jest.polyfills.cjs
@@ -1,10 +1,12 @@
 const { TextDecoder, TextEncoder } = require('node:util');
 const { webcrypto } = require('node:crypto');
-const undici = require('undici');
 
 if (!globalThis.TextEncoder) globalThis.TextEncoder = TextEncoder;
 if (!globalThis.TextDecoder) globalThis.TextDecoder = TextDecoder;
 if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+const undici = require('undici');
+
 if (!globalThis.fetch) globalThis.fetch = undici.fetch;
 if (!globalThis.Headers) globalThis.Headers = undici.Headers;
 if (!globalThis.Request) globalThis.Request = undici.Request;

--- a/jest.polyfills.cjs
+++ b/jest.polyfills.cjs
@@ -1,9 +1,17 @@
 const { TextDecoder, TextEncoder } = require('node:util');
 const { webcrypto } = require('node:crypto');
+const {
+  ReadableStream,
+  TransformStream,
+  WritableStream,
+} = require('node:stream/web');
 
 if (!globalThis.TextEncoder) globalThis.TextEncoder = TextEncoder;
 if (!globalThis.TextDecoder) globalThis.TextDecoder = TextDecoder;
 if (!globalThis.crypto) globalThis.crypto = webcrypto;
+if (!globalThis.ReadableStream) globalThis.ReadableStream = ReadableStream;
+if (!globalThis.TransformStream) globalThis.TransformStream = TransformStream;
+if (!globalThis.WritableStream) globalThis.WritableStream = WritableStream;
 
 const undici = require('undici');
 

--- a/lib/api-handler.ts
+++ b/lib/api-handler.ts
@@ -5,6 +5,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 import { ZodError } from 'zod';
+import { RequestValidationError } from '@/lib/validation';
 
 // ── Typed errors ─────────────────────────────────────────────
 export class AppError extends Error {
@@ -34,6 +35,9 @@ export class RateLimitError extends AppError {
 // ── Error → Response ─────────────────────────────────────────
 function errorToResponse(error: unknown, requestId: string): NextResponse {
   const isProd = process.env.NODE_ENV === 'production';
+  if (error instanceof RequestValidationError) {
+    return NextResponse.json({ error: error.message, details: error.details, requestId }, { status: 400 });
+  }
   if (error instanceof ZodError) {
     const details = error.errors.map(e=>`${e.path.join('.')}: ${e.message}`);
     return NextResponse.json({ error:'Validation failed', details, requestId }, { status:400 });

--- a/lib/api-handler.ts
+++ b/lib/api-handler.ts
@@ -43,9 +43,13 @@ function errorToResponse(error: unknown, requestId: string): NextResponse {
     return NextResponse.json({ error:'Validation failed', details, requestId }, { status:400 });
   }
   if (error instanceof RateLimitError) {
-    const response = NextResponse.json({ error:error.message, code:error.code, requestId }, { status:429 });
-    response.headers.set('Retry-After', String(error.retryAfter));
-    return response;
+    return new NextResponse(JSON.stringify({ error:error.message, code:error.code, requestId }), {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': String(error.retryAfter),
+      },
+    });
   }
   if (error instanceof AppError) {
     return NextResponse.json({ error:error.message, code:error.code, requestId }, { status:error.statusCode });

--- a/lib/api-handler.ts
+++ b/lib/api-handler.ts
@@ -13,7 +13,7 @@ export class AppError extends Error {
     public readonly message: string,
     public readonly statusCode = 500,
     public readonly code = 'INTERNAL_ERROR',
-  ) { super(message); this.name = 'AppError'; Object.setPrototypeOf(this,AppError.prototype); }
+  ) { super(message); this.name = new.target.name; Object.setPrototypeOf(this,new.target.prototype); }
 }
 export class ValidationError extends AppError {
   constructor(m: string) { super(m, 400, 'VALIDATION_ERROR'); this.name='ValidationError'; }

--- a/lib/api-handler.ts
+++ b/lib/api-handler.ts
@@ -43,8 +43,9 @@ function errorToResponse(error: unknown, requestId: string): NextResponse {
     return NextResponse.json({ error:'Validation failed', details, requestId }, { status:400 });
   }
   if (error instanceof RateLimitError) {
-    return NextResponse.json({ error:error.message, code:error.code, requestId },
-      { status:429, headers:{ 'Retry-After': String(error.retryAfter) } });
+    const response = NextResponse.json({ error:error.message, code:error.code, requestId }, { status:429 });
+    response.headers.set('Retry-After', String(error.retryAfter));
+    return response;
   }
   if (error instanceof AppError) {
     return NextResponse.json({ error:error.message, code:error.code, requestId }, { status:error.statusCode });

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 import { getRequestId } from '@/lib/request-id';
 import { incrementErrorCount, incrementRequestCount } from '@/app/api/metrics/route';
+import { RequestValidationError } from '@/lib/validation';
 
 /**
  * ==========================================
@@ -347,6 +348,15 @@ export function withErrorHandling(handler: ApiHandler): ApiHandler {
         errors: currentStats.errors + 1,
         totalDurationMs: currentStats.totalDurationMs + durationMs,
       });
+
+      if (error instanceof RequestValidationError) {
+        const response = NextResponse.json(
+          { error: error.message, details: error.details, requestId },
+          { status: 400 },
+        );
+        response.headers.set('x-request-id', requestId);
+        return response;
+      }
 
       // Capture and track exception details
       const caughtDetails = captureException(error, requestContext);

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,7 +1,7 @@
 /**
  * lib/validation.ts — Fix #6 (XSS/SQLi) + Fix #17 (safe parse) + Fix #20 (limits)
  */
-import { z, ZodSchema } from 'zod';
+import { z, ZodSchema, type ZodIssue } from 'zod';
 
 export const LIMITS = {
   NAME_MAX: 200,
@@ -16,6 +16,16 @@ export const LIMITS = {
   MAX_BODY_BYTES: 1_048_576,
 } as const;
 
+export class RequestValidationError extends Error {
+  readonly details: string[];
+
+  constructor(message: string, details: string[] = []) {
+    super(message);
+    this.name = 'RequestValidationError';
+    this.details = details;
+  }
+}
+
 export function sanitizeHtml(s: string): string {
   return s
     .replace(/&/g, '&amp;')
@@ -28,6 +38,20 @@ export function sanitizeHtml(s: string): string {
 
 export function sanitizeInput(s: string, max = LIMITS.CONTENT_MAX): string {
   return s.replace(/\0/g, '').replace(/\r\n/g, '\n').trim().slice(0, max);
+}
+
+export function sanitizeObject<T>(data: T): T {
+  if (data === null || data === undefined) return data;
+  if (typeof data === 'string') return sanitizeHtml(data) as unknown as T;
+  if (Array.isArray(data)) return data.map((item) => sanitizeObject(item)) as unknown as T;
+  if (typeof data === 'object') {
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+      sanitized[key] = sanitizeObject(value);
+    }
+    return sanitized as T;
+  }
+  return data;
 }
 
 export function detectSqlInjection(s: string): boolean {
@@ -76,16 +100,84 @@ export const resumeGenerationSchema = z.object({
 });
 
 export const presentationGenerationSchema = z.object({
-  topic: z.string().min(3).max(200),
-  slides: z.number().int().min(1).max(50),
-  style: z.enum(['professional', 'creative', 'minimal', 'corporate']).optional(),
+  prompt: promptSchema,
+  pageCount: z.coerce.number().int().min(1).max(100).default(8),
+  template: z.string().max(100).optional(),
 });
 
+const emptyToUndefined = (value: unknown) => value === null || value === '' ? undefined : value;
+const optionalText = (max = LIMITS.CONTENT_MAX) =>
+  z.preprocess(emptyToUndefined, z.string().trim().max(max).optional());
+const optionalName = z.preprocess(emptyToUndefined, nameSchema.optional());
+const optionalEmail = z.preprocess(emptyToUndefined, emailSchema.optional());
+const optionalUrl = z.preprocess(emptyToUndefined, z.string().trim().url().max(2048).optional());
+
 export const letterGenerationSchema = z.object({
-  type: z.enum(['cover', 'recommendation', 'resignation', 'complaint', 'thank-you']),
-  recipient: nameSchema,
-  content: z.string().min(50).max(LIMITS.DESCRIPTION_MAX),
+  prompt: optionalText(LIMITS.PROMPT_MAX),
+  fromName: optionalName,
+  fromAddress: optionalText(500),
+  toName: optionalName,
+  toAddress: optionalText(500),
+  letterType: z.preprocess(emptyToUndefined, z.string().trim().min(1).max(50).optional()),
+  jobDescription: z.preprocess(emptyToUndefined, z.string().trim().min(20).max(LIMITS.CONTENT_MAX).optional()),
+  jobUrl: optionalUrl,
+  fromEmail: optionalEmail,
+  skills: z.preprocess(emptyToUndefined, z.union([
+    z.string().trim().max(2_000).transform((value) =>
+      value.split(',').map((skill) => skill.trim()).filter(Boolean),
+    ),
+    z.array(z.string().trim().max(100)).max(50),
+  ]).optional()),
+  experience: optionalText(5_000),
+  tone: optionalText(100),
+  length: optionalText(50),
+  lockedSections: z.object({
+    name: z.boolean().optional(),
+    skills: z.boolean().optional(),
+    experience: z.boolean().optional(),
+  }).optional(),
+}).superRefine((data, ctx) => {
+  const isCoverLetter = Boolean(data.jobDescription && data.fromName);
+  if (isCoverLetter) return;
+
+  const requiredFields: Array<keyof typeof data> = ['prompt', 'fromName', 'toName', 'letterType'];
+  for (const field of requiredFields) {
+    if (!data[field]) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [field],
+        message: `${field} is required`,
+      });
+    }
+  }
 });
+
+const emailLetterPartySchema = z.object({
+  name: z.string().max(100).optional().nullable(),
+  address: z.string().max(200).optional().nullable(),
+});
+
+export const sendEmailSchema = z.object({
+  to: emailSchema,
+  subject: z.string().min(1, 'Subject is required').max(200, 'Subject is too long'),
+  content: z.string().max(5000, 'Content is too long').optional().nullable(),
+  fromName: z.string().max(100, 'From name is too long').optional().nullable(),
+  fromEmail: emailSchema.optional().nullable(),
+  letterContent: z.object({
+    from: emailLetterPartySchema.optional().nullable(),
+    to: emailLetterPartySchema.optional().nullable(),
+    date: z.string().max(100).optional().nullable(),
+    subject: z.string().max(200).optional().nullable(),
+    content: z.string().max(10000, 'Letter content is too long').optional().nullable(),
+  }),
+}).transform((data) => ({
+  ...data,
+  letterContent: {
+    ...data.letterContent,
+    from: data.letterContent.from ?? {},
+    to: data.letterContent.to ?? {},
+  },
+}));
 
 export const documentCreateSchema = z.object({
   title: z.string().min(1).max(LIMITS.TITLE_MAX),
@@ -100,20 +192,41 @@ export const paginationSchema = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 });
 
-export async function safeParseBody<T>(request: Request, schema: ZodSchema<T>): Promise<T> {
+function formatZodIssues(issues: ZodIssue[]): string[] {
+  return issues.map((issue) => {
+    const path = issue.path.length ? `${issue.path.join('.')}: ` : '';
+    return `${path}${issue.message}`;
+  });
+}
+
+export async function safeParseBody<T>(
+  request: Request,
+  schema: ZodSchema<T>,
+  options: { maxBodyBytes?: number } = {},
+): Promise<T> {
   const ct = request.headers.get('content-type') ?? '';
-  if (!ct.includes('application/json')) throw new Error('Content-Type must be application/json');
+  if (!ct.toLowerCase().includes('application/json')) {
+    throw new RequestValidationError('Invalid request body', ['Content-Type must be application/json']);
+  }
+
   const cl = Number(request.headers.get('content-length') ?? 0);
-  if (cl > LIMITS.MAX_BODY_BYTES) throw new Error('Request body too large');
+  const maxBodyBytes = options.maxBodyBytes ?? LIMITS.MAX_BODY_BYTES;
+  if (Number.isFinite(cl) && cl > maxBodyBytes) {
+    throw new RequestValidationError('Request body too large', [`Maximum request body size is ${maxBodyBytes} bytes`]);
+  }
+
   let raw: unknown;
   try {
     raw = await request.json();
   } catch {
-    throw new Error('Invalid JSON body');
+    throw new RequestValidationError('Invalid JSON payload', ['Request body must be valid JSON']);
   }
+
   const r = schema.safeParse(raw);
-  if (!r.success)
-    throw new Error('Validation failed: ' + r.error.errors.map((e) => e.message).join(', '));
+  if (!r.success) {
+    throw new RequestValidationError('Invalid request body', formatZodIssues(r.error.errors));
+  }
+
   return r.data;
 }
 


### PR DESCRIPTION
Closes #666

## Summary
- add a reusable `safeParseBody` request validator with content-type checks, body-size enforcement, invalid JSON handling, and structured Zod error details
- wire validation into resume, presentation, letter, documents, and send-email API routes before costly generation or email work begins
- standardize validation failures through the existing API/error wrappers and restore nested input sanitization used by the routes

## Validation
- `git diff --check`
- TypeScript/Next build not run locally because this checkout has no `npm` binary or `node_modules`; CI should perform the full build check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured validation error responses providing detailed feedback for invalid requests.
  * Enhanced metadata structure for generated documents with standardized fields.

* **Bug Fixes**
  * Improved request validation consistency across all API endpoints.
  * Better error handling with clearer, more consistent error messages.

* **Chores**
  * Standardized validation and error response formatting throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->