### PR TITLE
fix: await dispatchErrorAlert and captureException to prevent unhandled promise (closes #699)

### DIFF
--- a/app/api/error-test/route.ts
+++ b/app/api/error-test/route.ts
@@ -34,7 +34,7 @@ async function handler(request: NextRequest) {
       try {
         throw new DatabaseError(`Mock Spike Error #${i} for alert threshold verification.`);
       } catch (err) {
-        captureException(err, {
+        await captureException(err, {
           requestId: `mock-spike-id-${i}-${Date.now()}`,
           path: '/api/error-test',
           method: 'GET',

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -194,7 +194,7 @@ function dispatchSpikeAlert(rate: number, total: number, errors: number) {
  * ==========================================
  */
 
-export function captureException(error: any, requestContext: {
+export async function captureException(error: any, requestContext: {
   requestId: string;
   path: string;
   method: string;
@@ -277,7 +277,7 @@ export function captureException(error: any, requestContext: {
   }
 
   // 4. Alert Routing
-  dispatchErrorAlert(errorDetails);
+  await dispatchErrorAlert(errorDetails);
 
   return errorDetails;
 }
@@ -359,7 +359,7 @@ export function withErrorHandling(handler: ApiHandler): ApiHandler {
       }
 
       // Capture and track exception details
-      const caughtDetails = captureException(error, requestContext);
+      const caughtDetails = await captureException(error, requestContext);
 
       // Standardized production-grade error response
       const isOperational = error instanceof AppError && error.isOperational;

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -163,13 +163,17 @@ export async function dispatchErrorAlert(errorDetails: any) {
   // If Slack Webhook is configured
   if (process.env.SLACK_WEBHOOK_URL) {
     try {
-      await fetch(process.env.SLACK_WEBHOOK_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          text: `*${alertPayload.title}*\n*Endpoint:* ${alertPayload.endpoint}\n*Request ID:* \`${alertPayload.requestId}\`\n*Environment:* \`${alertPayload.environment}\``,
-        }),
-      });
+const res = await fetch(process.env.SLACK_WEBHOOK_URL, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    text: `*${alertPayload.title}*\n*Endpoint:* ${alertPayload.endpoint}\n*Request ID:* \`${alertPayload.requestId}\`\n*Environment:* \`${alertPayload.environment}\``,
+  }),
+  signal: AbortSignal.timeout(5000),
+});
+if (!res.ok) {
+  logger.error(null, `Slack alert failed: ${res.status} ${res.statusText}`);
+}
     } catch (e) {
       logger.error(null, 'Failed to dispatch Slack alert', e);
     }

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -163,17 +163,17 @@ export async function dispatchErrorAlert(errorDetails: any) {
   // If Slack Webhook is configured
   if (process.env.SLACK_WEBHOOK_URL) {
     try {
-const res = await fetch(process.env.SLACK_WEBHOOK_URL, {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({
-    text: `*${alertPayload.title}*\n*Endpoint:* ${alertPayload.endpoint}\n*Request ID:* \`${alertPayload.requestId}\`\n*Environment:* \`${alertPayload.environment}\``,
-  }),
-  signal: AbortSignal.timeout(5000),
-});
-if (!res.ok) {
-  logger.error(null, `Slack alert failed: ${res.status} ${res.statusText}`);
-}
+      const res = await fetch(process.env.SLACK_WEBHOOK_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          text: `...`,
+        }),
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!res.ok) {
+        logger.error(null, `Slack alert failed: ${res.status} ${res.statusText}`);
+      }
     } catch (e) {
       logger.error(null, 'Failed to dispatch Slack alert', e);
     }


### PR DESCRIPTION
Closes #699

## What this PR does
Fixes the unhandled promise rejection caused by calling `dispatchErrorAlert` without `await`.

## Changes
- `lib/error-handler.ts`: added `await` to `dispatchErrorAlert(errorDetails)` call at line 280
- `lib/error-handler.ts`: made `captureException` async since it now uses `await` internally
- `lib/error-handler.ts`: added `await` to `captureException` call at line 362
- `app/api/error-test/route.ts`: added `await` to `captureException` call

## Why
Without `await`, if the Slack webhook request inside `dispatchErrorAlert` fails, the error is silently swallowed with no way to debug it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure error capture and alert dispatch fully complete before sending error responses, improving reliability and determinism.
  * Add timeout and failure logging for outgoing alert notifications to surface webhook delivery issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->