### PR TITLE
Fix: Missing Inline Formatting in DOCX Exports

### DIFF
--- a/lib/documents/export.ts
+++ b/lib/documents/export.ts
@@ -263,7 +263,7 @@ function parseContentToParagraphs(content: string): Paragraph[] {
     if (trimmed.startsWith('# ')) {
       paragraphs.push(
         new Paragraph({
-          text: trimmed.substring(2),
+          children: parseInlineFormatting(trimmed.substring(2)),
           heading: HeadingLevel.HEADING_1,
           spacing: { before: 300, after: 200 },
         })
@@ -271,7 +271,7 @@ function parseContentToParagraphs(content: string): Paragraph[] {
     } else if (trimmed.startsWith('## ')) {
       paragraphs.push(
         new Paragraph({
-          text: trimmed.substring(3),
+          children: parseInlineFormatting(trimmed.substring(3)),
           heading: HeadingLevel.HEADING_2,
           spacing: { before: 250, after: 150 },
         })
@@ -279,7 +279,7 @@ function parseContentToParagraphs(content: string): Paragraph[] {
     } else if (trimmed.startsWith('### ')) {
       paragraphs.push(
         new Paragraph({
-          text: trimmed.substring(4),
+          children: parseInlineFormatting(trimmed.substring(4)),
           heading: HeadingLevel.HEADING_3,
           spacing: { before: 200, after: 100 },
         })
@@ -289,7 +289,7 @@ function parseContentToParagraphs(content: string): Paragraph[] {
     else if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
       paragraphs.push(
         new Paragraph({
-          text: trimmed.substring(2),
+          children: parseInlineFormatting(trimmed.substring(2)),
           bullet: { level: 0 },
           spacing: { after: 100 },
         })
@@ -297,10 +297,10 @@ function parseContentToParagraphs(content: string): Paragraph[] {
     }
     // Numbered lists
     else if (/^\d+\.\s/.test(trimmed)) {
-      const text = trimmed.replace(/^\d+\.\s/, '');
+      const listText = trimmed.replace(/^\d+\.\s/, '');
       paragraphs.push(
         new Paragraph({
-          text,
+          children: parseInlineFormatting(listText),
           numbering: { reference: 'my-numbering', level: 0 },
           spacing: { after: 100 },
         })
@@ -323,12 +323,39 @@ function parseContentToParagraphs(content: string): Paragraph[] {
 }
 
 /**
- * Parse inline formatting (bold, italic)
+ * Parse inline formatting (bold, italic, bold+italic)
+ * Converts Markdown-style inline syntax to styled TextRun objects:
+ *   ***text*** → bold + italic
+ *   **text**   → bold
+ *   *text*     → italic
  */
-function parseInlineFormatting(text: string): TextRun[] {
+function parseInlineFormatting(text: string, fontSize: number = 22): TextRun[] {
   const runs: TextRun[] = [];
-  // Simple parsing - can be enhanced
-  runs.push(new TextRun({ text, size: 22 }));
+  // Regex matches: ***bold italic***, **bold**, *italic*, or plain text segments
+  const pattern = /(\*{3}(.+?)\*{3})|(\*{2}(.+?)\*{2})|(\*(.+?)\*)|([^*]+)/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match[1]) {
+      // ***bold italic***
+      runs.push(new TextRun({ text: match[2], bold: true, italics: true, size: fontSize }));
+    } else if (match[3]) {
+      // **bold**
+      runs.push(new TextRun({ text: match[4], bold: true, size: fontSize }));
+    } else if (match[5]) {
+      // *italic*
+      runs.push(new TextRun({ text: match[6], italics: true, size: fontSize }));
+    } else if (match[7]) {
+      // plain text
+      runs.push(new TextRun({ text: match[7], size: fontSize }));
+    }
+  }
+
+  // Fallback: if regex produced no runs, return the original text as-is
+  if (runs.length === 0) {
+    runs.push(new TextRun({ text, size: fontSize }));
+  }
+
   return runs;
 }
 


### PR DESCRIPTION
Closes #634 

- Problem:
The document generator's AI produces content using standard Markdown syntax (`**bold**, *italic*, ***bold italic***`), but when exporting to DOCX, the `parseInlineFormatting` function was a placeholder stub that passed raw markdown through as plain text. This caused exported `.docx`files to display literal asterisks instead of actual formatted text. 

- Root Cause:
- The parseInlineFormatting function simply pushed the entire input string as a single unstyled TextRun, ignoring all Markdown inline syntax:
```
function parseInlineFormatting(text: string): TextRun[] {
  const runs: TextRun[] = [];
  runs.push(new TextRun({ text, size: 22 }));
  return runs;
}
```

Additionally, bullet points, numbered lists, and headers used the `text:` property directly on `Paragraph`, bypassing `parseInlineFormatting` entirely.

- Changes:
All changes are in `lib/documents/export.ts`: 
- Rewrote parseInlineFormatting with a regex-based tokeniser that properly converts Markdown inline syntax into styled `TextRun` objects:
1. `***text***` -> bold + italic 
2. `**text** `-> bold
3.` *text*` -> italic
4. Includes a fallback for edge cases where the regex produces no matches.

- Updated bullet points to use `children: parseInlineFormatting(...)` instead of `text: `
- Updated numbered lists to use `children: parseInlineFormatting(...)` instead of `text:`
- Updated headers (H1, H2, H3) to use `children: parseInlineFormatting(...)` instead of `text: `

- What's Not Changed-
- The HTML/PDF export path (`formatContentForHtml`) already handles bold/italic correctly and was left untouched.
- No new dependencies - the fix uses only the existing`TextRun` API from the `docx` package. 

Testing:
- `npx tsc --noEmit` passes with zero errors in the modified file.
- Manually verified DOCX export renders bold, italic and bold-italic text correctly in Word and LibreOffice. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Markdown-style inline formatting (bold, italics, and bold-italics) in exported document headings and list items.
  * Enhanced inline text rendering to properly display styled content when exporting documents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->