### PR TITLE
feat(hooks): add reusable useShare hook and refactor share duplication (#660)

### DIFF
--- a/app/diagram/page.tsx
+++ b/app/diagram/page.tsx
@@ -3,52 +3,27 @@ import { SiteHeader } from "@/components/site-header";
 import { DiagramGenerator } from "@/components/diagram/diagram-generator";
 import { CreateDocumentGuard } from "@/components/ui/auth-guard";
 import { Sparkles, Workflow, Zap, Star, Wand2, Share2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { DiagramGeneratorSkeleton } from "@/components/ui/skeleton";
-import { useToast } from "@/hooks/use-toast";
+import { useShare } from "@/hooks/use-share";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 export default function DiagramPage() {
   const [isLoading, setIsLoading] = useState(true);
-  const [copied, setCopied] = useState(false);
-  const { toast } = useToast();
+
+  const { copied, shareViaWebShare } = useShare();
 
   useEffect(() => {
-    // Simulate loading
     const timer = setTimeout(() => setIsLoading(false), 1500);
     return () => clearTimeout(timer);
   }, []);
-  const handleShare = async () => {
-    try {
-      const shareData = {
-        title: 'DraftDeckAI Diagram Studio',
-        text: 'Create visual diagrams and flowcharts with AI guidance!',
-        url: window.location.href
-      };
-      
-      if (navigator.share) {
-        await navigator.share(shareData);
-      } else {
-        await navigator.clipboard.writeText(window.location.href);
-        setCopied(true);
-        setTimeout(() => {
-          setCopied(false);
-        }, 2000);
-        toast({
-          title: "Link copied!",
-          description: "Diagram Studio link has been copied to your clipboard",
-        });
-      }
-    } catch (error) {
-      if ((error as Error).name !== 'AbortError') {
-        toast({
-          title: "Share failed",
-          description: "Failed to share diagram studio link. Please try again.",
-          variant: "destructive",
-        });
-      }
-    }
-  };
+
+  const handleShare = useCallback(() => {
+    shareViaWebShare({
+      title: "DraftDeckAI Diagram Studio",
+      text: "Create visual diagrams and flowcharts with AI guidance!",
+    });
+  }, [shareViaWebShare]);
 
   return (
     <div className="min-h-screen flex flex-col relative overflow-hidden">

--- a/components/resume/resume-generator.tsx
+++ b/components/resume/resume-generator.tsx
@@ -16,6 +16,7 @@ import { ResumeTemplates } from "@/components/resume/resume-templates";
 import { GuidedResumeGenerator } from "@/components/resume/guided-resume-generator";
 import { LinkedInImport } from "@/components/resume/linkedin-import";
 import { useToast } from "@/hooks/use-toast";
+import { useShare } from "@/hooks/use-share";
 import {
   File as FileIcon,
   Loader2,
@@ -359,80 +360,21 @@ export function ResumeGenerator({ initialSession }: { initialSession?: any }) {
     }
   };
 
-  const copyShareLink = async () => {
-    if (!shareUrl) return;
-
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-      toast({
-        title: "Link copied!",
-        description: "Share link has been copied to your clipboard",
-      });
-    } catch (error) {
-      toast({
-        title: "Failed to copy",
-        description: "Please copy the URL manually",
-        variant: "destructive",
-      });
-    }
-  };
-
-  const shareViaEmail = () => {
-    const subject = encodeURIComponent('Check out my resume!');
-    const body = encodeURIComponent(`I wanted to share my professional resume with you:\\n\\n${shareUrl}`);
-    window.open(`mailto:?subject=${subject}&body=${body}`, '_blank');
-  };
-
-  const shareViaWhatsApp = () => {
-    const text = encodeURIComponent(`Check out my resume: ${shareUrl}`);
-    window.open(`https://wa.me/?text=${text}`, '_blank');
-  };
-
-  const shareViaTwitter = () => {
-    const text = encodeURIComponent('Check out my professional resume!');
-    const url = encodeURIComponent(shareUrl);
-    window.open(`https://twitter.com/intent/tweet?text=${text}&url=${url}`, '_blank');
-  };
-
-  const shareViaLinkedIn = () => {
-    const url = encodeURIComponent(shareUrl);
-    window.open(`https://www.linkedin.com/sharing/share-offsite/?url=${url}`, '_blank');
-  };
-
-  const shareViaFacebook = () => {
-    const url = encodeURIComponent(shareUrl);
-    window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, '_blank');
-  };
-
-  const shareViaTelegram = () => {
-    const text = encodeURIComponent('Check out my resume!');
-    const url = encodeURIComponent(shareUrl);
-    window.open(`https://t.me/share/url?url=${url}&text=${text}`, '_blank');
-  };
-
-  const shareViaWebShare = async () => {
-    if (navigator.share) {
-      try {
-        await navigator.share({
-          title: 'My Resume',
-          text: 'Check out my professional resume!',
-          url: shareUrl
-        });
-        toast({
-          title: "Shared successfully!",
-          description: "Resume shared via Web Share API",
-        });
-      } catch (error) {
-        // User cancelled sharing
-      }
-    } else {
-      toast({
-        title: "Not supported",
-        description: "Web Share API is not supported on this device",
-        variant: "destructive",
-      });
-    }
-  };
+  const {
+    copyToClipboard: copyShareLink,
+    shareViaEmail,
+    shareViaWhatsApp,
+    shareViaTwitter,
+    shareViaLinkedIn,
+    shareViaFacebook,
+    shareViaTelegram,
+    shareViaWebShare,
+  } = useShare(shareUrl, {
+    emailSubject: "Check out my resume!",
+    emailBody: `I wanted to share my professional resume with you:\n\n${shareUrl}`,
+    text: "Check out my professional resume!",
+    title: "My Resume",
+  });
 
   return (
     <>

--- a/hooks/use-share.ts
+++ b/hooks/use-share.ts
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useToast } from "@/hooks/use-toast";
+
+/**
+ * Configuration options for the useShare hook.
+ * All fields are optional; sensible defaults are applied when omitted.
+ */
+export interface ShareConfig {
+  /** Default URL to share. Falls back to window.location.href when not provided. */
+  url?: string;
+  /** Title used for the Web Share API and as a subject hint for social platforms. */
+  title?: string;
+  /** Short descriptive text sent to social sharing targets. */
+  text?: string;
+  /** Subject line for the mailto share. */
+  emailSubject?: string;
+  /**
+   * Body text for the mailto share (plain text, no HTML).
+   * If omitted the resolved URL is appended automatically.
+   */
+  emailBody?: string;
+}
+
+export interface UseShareReturn {
+  /** True for two seconds after a successful clipboard copy. */
+  copied: boolean;
+  copyToClipboard: (url?: string) => Promise<void>;
+  shareViaEmail: (config?: Pick<ShareConfig, "url" | "emailSubject" | "emailBody">) => void;
+  shareViaWhatsApp: (config?: Pick<ShareConfig, "url" | "text">) => void;
+  shareViaTwitter: (config?: Pick<ShareConfig, "url" | "text">) => void;
+  shareViaLinkedIn: (url?: string) => void;
+  shareViaFacebook: (url?: string) => void;
+  shareViaTelegram: (config?: Pick<ShareConfig, "url" | "text">) => void;
+  shareViaWebShare: (config?: Pick<ShareConfig, "url" | "title" | "text">) => Promise<void>;
+}
+
+/**
+ * useShare provides a single, reusable set of social-sharing utilities that
+ * can be dropped into any component. It encapsulates clipboard access, all
+ * seven supported share targets, the Web Share API wrapper, and success or
+ * failure toast notifications so callers do not need to duplicate that logic.
+ *
+ * @param defaultUrl  URL shared by default. Falls back to window.location.href.
+ * @param defaults    Default text/title/subject used when a caller omits them.
+ */
+export function useShare(
+  defaultUrl?: string,
+  defaults?: Omit<ShareConfig, "url">
+): UseShareReturn {
+  const [copied, setCopied] = useState(false);
+  const { toast } = useToast();
+
+  const resolveUrl = useCallback(
+    (override?: string): string =>
+      override ??
+      defaultUrl ??
+      (typeof window !== "undefined" ? window.location.href : ""),
+    [defaultUrl]
+  );
+
+  const copyToClipboard = useCallback(
+    async (url?: string) => {
+      const target = resolveUrl(url);
+      if (!target) return;
+      try {
+        await navigator.clipboard.writeText(target);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+        toast({
+          title: "Link copied!",
+          description: "Share link has been copied to your clipboard",
+        });
+      } catch {
+        toast({
+          title: "Failed to copy",
+          description: "Please copy the URL manually",
+          variant: "destructive",
+        });
+      }
+    },
+    [resolveUrl, toast]
+  );
+
+  const shareViaEmail = useCallback(
+    (config?: Pick<ShareConfig, "url" | "emailSubject" | "emailBody">) => {
+      const url = resolveUrl(config?.url);
+      const subject = encodeURIComponent(
+        config?.emailSubject ?? defaults?.emailSubject ?? "Check this out!"
+      );
+      const body = encodeURIComponent(
+        config?.emailBody ??
+          defaults?.emailBody ??
+          `I wanted to share this link with you:\n\n${url}`
+      );
+      window.open(`mailto:?subject=${subject}&body=${body}`, "_blank");
+    },
+    [resolveUrl, defaults?.emailSubject, defaults?.emailBody]
+  );
+
+  const shareViaWhatsApp = useCallback(
+    (config?: Pick<ShareConfig, "url" | "text">) => {
+      const url = resolveUrl(config?.url);
+      const text = encodeURIComponent(
+        config?.text ?? defaults?.text ?? `Check this out: ${url}`
+      );
+      window.open(`https://wa.me/?text=${text}`, "_blank");
+    },
+    [resolveUrl, defaults?.text]
+  );
+
+  const shareViaTwitter = useCallback(
+    (config?: Pick<ShareConfig, "url" | "text">) => {
+      const url = resolveUrl(config?.url);
+      const text = encodeURIComponent(
+        config?.text ?? defaults?.text ?? "Check this out!"
+      );
+      const encodedUrl = encodeURIComponent(url);
+      window.open(
+        `https://twitter.com/intent/tweet?text=${text}&url=${encodedUrl}`,
+        "_blank"
+      );
+    },
+    [resolveUrl, defaults?.text]
+  );
+
+  const shareViaLinkedIn = useCallback(
+    (url?: string) => {
+      const encodedUrl = encodeURIComponent(resolveUrl(url));
+      window.open(
+        `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+        "_blank"
+      );
+    },
+    [resolveUrl]
+  );
+
+  const shareViaFacebook = useCallback(
+    (url?: string) => {
+      const encodedUrl = encodeURIComponent(resolveUrl(url));
+      window.open(
+        `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+        "_blank"
+      );
+    },
+    [resolveUrl]
+  );
+
+  const shareViaTelegram = useCallback(
+    (config?: Pick<ShareConfig, "url" | "text">) => {
+      const url = resolveUrl(config?.url);
+      const text = encodeURIComponent(
+        config?.text ?? defaults?.text ?? "Check this out!"
+      );
+      const encodedUrl = encodeURIComponent(url);
+      window.open(
+        `https://t.me/share/url?url=${encodedUrl}&text=${text}`,
+        "_blank"
+      );
+    },
+    [resolveUrl, defaults?.text]
+  );
+
+  const shareViaWebShare = useCallback(
+    async (config?: Pick<ShareConfig, "url" | "title" | "text">) => {
+      const url = resolveUrl(config?.url);
+      if (navigator.share) {
+        try {
+          await navigator.share({
+            title: config?.title ?? defaults?.title ?? "Shared via DraftDeckAI",
+            text: config?.text ?? defaults?.text ?? "Check this out!",
+            url,
+          });
+          toast({
+            title: "Shared successfully!",
+            description: "Content shared via Web Share API",
+          });
+        } catch (error) {
+          if ((error as Error).name !== "AbortError") {
+            toast({
+              title: "Share failed",
+              description: "An error occurred while sharing. Please try again.",
+              variant: "destructive",
+            });
+          }
+        }
+      } else {
+        await copyToClipboard(url);
+      }
+    },
+    [resolveUrl, defaults?.title, defaults?.text, copyToClipboard, toast]
+  );
+
+  return {
+    copied,
+    copyToClipboard,
+    shareViaEmail,
+    shareViaWhatsApp,
+    shareViaTwitter,
+    shareViaLinkedIn,
+    shareViaFacebook,
+    shareViaTelegram,
+    shareViaWebShare,
+  };
+}

--- a/hooks/use-share.ts
+++ b/hooks/use-share.ts
@@ -23,17 +23,36 @@ export interface ShareConfig {
   emailBody?: string;
 }
 
+/** Public API returned by the useShare hook. */
 export interface UseShareReturn {
   /** True for two seconds after a successful clipboard copy. */
   copied: boolean;
+  /** Copies the given URL (or the hook default) to the clipboard. */
   copyToClipboard: (url?: string) => Promise<void>;
+  /** Opens a mailto: link with an optional subject and body. */
   shareViaEmail: (config?: Pick<ShareConfig, "url" | "emailSubject" | "emailBody">) => void;
+  /** Opens WhatsApp Web with the resolved URL always appended to the message text. */
   shareViaWhatsApp: (config?: Pick<ShareConfig, "url" | "text">) => void;
+  /** Opens the Twitter/X intent page with text and URL. */
   shareViaTwitter: (config?: Pick<ShareConfig, "url" | "text">) => void;
+  /** Opens the LinkedIn share dialog for the given URL. */
   shareViaLinkedIn: (url?: string) => void;
+  /** Opens the Facebook sharer for the given URL. */
   shareViaFacebook: (url?: string) => void;
+  /** Opens Telegram share with the resolved URL and optional text. */
   shareViaTelegram: (config?: Pick<ShareConfig, "url" | "text">) => void;
+  /** Uses the native Web Share API when available, falling back to clipboard copy. */
   shareViaWebShare: (config?: Pick<ShareConfig, "url" | "title" | "text">) => Promise<void>;
+}
+
+/**
+ * Opens a URL in a new tab with rel="noopener noreferrer" semantics to
+ * prevent the opened page from accessing window.opener.
+ *
+ * @param url - The URL to open.
+ */
+function openInNewTab(url: string): void {
+  window.open(url, "_blank", "noopener,noreferrer");
 }
 
 /**
@@ -52,9 +71,14 @@ export function useShare(
   const [copied, setCopied] = useState(false);
   const { toast } = useToast();
 
+  /**
+   * Resolves the URL to share. Only accepts a plain string override;
+   * non-string values (e.g. event objects) are ignored and fall through
+   * to defaultUrl or window.location.href.
+   */
   const resolveUrl = useCallback(
     (override?: string): string =>
-      override ??
+      (typeof override === "string" ? override : undefined) ??
       defaultUrl ??
       (typeof window !== "undefined" ? window.location.href : ""),
     [defaultUrl]
@@ -94,7 +118,7 @@ export function useShare(
           defaults?.emailBody ??
           `I wanted to share this link with you:\n\n${url}`
       );
-      window.open(`mailto:?subject=${subject}&body=${body}`, "_blank");
+      openInNewTab(`mailto:?subject=${subject}&body=${body}`);
     },
     [resolveUrl, defaults?.emailSubject, defaults?.emailBody]
   );
@@ -102,10 +126,11 @@ export function useShare(
   const shareViaWhatsApp = useCallback(
     (config?: Pick<ShareConfig, "url" | "text">) => {
       const url = resolveUrl(config?.url);
-      const text = encodeURIComponent(
-        config?.text ?? defaults?.text ?? `Check this out: ${url}`
-      );
-      window.open(`https://wa.me/?text=${text}`, "_blank");
+      const baseText = config?.text ?? defaults?.text ?? "Check this out:";
+      // Always append the URL so it is included even when defaults.text is set.
+      const combined = baseText.includes(url) ? baseText : `${baseText} ${url}`;
+      const text = encodeURIComponent(combined);
+      openInNewTab(`https://wa.me/?text=${text}`);
     },
     [resolveUrl, defaults?.text]
   );
@@ -117,9 +142,8 @@ export function useShare(
         config?.text ?? defaults?.text ?? "Check this out!"
       );
       const encodedUrl = encodeURIComponent(url);
-      window.open(
-        `https://twitter.com/intent/tweet?text=${text}&url=${encodedUrl}`,
-        "_blank"
+      openInNewTab(
+        `https://twitter.com/intent/tweet?text=${text}&url=${encodedUrl}`
       );
     },
     [resolveUrl, defaults?.text]
@@ -128,9 +152,8 @@ export function useShare(
   const shareViaLinkedIn = useCallback(
     (url?: string) => {
       const encodedUrl = encodeURIComponent(resolveUrl(url));
-      window.open(
-        `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
-        "_blank"
+      openInNewTab(
+        `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`
       );
     },
     [resolveUrl]
@@ -139,9 +162,8 @@ export function useShare(
   const shareViaFacebook = useCallback(
     (url?: string) => {
       const encodedUrl = encodeURIComponent(resolveUrl(url));
-      window.open(
-        `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
-        "_blank"
+      openInNewTab(
+        `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`
       );
     },
     [resolveUrl]
@@ -154,9 +176,8 @@ export function useShare(
         config?.text ?? defaults?.text ?? "Check this out!"
       );
       const encodedUrl = encodeURIComponent(url);
-      window.open(
-        `https://t.me/share/url?url=${encodedUrl}&text=${text}`,
-        "_blank"
+      openInNewTab(
+        `https://t.me/share/url?url=${encodedUrl}&text=${text}`
       );
     },
     [resolveUrl, defaults?.text]


### PR DESCRIPTION
## Summary

Closes #660. Share functionality was duplicated across at least two components (`components/resume/resume-generator.tsx` with 8 share functions, `app/diagram/page.tsx` with its own `handleShare` function). This PR extracts all of it into a single `useShare` hook.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor (non-breaking change that improves code quality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes

### `hooks/use-share.ts` (new file)

A generic, reusable React hook that exposes:

| Export | Description |
|--------|-------------|
| `copyToClipboard(url?)` | Writes to the Clipboard API; shows a success or error toast. Sets `copied: true` for 2 seconds. |
| `shareViaEmail(config?)` | Opens a `mailto:` link with configurable subject and body. |
| `shareViaWhatsApp(config?)` | Opens `wa.me` with encoded text; the resolved URL is always appended. |
| `shareViaTwitter(config?)` | Opens the Twitter intent URL. |
| `shareViaLinkedIn(url?)` | Opens LinkedIn share offsite. |
| `shareViaFacebook(url?)` | Opens Facebook sharer. |
| `shareViaTelegram(config?)` | Opens Telegram share URL. |
| `shareViaWebShare(config?)` | Calls `navigator.share`; falls back to `copyToClipboard` when the API is unavailable. |
| `copied` | Boolean true for 2 s after a clipboard copy. |

Each function accepts per-call overrides for `url`, `title`, and `text`, and picks up component-level defaults from the hook's second argument before falling back to generic strings.

### `components/resume/resume-generator.tsx`

- Added import of `useShare`.
- Replaced the 8 inline share functions with a single `useShare(shareUrl, defaults)` call.

### `app/diagram/page.tsx`

- Removed `useState` for `copied` and the inline `handleShare` async function.
- Added `useShare()`, destructuring `copied` and `shareViaWebShare`.
- Removed the now-redundant `useToast` import.

## Before and after (diagram page)

**Before (42 lines):**
```tsx
const [copied, setCopied] = useState(false);
const { toast } = useToast();

const handleShare = async () => {
  try {
    const shareData = { title: '...', text: '...', url: window.location.href };
    if (navigator.share) {
      await navigator.share(shareData);
    } else {
      await navigator.clipboard.writeText(window.location.href);
      setCopied(true);
      setTimeout(() => setCopied(false), 2000);
      toast({ title: "Link copied!", ... });
    }
  } catch (error) {
    if ((error as Error).name !== 'AbortError') {
      toast({ title: "Share failed", ..., variant: "destructive" });
    }
  }
};
```

**After (8 lines):**
```tsx
const { copied, shareViaWebShare } = useShare();
const handleShare = useCallback(() => {
  shareViaWebShare({
    title: "DraftDeckAI Diagram Studio",
    text: "Create visual diagrams and flowcharts with AI guidance!",
  });
}, [shareViaWebShare]);
```

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review of code changes completed
- [x] No new warnings introduced
- [x] All share handlers use `noopener,noreferrer` to prevent window.opener exposure
- [x] `resolveUrl` guards against non-string overrides (e.g. event objects)
- [x] WhatsApp share always includes the resolved URL in the message text
- [ ] Unit tests added or updated (covered by issue #663 test suite)