### PR TITLE
fix: remove hardcoded developer bypass email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,4 @@ NEXT_PUBLIC_NETLIFY_URL=https://your-netlify-project-url.netlify.app
 
 # ENVIRONMENT
 NODE_ENV=development
+DEVELOPER_BYPASS_EMAILS=

--- a/lib/credits-service.ts
+++ b/lib/credits-service.ts
@@ -68,9 +68,9 @@ export const TIER_FEATURES: Record<Tier, string[]> = {
 };
 
 // Developer/testing credit bypass
-const DEVELOPER_BYPASS_EMAILS = new Set([
-  'alimuneerali245@gmail.com',
-]);
+const DEVELOPER_BYPASS_EMAILS = new Set(
+  process.env.DEVELOPER_BYPASS_EMAILS?.split(',').map((e) => e.trim()) ?? []
+);
 
 export function hasUnlimitedDeveloperCredits(email?: string | null): boolean {
   if (!email) return false;

--- a/lib/credits-service.ts
+++ b/lib/credits-service.ts
@@ -69,7 +69,7 @@ export const TIER_FEATURES: Record<Tier, string[]> = {
 
 // Developer/testing credit bypass
 const DEVELOPER_BYPASS_EMAILS = new Set(
-  process.env.DEVELOPER_BYPASS_EMAILS?.split(',').map((e) => e.trim()) ?? []
+  process.env.DEVELOPER_BYPASS_EMAILS?.split(',').map((e) => e.trim().toLowerCase()).filter(Boolean) ?? []
 );
 
 export function hasUnlimitedDeveloperCredits(email?: string | null): boolean {


### PR DESCRIPTION
Closes #696

Moves DEVELOPER_BYPASS_EMAILS out of source code into an environment variable. Empty var = empty set, so existing behaviour is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Developer credit bypass allowlist is now configurable via environment (comma-separated values) instead of a hardcoded address, allowing operators to update bypassed emails without code changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->