### PR TITLE
`fix: prevent open redirect in auth callback parameter (fixes #771)`

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,8 +1,9 @@
 import { createRoute } from "@/lib/supabase/server";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { sendWelcomeEmail } from "@/lib/email";
 import { createClient } from '@supabase/supabase-js';
 import { logger } from "@/lib/logger";
+import { DEFAULT_REDIRECT_PATH, getSafeRedirectPath } from "@/lib/redirect-utils";
 
 export const dynamic = 'force-dynamic';
 
@@ -104,7 +105,12 @@ async function processReferral(referralCode: string, newUserId: string) {
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get("code");
-  const next = requestUrl.searchParams.get("next") || "/";
+  const next = requestUrl.searchParams.get("next");
+  const safeRedirectPath = getSafeRedirectPath(
+    next,
+    requestUrl.origin,
+    DEFAULT_REDIRECT_PATH,
+  );
   const type = requestUrl.searchParams.get("type");
   const referralCode = requestUrl.searchParams.get("ref");
 
@@ -189,7 +195,7 @@ export async function GET(request: NextRequest) {
       }
       
       // Default redirect
-      const nextUrl = new URL(next, requestUrl.origin);
+      const nextUrl = new URL(safeRedirectPath, requestUrl.origin);
       return Response.redirect(nextUrl.toString());
     } catch (err) {
       logger.error("Auth callback exception:", err);

--- a/lib/__tests__/redirect-utils.test.ts
+++ b/lib/__tests__/redirect-utils.test.ts
@@ -1,0 +1,42 @@
+import {
+  DEFAULT_REDIRECT_PATH,
+  getSafeRedirectPath,
+} from "../redirect-utils";
+
+describe("getSafeRedirectPath", () => {
+  const origin = "https://draftdeckai.com";
+
+  it("allows internal relative paths", () => {
+    expect(getSafeRedirectPath("/workspace?tab=recent", origin)).toBe(
+      "/workspace?tab=recent",
+    );
+  });
+
+  it("allows same-origin absolute URLs", () => {
+    expect(
+      getSafeRedirectPath("https://draftdeckai.com/profile#billing", origin),
+    ).toBe("/profile#billing");
+  });
+
+  it("falls back for external absolute URLs", () => {
+    expect(getSafeRedirectPath("https://example.com/phish", origin)).toBe(
+      DEFAULT_REDIRECT_PATH,
+    );
+  });
+
+  it("falls back for protocol-relative external URLs", () => {
+    expect(getSafeRedirectPath("//example.com/phish", origin)).toBe(
+      DEFAULT_REDIRECT_PATH,
+    );
+  });
+
+  it("falls back for malformed URLs", () => {
+    expect(getSafeRedirectPath("http://[invalid-url", origin)).toBe(
+      DEFAULT_REDIRECT_PATH,
+    );
+  });
+
+  it("falls back when the redirect is blank", () => {
+    expect(getSafeRedirectPath("   ", origin)).toBe(DEFAULT_REDIRECT_PATH);
+  });
+});

--- a/lib/__tests__/redirect-utils.test.ts
+++ b/lib/__tests__/redirect-utils.test.ts
@@ -39,4 +39,10 @@ describe("getSafeRedirectPath", () => {
   it("falls back when the redirect is blank", () => {
     expect(getSafeRedirectPath("   ", origin)).toBe(DEFAULT_REDIRECT_PATH);
   });
+
+  it("falls back for non-root relative paths", () => {
+    expect(getSafeRedirectPath("dashboard", origin)).toBe(
+      DEFAULT_REDIRECT_PATH,
+    );
+  });
 });

--- a/lib/redirect-utils.ts
+++ b/lib/redirect-utils.ts
@@ -1,4 +1,4 @@
-const DEFAULT_REDIRECT_PATH = "/";
+export const DEFAULT_REDIRECT_PATH = "/";
 
 /**
  * Restrict post-auth redirects to the current application origin.
@@ -18,22 +18,31 @@ export function getSafeRedirectPath(
     return fallbackPath;
   }
 
+  if (trimmedNext.startsWith("//") || trimmedNext.startsWith("\\\\")) {
+    return fallbackPath;
+  }
+
   try {
     const appUrl = new URL(origin);
+    const hasScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmedNext);
+
+    if (hasScheme) {
+      const candidateUrl = new URL(trimmedNext);
+
+      if (candidateUrl.origin !== appUrl.origin) {
+        return fallbackPath;
+      }
+
+      return `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}`;
+    }
+
+    if (!trimmedNext.startsWith("/")) {
+      return fallbackPath;
+    }
+
     const candidateUrl = new URL(trimmedNext, appUrl);
-
-    if (candidateUrl.origin !== appUrl.origin) {
-      return fallbackPath;
-    }
-
-    if (!candidateUrl.pathname.startsWith("/")) {
-      return fallbackPath;
-    }
-
     return `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}`;
   } catch {
     return fallbackPath;
   }
 }
-
-export { DEFAULT_REDIRECT_PATH };

--- a/lib/redirect-utils.ts
+++ b/lib/redirect-utils.ts
@@ -1,0 +1,39 @@
+const DEFAULT_REDIRECT_PATH = "/";
+
+/**
+ * Restrict post-auth redirects to the current application origin.
+ * Falls back to "/" when the provided target is blank, malformed, or external.
+ */
+export function getSafeRedirectPath(
+  next: string | null | undefined,
+  origin: string,
+  fallbackPath: string = DEFAULT_REDIRECT_PATH,
+): string {
+  if (!next) {
+    return fallbackPath;
+  }
+
+  const trimmedNext = next.trim();
+  if (!trimmedNext) {
+    return fallbackPath;
+  }
+
+  try {
+    const appUrl = new URL(origin);
+    const candidateUrl = new URL(trimmedNext, appUrl);
+
+    if (candidateUrl.origin !== appUrl.origin) {
+      return fallbackPath;
+    }
+
+    if (!candidateUrl.pathname.startsWith("/")) {
+      return fallbackPath;
+    }
+
+    return `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}`;
+  } catch {
+    return fallbackPath;
+  }
+}
+
+export { DEFAULT_REDIRECT_PATH };

--- a/types/jest-globals.d.ts
+++ b/types/jest-globals.d.ts
@@ -1,0 +1,19 @@
+declare const describe: (
+  name: string,
+  fn: () => void,
+) => void;
+
+declare const it: (
+  name: string,
+  fn: () => void | Promise<void>,
+) => void;
+
+declare const test: typeof it;
+
+declare const beforeAll: (fn: () => void | Promise<void>) => void;
+declare const beforeEach: (fn: () => void | Promise<void>) => void;
+declare const afterAll: (fn: () => void | Promise<void>) => void;
+declare const afterEach: (fn: () => void | Promise<void>) => void;
+
+declare const expect: any;
+declare const jest: any;


### PR DESCRIPTION
## Description

This PR fixes the open redirect vulnerability reported in:

**[Bug]: Auth callback allows open redirect through next query parameter #771**

The issue was caused by the auth callback flow trusting the `next` query parameter and using it directly to construct the post-login redirect URL. Because that value was not validated, an attacker could craft a login URL with an external redirect target and cause authenticated users to be sent to a third-party site after sign-in.

This change introduces strict redirect validation so that only safe internal DraftDeckAI routes are allowed after authentication.

---

## Problem

Before this fix, the callback route contained logic equivalent to:

```ts
const next = requestUrl.searchParams.get("next") || "/";
const nextUrl = new URL(next, requestUrl.origin);
return Response.redirect(nextUrl.toString());
```

### Why this was vulnerable

`new URL(next, requestUrl.origin)` accepts both:
- internal relative paths like `/dashboard`
- external absolute URLs like `https://example.com`

That means a malicious link like:

```txt
/auth/callback?next=https://example.com
```

could redirect a successfully authenticated user off-site.

---

## Root Cause

The `next` parameter was:
- accepted directly from the request
- not checked for same-origin safety
- not restricted to internal app paths
- allowed to resolve external absolute URLs

This created an **open redirect** vulnerability in the authentication callback flow.

---

## Solution

This PR adds a dedicated redirect sanitization utility and updates the callback route to use it.

### What changed

- added a reusable helper: `lib/redirect-utils.ts`
- validated redirect targets against the current application origin
- allowed only:
  - same-origin absolute URLs
  - root-relative internal paths
- rejected:
  - external absolute URLs
  - protocol-relative URLs like `//example.com`
  - malformed URLs
  - blank values
  - non-root relative values like `dashboard`
- added regression tests to cover safe and unsafe redirect inputs

---

## Detailed Code Changes

### 1. Added redirect validation helper

New file:

`lib/redirect-utils.ts`

### Added code

```ts
export const DEFAULT_REDIRECT_PATH = "/";

export function getSafeRedirectPath(
  next: string | null | undefined,
  origin: string,
  fallbackPath: string = DEFAULT_REDIRECT_PATH,
): string {
  if (!next) {
    return fallbackPath;
  }

  const trimmedNext = next.trim();
  if (!trimmedNext) {
    return fallbackPath;
  }

  if (trimmedNext.startsWith("//") || trimmedNext.startsWith("\\\\")) {
    return fallbackPath;
  }

  try {
    const appUrl = new URL(origin);
    const hasScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmedNext);

    if (hasScheme) {
      const candidateUrl = new URL(trimmedNext);

      if (candidateUrl.origin !== appUrl.origin) {
        return fallbackPath;
      }

      return `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}`;
    }

    if (!trimmedNext.startsWith("/")) {
      return fallbackPath;
    }

    const candidateUrl = new URL(trimmedNext, appUrl);
    return `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}`;
  } catch {
    return fallbackPath;
  }
}
```

