### PR TITLE
fix(theme): persist theme preference, respect system default, prevent FOUC (#654)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,6 +21,17 @@ export const metadata: Metadata = {
   description:
     "Create beautiful resumes, presentations, CVs and letters with AI",
 };
+
+/**
+ * Inline script injected into <head> to apply the correct theme class
+ * before the first paint, preventing a flash of the wrong color scheme.
+ *
+ * It reads the same localStorage key ("theme") that next-themes uses,
+ * so the two are always in sync. The script must be a plain string
+ * (not a module) so the browser executes it synchronously.
+ */
+const themeScript = `(function(){try{var s=localStorage.getItem('theme');var d=document.documentElement;if(s==='dark'){d.classList.add('dark');}else if(s==='light'){d.classList.remove('dark');}else{if(window.matchMedia('(prefers-color-scheme: dark)').matches){d.classList.add('dark');}else{d.classList.remove('dark');}}}catch(e){}})();`;
+
 export default function RootLayout({
   children,
 }: {
@@ -29,6 +40,8 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Blocking theme script -- must be first in <head> to prevent FOUC */}
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
         <link rel="manifest" href="/manifest.json" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <link

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -27,9 +27,10 @@ export function Providers({ children }: { children: ReactNode }) {
       <AuthProvider>
         <ThemeProvider
           attribute="class"
-          defaultTheme="light"
-          enableSystem={true}
-          disableTransitionOnChange={false}
+          defaultTheme="system"
+          enableSystem
+          storageKey="theme"
+          disableTransitionOnChange
         >
           <TooltipProvider>
             <ToastProvider>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 export const ThemeToggle = React.forwardRef<HTMLButtonElement>((props, ref) => {
-  const { setTheme, theme, resolvedTheme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -25,9 +25,7 @@ export const ThemeToggle = React.forwardRef<HTMLButtonElement>((props, ref) => {
   }
 
   const handleToggle = () => {
-    console.log("Theme toggle clicked!", { resolvedTheme });
-    const newTheme = resolvedTheme === "dark" ? "light" : "dark";
-    setTheme(newTheme);
+    setTheme(resolvedTheme === "dark" ? "light" : "dark");
   };
 
   return (
@@ -38,7 +36,7 @@ export const ThemeToggle = React.forwardRef<HTMLButtonElement>((props, ref) => {
       className="rounded-full cursor-pointer relative z-10"
       onClick={handleToggle}
       aria-label={`Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode`}
-      style={{ pointerEvents: 'auto' }}
+      style={{ pointerEvents: "auto" }}
       {...props}
     >
       <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />


### PR DESCRIPTION
Closes #654

## Root cause

Three separate problems combined to produce the reported symptom.

### 1. Flash of wrong theme on page load (main cause of perceived non-persistence)

`next-themes` persists the user choice to `localStorage` correctly, but the server-side render has no access to `localStorage`. Every SSR response is sent with no `dark` class on `<html>`. When JavaScript loads and `next-themes` reads the stored preference, it adds the class, but by then the browser has already painted the light-themed page. Users see a brief flash of the wrong theme and reasonably conclude the preference was not saved.

**Fix (`app/layout.tsx`):** A small blocking inline script is placed as the very first child of `<head>`. Because it is a synchronous script, the browser executes it before any paint. It reads `localStorage.getItem('theme')` (the same key `next-themes` uses) and immediately sets or removes the `dark` class on `<html>`. The script is minified, wrapped in an IIFE, and guarded with `try/catch` so it never throws in environments where `localStorage` is unavailable.

### 2. System preference not respected on first visit

`defaultTheme="light"` was hardcoded in the `ThemeProvider`. A user visiting for the first time with their OS set to dark mode would always get the light theme until they manually toggled it.

**Fix (`app/providers.tsx`):**
- `defaultTheme` changed from `"light"` to `"system"`.
- `storageKey` set explicitly to `"theme"` so it matches the inline script exactly.
- `disableTransitionOnChange` enabled to prevent CSS transitions from animating the theme swap on initial load, which was itself visible as a flash.

### 3. Debug `console.log` in toggle handler

`console.log("Theme toggle clicked!", { resolvedTheme })` was left in the production code path.

**Fix (`components/theme-toggle.tsx`):** The `console.log` call is removed. The toggle logic is otherwise unchanged.

## Files changed

| File | Change |
|------|--------|
| `app/layout.tsx` | Add blocking FOUC-prevention `<script>` as first child of `<head>` |
| `app/providers.tsx` | `defaultTheme="system"`, explicit `storageKey`, `disableTransitionOnChange` |
| `components/theme-toggle.tsx` | Remove debug `console.log` |

## Verification checklist

- [ ] Set theme to dark, refresh the page: dark theme appears immediately with no flash
- [ ] Clear `localStorage`, visit with OS dark mode: site opens in dark theme
- [ ] Clear `localStorage`, visit with OS light mode: site opens in light theme
- [ ] Toggle theme and open a new tab: new tab respects the stored preference
- [ ] Browser console shows no theme-related log output
- [ ] Toggle animation still works after the fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced theme preference handling with improved localStorage integration and system preference fallback detection.

* **Bug Fixes**
  * Eliminated initial theme flash by injecting theme detection before page render.

* **Refactor**
  * Optimized theme toggle component and provider configuration for improved performance and code clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->