### PR TITLE
fix: replace placeholder Vercel URL with env var in allowedOrigins (closes #697)

### DIFF
--- a/lib/security.ts
+++ b/lib/security.ts
@@ -192,7 +192,7 @@ export function isAllowedOrigin(origin: string | null, host: string): boolean {
   const allowedOrigins = [
     `https://${host}`,
     'https://draftdeckai.com',
-    ...(process.env.NEXT_PUBLIC_VERCEL_URL ? [`https://${process.env.NEXT_PUBLIC_VERCEL_URL}`] : []),
+    ...(process.env.NEXT_PUBLIC_VERCEL_URL ? [`https://${process.env.NEXT_PUBLIC_VERCEL_URL.replace(/^https?:\/\//, '')}`] : []),
   ];
 
   if (process.env.NODE_ENV === 'development') {

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -192,7 +192,7 @@ export function isAllowedOrigin(origin: string | null, host: string): boolean {
   const allowedOrigins = [
     `https://${host}`,
     'https://draftdeckai.com',
-    'https://your-vercel-url.vercel.app',
+    ...(process.env.NEXT_PUBLIC_VERCEL_URL ? [`https://${process.env.NEXT_PUBLIC_VERCEL_URL}`] : []),
   ];
 
   if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
Closes #697

## What this PR does
Removes the hardcoded placeholder `https://your-vercel-url.vercel.app` from the `allowedOrigins` array in `lib/security.ts`.

## Changes
- Replaced the placeholder string with `process.env.NEXT_PUBLIC_VERCEL_URL`
- Uses spread syntax to safely skip the entry if the env var is not set
- No placeholder URLs remain in production origin validation

## Why
A placeholder URL in the allowedOrigins whitelist weakens origin validation and may unintentionally allow unauthorized origins in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cross-origin request validation to use dynamic environment-aware configuration for determining allowed origins, improving application security and stability across different deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->