### PR TITLE
fix: replace global setInterval with lazy pruning to prevent memory leak (closes #698)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -81,10 +81,10 @@ const RL = {
 type RLKey = keyof typeof RL;
 
 const store = new Map<string, { count: number; reset: number }>();
-setInterval(() => {
+function pruneStore() {
   const now = Date.now();
   for (const [k, d] of store) if (now > d.reset) store.delete(k);
-}, 60_000);
+}
 
 function rlKey(p: string): RLKey {
   // Strip version prefix so /api/v1/generate/... and /api/generate/... share the same bucket
@@ -95,6 +95,7 @@ function rlKey(p: string): RLKey {
 }
 
 function checkRL(ip: string, pathname: string) {
+  pruneStore();
   const k = rlKey(pathname);
   const cfg = RL[k];
   const now = Date.now();


### PR DESCRIPTION
Closes #698

## What this PR does
Removes the global `setInterval` in `middleware.ts` that caused timer accumulation during cold starts or worker restarts in serverless environments.

## Changes
- Replaced `setInterval` with a `pruneStore()` function
- `pruneStore()` is called lazily on every rate-limit check instead of running on a global timer
- No behaviour change — expired entries are still cleaned up, just on-demand instead of every 60s

## Why
In serverless/edge environments, each cold start re-evaluates the module and registers a new global timer, causing uncontrolled timer accumulation and memory leaks.