### PR TITLE
fix: replace 'Back to Top' text with ArrowUp icon for cleaner UI

### DIFF
--- a/components/ui/Footer.tsx
+++ b/components/ui/Footer.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Link from "next/link";
 import { FaGithub, FaLinkedin, FaTwitter } from "react-icons/fa";
-import { Sparkles, Mail, FileText, Presentation, BookOpen, Heart, Shield, Zap } from "lucide-react";
+import { Sparkles, Mail, FileText, Presentation, BookOpen, Heart, Shield, Zap, ArrowUp } from "lucide-react";
 
 export default function Footer() {
   return (
@@ -191,14 +191,14 @@ export default function Footer() {
           </div>
         </div>
 
-        {/* Optional: Back to Top Button */}
+       {/* Back to Top Button */}
         <div className="mt-8 text-center">
           <button
             onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-            className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold text-sm hover:scale-105 transition-all duration-300 shadow-lg hover:shadow-xl"
+            aria-label="Back to top"
+            className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gradient-to-r from-blue-600 to-purple-600 text-white hover:scale-110 transition-all duration-300 shadow-lg hover:shadow-xl"
           >
-            <Sparkles className="h-4 w-4" />
-            Back to Top
+            <ArrowUp className="h-5 w-5" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
Fixes #770

## Changes
- Replaced "Back to Top" text button with a clean `ArrowUp` icon from Lucide React
- Added `aria-label="Back to top"` for accessibility
- Kept smooth scroll and hover/scale transition effects
- Removed unnecessary text, making it minimal and mobile-friendly

## Screenshots
<img width="1902" height="891" alt="image" src="https://github.com/user-attachments/assets/81fb66fc-ed55-4a8a-9075-a4465f63f8e4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the "Back to Top" footer button with a circular gradient button featuring an up arrow icon, replacing the previous text-based layout for a cleaner appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->