### PR TITLE
Add PDF export for presentations issue#652

### DIFF
--- a/app/presentation/view/[id]/page.tsx
+++ b/app/presentation/view/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { Loader2, ArrowLeft, Download } from 'lucide-react';
 import Link from 'next/link';
+import { exportAsPDF } from '@/lib/presentation-export';
 
 interface Slide {
   slideNumber: number;
@@ -30,10 +31,13 @@ interface Presentation {
 export default function ViewPresentationPage() {
   const params = useParams();
   const id = params?.id as string;
-  
+
   const [presentation, setPresentation] = useState<Presentation | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState('');
+  const [orientation, setOrientation] = useState<'portrait' | 'landscape'>('landscape');
 
   useEffect(() => {
     if (!id) return;
@@ -41,7 +45,7 @@ export default function ViewPresentationPage() {
     async function loadPresentation() {
       try {
         const response = await fetch(`/api/presentations/${id}`);
-        
+
         if (!response.ok) {
           throw new Error('Presentation not found');
         }
@@ -58,6 +62,36 @@ export default function ViewPresentationPage() {
 
     loadPresentation();
   }, [id]);
+
+  async function handleExportPDF() {
+    try {
+      setExportError('');
+      setExporting(true);
+
+      if (!presentation) {
+        throw new Error('Presentation not loaded');
+      }
+
+      const slideElements = Array.from(
+        document.querySelectorAll('[data-presentation-slide]')
+      ) as HTMLElement[];
+
+      if (!slideElements.length) {
+        throw new Error('No slides found');
+      }
+
+      await exportAsPDF(slideElements, presentation.title || 'presentation', {
+        format: 'pdf',
+        quality: 2,
+        orientation,
+      });
+    } catch (err) {
+      console.error('PDF export failed:', err);
+      setExportError('Failed to export PDF');
+    } finally {
+      setExporting(false);
+    }
+  }
 
   if (loading) {
     return (
@@ -81,7 +115,7 @@ export default function ViewPresentationPage() {
           <p className="text-muted-foreground mb-6">
             {error || 'This presentation may have been deleted or the link is invalid.'}
           </p>
-          <Link 
+          <Link
             href="/presentation"
             className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-bold transition-all"
           >
@@ -95,17 +129,56 @@ export default function ViewPresentationPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
       <div className="fixed top-0 left-0 right-0 bg-background/80 backdrop-blur-xl border-b border-border z-50">
         <div className="max-w-7xl mx-auto px-6 py-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-4 flex-wrap">
             <div>
               <h1 className="text-xl font-bold">{presentation.title}</h1>
               <p className="text-sm text-muted-foreground">
                 Shared presentation • View only
               </p>
             </div>
-            <div className="flex items-center gap-3">
+
+            <div className="flex items-center gap-3 flex-wrap">
+              <div className="flex items-center gap-2">
+                <label
+                  htmlFor="orientation"
+                  className="text-sm text-muted-foreground font-medium"
+                >
+                  Orientation
+                </label>
+                <select
+                  id="orientation"
+                  value={orientation}
+                  onChange={(e) =>
+                    setOrientation(e.target.value as 'portrait' | 'landscape')
+                  }
+                  className="px-3 py-2 rounded-xl border border-border bg-background text-sm"
+                >
+                  <option value="landscape">Landscape</option>
+                  <option value="portrait">Portrait</option>
+                </select>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleExportPDF}
+                disabled={exporting}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-all disabled:opacity-50"
+              >
+                {exporting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Exporting...
+                  </>
+                ) : (
+                  <>
+                    <Download className="w-4 h-4" />
+                    Export as PDF
+                  </>
+                )}
+              </button>
+
               <Link
                 href="/presentation"
                 className="flex items-center gap-2 px-4 py-2 hover:bg-muted rounded-xl transition-colors"
@@ -115,54 +188,57 @@ export default function ViewPresentationPage() {
               </Link>
             </div>
           </div>
+
+          {exportError ? (
+            <div className="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+              {exportError}
+            </div>
+          ) : null}
         </div>
       </div>
 
-      {/* Slides */}
       <div className="pt-24 pb-16 max-w-6xl mx-auto px-6">
         <div className="space-y-12">
           {presentation.slides.map((slide, index) => (
-            <div 
-              key={index} 
+            <div
+              key={index}
+              data-presentation-slide
               className="bg-card rounded-[2rem] shadow-xl border border-border overflow-hidden"
             >
-              <div 
+              <div
                 className="p-12 md:p-16 min-h-[600px] flex items-center justify-center relative"
                 style={{
-                  background: slide.design?.background || 'linear-gradient(to bottom right, #3b82f6, #8b5cf6)'
+                  background:
+                    slide.design?.background ||
+                    'linear-gradient(to bottom right, #3b82f6, #8b5cf6)',
                 }}
               >
-                {/* Slide Number */}
                 <div className="absolute top-8 right-8 bg-white/20 backdrop-blur-md border border-white/30 px-4 py-2 rounded-full text-sm font-bold text-white">
                   SLIDE {slide.slideNumber}
                 </div>
 
                 <div className="max-w-5xl w-full relative z-10 text-white">
-                  {/* Title */}
                   <h2 className="text-4xl md:text-5xl font-bold mb-8 leading-tight">
                     {slide.title}
                   </h2>
 
-                  {/* Subtitle */}
                   {slide.subtitle && (
                     <p className="text-2xl md:text-3xl mb-10 font-light opacity-90">
                       {slide.subtitle}
                     </p>
                   )}
 
-                  {/* Content */}
                   {slide.content && !slide.bullets && (
                     <p className="text-xl md:text-2xl leading-relaxed opacity-90">
                       {slide.content}
                     </p>
                   )}
 
-                  {/* Bullets */}
                   {slide.bullets && slide.bullets.length > 0 && (
                     <div className="grid gap-4 mt-10">
                       {slide.bullets.map((bullet, idx) => (
-                        <div 
-                          key={idx} 
+                        <div
+                          key={idx}
                           className="flex items-start gap-4 bg-white/10 backdrop-blur-sm rounded-2xl p-6 border border-white/20"
                         >
                           <div className="flex-shrink-0 w-10 h-10 rounded-full bg-white/30 flex items-center justify-center text-lg font-bold">
@@ -181,7 +257,6 @@ export default function ViewPresentationPage() {
           ))}
         </div>
 
-        {/* Footer */}
         <div className="mt-16 text-center">
           <p className="text-muted-foreground mb-4">
             Want to create your own stunning presentations?

--- a/lib/presentation-export.ts
+++ b/lib/presentation-export.ts
@@ -1,19 +1,113 @@
-import html2canvas from 'html2canvas';
-import jsPDF from 'jspdf';
+import html2canvas from "html2canvas";
+import jsPDF from "jspdf";
 import {
-  SLIDE_LAYOUT, PAD, SAFE, SPLIT, COVER, CONTENT,
-  FONT, LINE, PARA_BEFORE, FONT_FACE, insetMargins,
-  fitTextInBox, fitBullets,
-} from '@/lib/slide-layout-tokens';
+  SLIDE_LAYOUT,
+  PAD,
+  SAFE,
+  SPLIT,
+  CONTENT,
+  FONT,
+  LINE,
+  PARA_BEFORE,
+  FONT_FACE,
+  insetMargins,
+  fitTextInBox,
+  fitBullets,
+} from "@/lib/slide-layout-tokens";
 
 /**
  * Export presentation to various formats
  */
-
 export interface ExportOptions {
-  format: 'png' | 'pdf' | 'pptx';
+  format: "png" | "pdf" | "pptx";
   quality?: number;
   includeSlideNumbers?: boolean;
+}
+
+export interface PDFExportOptions extends ExportOptions {
+  orientation?: "portrait" | "landscape";
+  targetSize?: { width: number; height: number };
+}
+
+const DEFAULT_PDF_SIZE = {
+  landscape: { width: 1920, height: 1080 },
+  portrait: { width: 1080, height: 1920 },
+} as const;
+
+async function waitForSlideResources(element: HTMLElement): Promise<void> {
+  const images = Array.from(element.querySelectorAll("img"));
+
+  await Promise.all(
+    images.map((img) =>
+      img.complete
+        ? Promise.resolve()
+        : new Promise<void>((resolve) => {
+            const done = () => resolve();
+            img.onload = done;
+            img.onerror = done;
+          })
+    )
+  );
+
+  if (typeof document !== "undefined" && document.fonts?.ready) {
+    try {
+      await document.fonts.ready;
+    } catch {
+      // Ignore font readiness failures.
+    }
+  }
+
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function getPdfPageSize(options?: PDFExportOptions) {
+  const orientation = options?.orientation === "portrait" ? "portrait" : "landscape";
+
+  if (options?.targetSize) {
+    return {
+      width: Math.max(320, Math.round(options.targetSize.width)),
+      height: Math.max(180, Math.round(options.targetSize.height)),
+    };
+  }
+
+  return DEFAULT_PDF_SIZE[orientation];
+}
+
+async function captureSlideCanvas(
+  slideElement: HTMLElement,
+  scale = 2
+): Promise<HTMLCanvasElement> {
+  const clone = slideElement.cloneNode(true) as HTMLElement;
+
+  clone.style.transform = "none";
+  clone.style.animation = "none";
+  clone.style.width = `${slideElement.clientWidth}px`;
+  clone.style.height = `${slideElement.clientHeight}px`;
+  clone.style.position = "fixed";
+  clone.style.left = "-10000px";
+  clone.style.top = "0";
+  clone.style.margin = "0";
+  clone.style.zIndex = "-1";
+  clone.style.pointerEvents = "none";
+
+  document.body.appendChild(clone);
+  try {
+    await waitForSlideResources(clone);
+    return await html2canvas(clone, {
+      scale,
+      backgroundColor: null,
+      logging: false,
+      useCORS: true,
+      allowTaint: true,
+      imageTimeout: 20000,
+      width: clone.clientWidth,
+      height: clone.clientHeight,
+      windowWidth: clone.clientWidth,
+      windowHeight: clone.clientHeight,
+    });
+  } finally {
+    document.body.removeChild(clone);
+  }
 }
 
 /**
@@ -21,31 +115,32 @@ export interface ExportOptions {
  */
 export async function exportSlideAsPNG(
   slideElement: HTMLElement,
-  slideName: string = 'slide'
+  slideName: string = "slide"
 ): Promise<void> {
   try {
     const canvas = await html2canvas(slideElement, {
       scale: 2,
-      backgroundColor: '#ffffff',
+      backgroundColor: "#ffffff",
       logging: false,
       useCORS: true,
       allowTaint: true,
-      proxy: '/api/proxy-image', // Use our proxy for external images
+      proxy: "/api/proxy-image", // Use our proxy for external images
     });
 
-    // Convert to blob and download
     canvas.toBlob((blob) => {
       if (!blob) return;
       const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
+      const link = document.createElement("a");
       link.href = url;
       link.download = `${slideName}.png`;
+      document.body.appendChild(link);
       link.click();
+      link.remove();
       URL.revokeObjectURL(url);
-    }, 'image/png', 1.0);
+    }, "image/png", 1.0);
   } catch (error) {
-    console.error('Error exporting slide as PNG:', error);
-    throw new Error('Failed to export slide as PNG');
+    console.error("Error exporting slide as PNG:", error);
+    throw new Error("Failed to export slide as PNG");
   }
 }
 
@@ -54,24 +149,33 @@ export async function exportSlideAsPNG(
  */
 export async function exportAllSlidesAsPNG(
   slideElements: HTMLElement[],
-  presentationName: string = 'presentation'
+  presentationName: string = "presentation"
 ): Promise<void> {
-  const JSZip = (await import('jszip')).default;
+  if (!slideElements.length) {
+    throw new Error("No slides to export");
+  }
+
+  const JSZip = (await import("jszip")).default;
   const zip = new JSZip();
 
   for (let i = 0; i < slideElements.length; i++) {
     try {
       const canvas = await html2canvas(slideElements[i], {
         scale: 2,
-        backgroundColor: '#ffffff',
+        backgroundColor: "#ffffff",
         logging: false,
         useCORS: true,
         allowTaint: true,
       });
 
-      // Convert canvas to blob
-      const blob = await new Promise<Blob>((resolve) => {
-        canvas.toBlob((b) => resolve(b!), 'image/png', 1.0);
+      const blob = await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((b) => {
+          if (!b) {
+            reject(new Error("Unable to create image blob"));
+            return;
+          }
+          resolve(b);
+        }, "image/png", 1.0);
       });
 
       zip.file(`slide-${i + 1}.png`, blob);
@@ -80,13 +184,14 @@ export async function exportAllSlidesAsPNG(
     }
   }
 
-  // Generate and download ZIP
-  const zipBlob = await zip.generateAsync({ type: 'blob' });
+  const zipBlob = await zip.generateAsync({ type: "blob" });
   const url = URL.createObjectURL(zipBlob);
-  const link = document.createElement('a');
+  const link = document.createElement("a");
   link.href = url;
   link.download = `${presentationName}.zip`;
+  document.body.appendChild(link);
   link.click();
+  link.remove();
   URL.revokeObjectURL(url);
 }
 
@@ -95,44 +200,56 @@ export async function exportAllSlidesAsPNG(
  */
 export async function exportAsPDF(
   slideElements: HTMLElement[],
-  presentationName: string = 'presentation'
+  presentationName: string = "presentation",
+  options: PDFExportOptions = { format: "pdf", quality: 2, orientation: "landscape" }
 ): Promise<void> {
+  if (!slideElements.length) {
+    throw new Error("No slides to export");
+  }
+
+  const pageSize = getPdfPageSize(options);
+  const orientation = options.orientation === "portrait" ? "portrait" : "landscape";
+  const pdf = new jsPDF({
+    orientation,
+    unit: "px",
+    format: [pageSize.width, pageSize.height],
+    compress: true,
+    hotfixes: ["px_scaling"],
+  });
+
   try {
-    const pdf = new jsPDF({
-      orientation: 'landscape',
-      unit: 'px',
-      format: [1920, 1080], // 16:9 aspect ratio
-    });
-
     for (let i = 0; i < slideElements.length; i++) {
-      const canvas = await html2canvas(slideElements[i], {
-        scale: 2,
-        backgroundColor: '#ffffff',
-        logging: false,
-        useCORS: true,
-        allowTaint: true,
-      });
+      const canvas = await captureSlideCanvas(slideElements[i], options.quality ?? 2);
+      const imgData = canvas.toDataURL("image/png", 1.0);
 
-      const imgData = canvas.toDataURL('image/png', 1.0);
-      
       if (i > 0) {
-        pdf.addPage();
+        pdf.addPage([pageSize.width, pageSize.height], orientation);
       }
 
-      // Add image to PDF (fill the page)
-      pdf.addImage(imgData, 'PNG', 0, 0, 1920, 1080, undefined, 'FAST');
+      const canvasRatio = canvas.width / canvas.height;
+      const pageRatio = pageSize.width / pageSize.height;
+      let drawWidth = pageSize.width;
+      let drawHeight = pageSize.height;
+
+      if (canvasRatio > pageRatio) {
+        drawHeight = Math.round(pageSize.width / canvasRatio);
+      } else {
+        drawWidth = Math.round(pageSize.height * canvasRatio);
+      }
+
+      const offsetX = Math.round((pageSize.width - drawWidth) / 2);
+      const offsetY = Math.round((pageSize.height - drawHeight) / 2);
+
+      pdf.addImage(imgData, "PNG", offsetX, offsetY, drawWidth, drawHeight, undefined, "MEDIUM");
     }
 
     pdf.save(`${presentationName}.pdf`);
   } catch (error) {
-    console.error('Error exporting as PDF:', error);
-    throw new Error('Failed to export as PDF');
+    console.error("Error exporting as PDF:", error);
+    throw new Error("Failed to export as PDF");
   }
 }
 
-/**
- * Export presentation as PPTX
- */
 /**
  * Helper to convert URL to Base64
  */
@@ -140,15 +257,15 @@ async function getBase64FromUrl(url: string): Promise<string> {
   try {
     const response = await fetch(url);
     const blob = await response.blob();
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onloadend = () => resolve(reader.result as string);
       reader.onerror = reject;
       reader.readAsDataURL(blob);
     });
   } catch (error) {
-    console.warn('Failed to convert image to base64:', error);
-    return '';
+    console.warn("Failed to convert image to base64:", error);
+    return "";
   }
 }
 
@@ -156,16 +273,14 @@ async function getBase64FromUrl(url: string): Promise<string> {
  * Helper to normalize hex color to 6 digits
  */
 function normalizeHex(hex: string): string {
-  if (!hex) return 'FFFFFF';
-  
-  // Remove hash and whitespace
-  hex = hex.replace('#', '').trim();
-  
-  // Expand 3-digit hex to 6-digit
+  if (!hex) return "FFFFFF";
+
+  hex = hex.replace("#", "").trim();
+
   if (hex.length === 3) {
-    hex = hex.split('').map(char => char + char).join('');
+    hex = hex.split("").map((char) => char + char).join("");
   }
-  
+
   return hex.toUpperCase();
 }
 
@@ -174,92 +289,84 @@ function normalizeHex(hex: string): string {
  */
 export async function exportAsPPTX(
   slideElements: HTMLElement[],
-  presentationName: string = 'presentation',
+  presentationName: string = "presentation",
   slides?: any[],
   theme?: any
 ): Promise<void> {
   try {
-    const PptxGenJS = (await import('pptxgenjs')).default;
+    const PptxGenJS = (await import("pptxgenjs")).default;
     const pptx = new PptxGenJS();
 
     pptx.layout = SLIDE_LAYOUT;
-    pptx.author = 'DraftDeckAI';
-    pptx.company = 'DraftDeckAI';
-    pptx.revision = '1';
+    pptx.author = "DraftDeckAI";
+    pptx.company = "DraftDeckAI";
+    pptx.revision = "1";
     pptx.subject = presentationName;
     pptx.title = presentationName;
 
-    // Determine Global Theme Colors
-    let globalBgColor = 'FFFFFF';
-    let globalTextColor = '000000';
+    let globalBgColor = "FFFFFF";
+    let globalTextColor = "000000";
 
-    console.log('🎨 Exporting PPTX with theme:', theme);
+    console.log("🎨 Exporting PPTX with theme:", theme);
 
     if (theme && theme.colors) {
-      // Explicit overrides for known dark themes
-      if (theme.id === 'alien' || theme.id === 'fluo' || theme.id === 'vortex' || theme.type === 'dark') {
-         // Force valid dark hexes
-         if (theme.id === 'alien') globalBgColor = '000000';
-         else if (theme.id === 'fluo') globalBgColor = '111111';
-         else if (theme.id === 'vortex') globalBgColor = '020617';
-         else globalBgColor = normalizeHex(theme.colors.background);
-         
-         // Ensure text is light
-         globalTextColor = 'FFFFFF'; 
+      if (theme.id === "alien" || theme.id === "fluo" || theme.id === "vortex" || theme.type === "dark") {
+        if (theme.id === "alien") globalBgColor = "000000";
+        else if (theme.id === "fluo") globalBgColor = "111111";
+        else if (theme.id === "vortex") globalBgColor = "020617";
+        else globalBgColor = normalizeHex(theme.colors.background);
+
+        globalTextColor = "FFFFFF";
       } else {
-         globalBgColor = normalizeHex(theme.colors.background);
-         globalTextColor = normalizeHex(theme.colors.foreground);
+        globalBgColor = normalizeHex(theme.colors.background);
+        globalTextColor = normalizeHex(theme.colors.foreground);
       }
     }
 
-    console.log('🎨 Calculated Colors - BG:', globalBgColor, 'Text:', globalTextColor);
+    console.log("🎨 Calculated Colors - BG:", globalBgColor, "Text:", globalTextColor);
 
-    // Safety check: Ensure contrast
-    if (globalBgColor === 'FFFFFF' && globalTextColor === 'FFFFFF') {
-      globalTextColor = '000000';
+    if (globalBgColor === "FFFFFF" && globalTextColor === "FFFFFF") {
+      globalTextColor = "000000";
     }
-    if ((globalBgColor === '000000' || globalBgColor === '111111' || globalBgColor === '020617') && globalTextColor === '000000') {
-      globalTextColor = 'FFFFFF';
+    if ((globalBgColor === "000000" || globalBgColor === "111111" || globalBgColor === "020617") && globalTextColor === "000000") {
+      globalTextColor = "FFFFFF";
     }
 
-    // If no structured data is provided, fall back to image capture (legacy)
     if (!slides || slides.length === 0) {
-      console.warn('No structured slide data provided, falling back to image capture');
+      console.warn("No structured slide data provided, falling back to image capture");
       for (let i = 0; i < slideElements.length; i++) {
         const canvas = await html2canvas(slideElements[i], {
           scale: 2,
-          backgroundColor: '#ffffff',
+          backgroundColor: "#ffffff",
           logging: false,
           useCORS: true,
           allowTaint: true,
         });
-        const imgData = canvas.toDataURL('image/png', 1.0);
+        const imgData = canvas.toDataURL("image/png", 1.0);
         const slide = pptx.addSlide();
-        slide.addImage({ data: imgData, x: 0, y: 0, w: '100%', h: '100%' });
+        slide.addImage({ data: imgData, x: 0, y: 0, w: "100%", h: "100%" });
       }
     } else {
-      // Native Generation
       for (const slideData of slides) {
         const slide = pptx.addSlide();
-        
-        // 1. Set Native Background Property
+
         slide.background = { color: globalBgColor };
-        
-        // 2. Add Full-Screen Rectangle (Absolute Failsafe)
-        // This physically covers the white slide with the theme color
+
         slide.addShape(pptx.ShapeType.rect, {
-          x: 0, y: 0, w: '100%', h: '100%',
+          x: 0,
+          y: 0,
+          w: "100%",
+          h: "100%",
           fill: { color: globalBgColor },
-          line: { width: 0 } // No border
+          line: { width: 0 },
         });
 
         const textColor = globalTextColor;
         const hasImage = !!slideData.imageUrl;
         const margins = insetMargins();
 
-        // Title
         const titleFit = fitTextInBox({
-          text: slideData.title || '',
+          text: slideData.title || "",
           fontSize: FONT.title,
           minFontSize: FONT.MIN_BODY,
           boxW: CONTENT.title.w,
@@ -267,35 +374,37 @@ export async function exportAsPPTX(
           lineSpacing: LINE.title,
         });
         slide.addText(slideData.title, {
-          x: CONTENT.title.x, y: CONTENT.title.y,
-          w: CONTENT.title.w, h: CONTENT.title.h,
+          x: CONTENT.title.x,
+          y: CONTENT.title.y,
+          w: CONTENT.title.w,
+          h: CONTENT.title.h,
           fontSize: titleFit.fontSize,
           bold: true,
           color: textColor,
-          align: 'center',
+          align: "center",
           fontFace: FONT_FACE,
           lineSpacingMultiple: 1.1,
           margin: margins,
         });
 
-        // Subtitle
         if (slideData.subtitle) {
           slide.addText(slideData.subtitle, {
-            x: PAD.left, y: 1.9, w: SAFE.w, h: 0.6,
+            x: PAD.left,
+            y: 1.9,
+            w: SAFE.w,
+            h: 0.6,
             fontSize: FONT.subtitle,
             color: textColor,
-            align: 'center',
+            align: "center",
             fontFace: FONT_FACE,
             margin: margins,
           });
         }
 
-        // Dynamic Y position after title area
         const bodyY = slideData.subtitle ? 2.6 : 2.0;
         const bodyW = hasImage ? SPLIT.textW : SAFE.w;
         const bodyH = hasImage ? CONTENT.bullets_split.h : CONTENT.bullets_full.h;
 
-        // Main Content
         if (slideData.content) {
           const bodyFit = fitTextInBox({
             text: slideData.content,
@@ -306,18 +415,20 @@ export async function exportAsPPTX(
             lineSpacing: LINE.body,
           });
           slide.addText(slideData.content, {
-            x: PAD.left, y: bodyY, w: bodyW, h: bodyFit.expandedH,
+            x: PAD.left,
+            y: bodyY,
+            w: bodyW,
+            h: bodyFit.expandedH,
             fontSize: bodyFit.fontSize,
             color: textColor,
-            align: 'left',
+            align: "left",
             fontFace: FONT_FACE,
-            valign: 'top',
+            valign: "top",
             lineSpacing: bodyFit.lineSpacing,
             margin: margins,
           });
         }
 
-        // Bullets
         if (slideData.bullets && slideData.bullets.length > 0) {
           const bulletFit = fitBullets({
             bullets: slideData.bullets,
@@ -330,34 +441,38 @@ export async function exportAsPPTX(
           });
           const bulletItems = slideData.bullets.map((b: string) => ({
             text: b,
-            options: { fontSize: bulletFit.fontSize, color: textColor, breakLine: true }
+            options: { fontSize: bulletFit.fontSize, color: textColor, breakLine: true },
           }));
           slide.addText(bulletItems, {
-            x: PAD.left, y: bodyY, w: bodyW, h: bulletFit.expandedH,
-            align: 'left',
+            x: PAD.left,
+            y: bodyY,
+            w: bodyW,
+            h: bulletFit.expandedH,
+            align: "left",
             bullet: true,
             fontFace: FONT_FACE,
-            valign: 'top',
+            valign: "top",
             lineSpacing: bulletFit.lineSpacing,
             paraSpaceBefore: PARA_BEFORE.bullet,
             margin: margins,
           });
         }
 
-        // Image
         if (slideData.imageUrl) {
           try {
             const base64Data = await getBase64FromUrl(slideData.imageUrl);
             if (base64Data) {
               slide.addImage({
                 data: base64Data,
-                x: CONTENT.image.x, y: CONTENT.image.y,
-                w: CONTENT.image.w, h: CONTENT.image.h,
-                sizing: { type: 'contain', w: CONTENT.image.w, h: CONTENT.image.h }
+                x: CONTENT.image.x,
+                y: CONTENT.image.y,
+                w: CONTENT.image.w,
+                h: CONTENT.image.h,
+                sizing: { type: "contain", w: CONTENT.image.w, h: CONTENT.image.h },
               });
             }
           } catch (err) {
-            console.error('Failed to add image to slide:', err);
+            console.error("Failed to add image to slide:", err);
           }
         }
       }
@@ -365,8 +480,8 @@ export async function exportAsPPTX(
 
     await pptx.writeFile({ fileName: `${presentationName}.pptx` });
   } catch (error) {
-    console.error('Error exporting as PPTX:', error);
-    throw new Error('Failed to export as PPTX');
+    console.error("Error exporting as PPTX:", error);
+    throw new Error("Failed to export as PPTX");
   }
 }
 
@@ -381,11 +496,11 @@ export async function exportPresentation(
   theme?: any
 ): Promise<void> {
   if (slideElements.length === 0) {
-    throw new Error('No slides to export');
+    throw new Error("No slides to export");
   }
 
   switch (options.format) {
-    case 'png':
+    case "png":
       if (slideElements.length === 1) {
         await exportSlideAsPNG(slideElements[0], presentationName);
       } else {
@@ -393,11 +508,15 @@ export async function exportPresentation(
       }
       break;
 
-    case 'pdf':
-      await exportAsPDF(slideElements, presentationName);
+    case "pdf":
+      await exportAsPDF(slideElements, presentationName, {
+        format: "pdf",
+        quality: options.quality ?? 2,
+        orientation: "landscape",
+      });
       break;
 
-    case 'pptx':
+    case "pptx":
       await exportAsPPTX(slideElements, presentationName, slides, theme);
       break;
 


### PR DESCRIPTION
## Description

Adds PDF export functionality to the presentation viewer so users can download presentations for offline viewing, printing, and sharing.

Fixes #652

## Type of Change

* [x] New feature (e.g., new page, component, or functionality)

## Changes Made

* Added Export as PDF button in the presentation viewer
* Added portrait and landscape orientation support for PDF exports
* Added loading state during PDF generation
* Added inline error handling for failed exports
* Added multi-slide PDF export support
* Preserved slide styling, layout, colors, and fonts using html2canvas and jsPDF
* Added slide detection using `data-presentation-slide` attributes

## Dependencies

* Uses `html2canvas` for slide rendering
* Uses `jsPDF` for PDF generation

## Checklist

* [x] My code follows the style guidelines of this project.
* [x] I have tested my changes in development mode (`npm run dev`)
* [x] This is already assigned Issue to me, not an unassigned issue.