### Why this is safe

This helper:
- trims incoming input
- blocks protocol-relative bypasses
- checks whether an absolute URL has the same origin
- only permits internal root-relative paths
- falls back safely to `/` when anything looks suspicious

---

### 2. Updated auth callback route

File changed:

`app/auth/callback/route.ts`

### Previous behavior

```ts
const next = requestUrl.searchParams.get("next") || "/";
const nextUrl = new URL(next, requestUrl.origin);
return Response.redirect(nextUrl.toString());
```

### New behavior

```ts
const next = requestUrl.searchParams.get("next");
const safeRedirectPath = getSafeRedirectPath(
  next,
  requestUrl.origin,
  DEFAULT_REDIRECT_PATH,
);

const nextUrl = new URL(safeRedirectPath, requestUrl.origin);
return Response.redirect(nextUrl.toString());
```

### Why this matters

Instead of trusting `next` directly, the route now:
1. reads the raw query value
2. sanitizes it through a dedicated validator
3. redirects only to a safe internal path

This closes the open redirect vector.

---

### 3. Added regression tests

File added/updated:

`lib/__tests__/redirect-utils.test.ts`

### Covered cases

```ts
it("allows internal relative paths", () => {
  expect(getSafeRedirectPath("/workspace?tab=recent", origin)).toBe(
    "/workspace?tab=recent",
  );
});

it("allows same-origin absolute URLs", () => {
  expect(
    getSafeRedirectPath("https://draftdeckai.com/profile#billing", origin),
  ).toBe("/profile#billing");
});

it("falls back for external absolute URLs", () => {
  expect(getSafeRedirectPath("https://example.com/phish", origin)).toBe(
    DEFAULT_REDIRECT_PATH,
  );
});

it("falls back for protocol-relative external URLs", () => {
  expect(getSafeRedirectPath("//example.com/phish", origin)).toBe(
    DEFAULT_REDIRECT_PATH,
  );
});

it("falls back for malformed URLs", () => {
  expect(getSafeRedirectPath("http://[invalid-url", origin)).toBe(
    DEFAULT_REDIRECT_PATH,
  );
});

it("falls back when the redirect is blank", () => {
  expect(getSafeRedirectPath("   ", origin)).toBe(DEFAULT_REDIRECT_PATH);
});

it("falls back for non-root relative paths", () => {
  expect(getSafeRedirectPath("dashboard", origin)).toBe(
    DEFAULT_REDIRECT_PATH,
  );
});
```

### Why these tests matter

These tests ensure the fix is stable and protects against the common redirect abuse patterns attackers typically use.

---

## Expected Behavior After Fix

After authentication:
- users can still be redirected to valid internal DraftDeckAI routes
- external redirect targets are blocked
- malformed or suspicious redirect targets fall back safely to `/`

---

## Security Impact

This PR removes an open redirect vulnerability from the auth callback flow.

### Prevented attack patterns

- phishing redirects after login
- malicious off-site redirect chains
- crafted callback URLs that exploit trusted login flows

---

## Checklist

- [x] Reproduced and understood the vulnerability
- [x] Identified the root cause in `app/auth/callback/route.ts`
- [x] Added a dedicated redirect sanitization helper
- [x] Restricted redirects to safe internal destinations
- [x] Added safe fallback behavior
- [x] Added regression tests for malicious and valid inputs
- [x] Kept the change scoped to the reported issue
- [x] PR title references the issue
- [x] Included detailed explanation of the code changes

---

## Issue Reference

Fixes #771


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication security by implementing redirect URL validation that prevents open redirect vulnerabilities, ensuring users are only redirected to trusted internal application paths during sign-in and callback flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->