### PR TITLE
fix: clear existing interval before overwrite in setupAutoSave

### DIFF
--- a/lib/version-history-service.ts
+++ b/lib/version-history-service.ts
@@ -322,6 +322,10 @@ export class VersionHistoryService {
       );
     };
 
+    if( this.autoSaveTimeout) {
+      clearInterval(this.autoSaveTimeout);
+      this.autoSaveTimeout = null;
+    }
     this.autoSaveTimeout = setInterval(autoSave, intervalMs);
 
     // Return cleanup function


### PR DESCRIPTION
Fixes #758

## Problem
setupAutoSave() was overwriting this.autoSaveTimeout without clearing the previous interval, causing multiple concurrent timers on re-call - a timer memory leak.

## Fix
Added clearInterval check before setInterval to prevent leak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where auto-save operations could accumulate across repeated initialization cycles, potentially impacting application performance. Cleanup procedures now properly reset to prevent duplicate operations from running simultaneously.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->