### PR TITLE
Setup Go backend module structure for migration

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,8 @@
+run:
+	go run go/cmd/server/main.go
+
+test:
+	go test ./...
+
+lint:
+	go vet ./...

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,4 +5,5 @@ go 1.21
 require (
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/golang-jwt/jwt/v5 v5.2.2
+	github.com/google/uuid v1.6.0
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,6 @@
+github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
+github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/backend/go/README.md
+++ b/backend/go/README.md
@@ -1,0 +1,42 @@
+# DraftDeckAI Go Backend
+
+## Run locally
+
+Set environment variable:
+
+```bash
+set SUPABASE_JWT_SECRET=testsecret
+```
+
+Run server:
+
+```bash
+make run
+```
+
+Server runs on:
+
+http://localhost:8080
+
+## Run tests
+
+```bash
+make test
+```
+
+## Run lint
+
+```bash
+make lint
+```
+
+## Project structure
+
+```text
+go/
+  cmd/server
+  internal
+  pkg
+```
+
+This structure follows standard Go project layout for backend migration.

--- a/backend/go/cmd/server/main.go
+++ b/backend/go/cmd/server/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/ItsAbir005/Draftdeckai/backend/pkg/auth"
+)
+
+func main() {
+	r := chi.NewRouter()
+
+	r.Use(middleware.RequestID)
+	r.Use(middleware.RealIP)
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{
+			"status":  "ok",
+			"service": "Draftdeckai Go Backend",
+		})
+	})
+
+	r.Route("/api", func(r chi.Router) {
+		r.Use(auth.RequireAuth())
+
+		r.Get("/user", func(w http.ResponseWriter, r *http.Request) {
+			user := auth.UserFromContext(r.Context())
+			if user == nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				json.NewEncoder(w).Encode(map[string]string{
+					"error": "Failed to retrieve user from context",
+				})
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"message": "Successfully authenticated",
+				"user":    user,
+			})
+		})
+	})
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	fmt.Printf("Starting server on port %s...\n", port)
+
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatalf("Server failed to start: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements initial Go backend migration module structure for issue #462.

### Changes made

* Added Go command entrypoint structure under `go/cmd/server`
* Added `internal` module directory
* Added backend `Makefile` with:

  * `run`
  * `test`
  * `lint`
* Added local development documentation in `go/README.md`
* Generated dependency lockfile (`go.sum`)
* Verified server starts locally on port 8080

### Validation

* `go mod tidy`
* `go run go/cmd/server/main.go`

Closes sub-issue of #462.
