### PR TITLE
fix: replace unsafe-inline with per-request nonces in script-src CSP (#736)

### DIFF
--- a/__mocks__/@upstash/redis.ts
+++ b/__mocks__/@upstash/redis.ts
@@ -1,0 +1,49 @@
+/**
+ * Jest manual mock for @upstash/redis.
+ *
+ * The real @upstash/redis package ships ESM-only transitive deps (e.g.
+ * uncrypto) that Jest cannot transform out of the box. Since the unit
+ * tests only exercise the in-process BoundedCache, a lightweight stub
+ * is sufficient for the test suite to compile and run without error.
+ */
+
+export class Redis {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async get<T>(_key: string): Promise<T | null> {
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async set(_key: string, _value: unknown, _opts?: unknown): Promise<void> {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async del(..._keys: string[]): Promise<void> {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async smembers(_key: string): Promise<string[]> {
+    return [];
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async sadd(_key: string, ..._members: string[]): Promise<void> {}
+
+  async scan(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _cursor: string | number,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _opts?: unknown,
+  ): Promise<[string | number, string[]]> {
+    return ['0', []];
+  }
+
+  async flushdb(): Promise<void> {}
+
+  pipeline() {
+    const self = this;
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      del: (..._keys: string[]) => self.pipeline(),
+      exec: async () => [],
+    };
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import { DeploymentStatusBanner } from "@/components/deployment-status-banner";
 import type { Metadata } from "next";
 import PlausibleProvider from 'next-plausible';
 import { useUTMCapture } from "@/hooks/useUTMCapture";
+import { headers } from 'next/headers';
 
 const inter = Inter({ subsets: ["latin"] });
 const poppins = Poppins({
@@ -57,23 +58,33 @@ export const metadata: Metadata = {
  */
 const themeScript = `(function(){try{var s=localStorage.getItem('theme');var d=document.documentElement;if(s==='dark'){d.classList.add('dark');}else if(s==='light'){d.classList.remove('dark');}else{if(window.matchMedia('(prefers-color-scheme: dark)').matches){d.classList.add('dark');}else{d.classList.remove('dark');}}}catch(e){}})();`;
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // Read the per-request nonce injected by middleware.
+  // The nonce is used to allowlist inline scripts in the Content-Security-Policy
+  // without relying on 'unsafe-inline', which would permit XSS script injection.
+  const headersList = await headers();
+  const nonce = headersList.get('x-nonce') ?? '';
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        {/* Blocking theme script -- must be first in <head> to prevent FOUC */}
-        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
-        
-        {/* Plausible Analytics setup */}
-        <PlausibleProvider 
+        {/* Blocking theme script -- must be first in <head> to prevent FOUC.
+            The nonce attribute allows this inline script under the nonce-based CSP
+            set by middleware, without requiring 'unsafe-inline' in script-src. */}
+        <script nonce={nonce} dangerouslySetInnerHTML={{ __html: themeScript }} />
+
+        {/* Plausible Analytics setup.
+            scriptProps.nonce ensures the inline init snippet passes the CSP check. */}
+        <PlausibleProvider
           domain="draftdeckai.com"
           src="https://plausible.io/js/script.tagged-events.outbound-links.js"
           trackOutboundLinks={true}
           taggedEvents={true}
+          scriptProps={{ nonce }}
         />
         
         <link rel="manifest" href="/manifest.json" />

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -14,7 +14,10 @@ const createJestConfig = nextJest({ dir: './' });
 const config = {
   testEnvironment: 'jsdom',
   testMatch: ['**/__tests__/**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
-  moduleNameMapper: { '^@/(.*)$': '<rootDir>/$1' },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+    '^@upstash/redis$': '<rootDir>/__mocks__/@upstash/redis.ts',
+  },
   setupFiles: ['<rootDir>/jest.polyfills.cjs'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   collectCoverageFrom: ['lib/**/*.ts', 'app/api/**/*.ts', '!**/__tests__/**'],

--- a/lib/csp.ts
+++ b/lib/csp.ts
@@ -4,64 +4,62 @@
  * Single source of truth for the Content-Security-Policy header.
  *
  * Imported by:
- *   - next.config.js  (static response headers for all routes)
- *   - middleware.ts   (dynamic per-request headers for page routes)
+ *   - next.config.js  (static response headers via lib/csp.mjs companion)
+ *   - middleware.ts   (dynamic per-request headers; uses buildCspWithNonce
+ *                      for HTML page routes to eliminate unsafe-inline)
  *
  * netlify.toml carries an equivalent inline CSP for CDN-edge delivery.
- * When updating this file, mirror the change in netlify.toml as well
- * (a comment in that file marks the relevant block).
+ * When updating this file, mirror the change in both lib/csp.mjs and
+ * netlify.toml (comments in those files mark the relevant blocks).
+ *
+ * Security posture (tracked changes from #735 to #736):
+ *   #735 - unified CSP into a single source of truth.
+ *   #736 - replaced 'unsafe-inline' in script-src with per-request nonces
+ *           so inline scripts cannot be injected by XSS; removed 'unsafe-eval'
+ *           from production builds (Next.js SWC does not require it).
  */
 
-/**
- * CSP directives with an inline explanation for each.
- * Keeping the rationale next to the value makes future audits easier.
- */
-export const CSP_DIRECTIVES: string[] = [
-  // Block any resource not explicitly permitted below.
+// ---------------------------------------------------------------------------
+// Shared directives (same for both nonce and non-nonce variants)
+// ---------------------------------------------------------------------------
+
+const SHARED_DIRECTIVES: string[] = [
+  // Only same-origin resources by default.
   "default-src 'self'",
 
-  // Scripts: same-origin plus trusted third-party bundles.
-  //   - 'unsafe-eval': required by Next.js SWC in development mode.
-  //   - 'unsafe-inline': needed until all inline scripts use nonces (tracked in #736).
-  //   - https://js.stripe.com: Stripe.js payment widget.
-  //   - https://cdn.jsdelivr.net: UI library bundles.
-  //   - https://plausible.io: privacy-first analytics script.
-  "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://js.stripe.com https://cdn.jsdelivr.net https://plausible.io",
-
-  // Styles: 'unsafe-inline' is required for Tailwind-generated class styles
-  // and third-party widget CSS injected at runtime.
+  // Styles: unsafe-inline is required for Tailwind-in-JS and third-party
+  // widget CSS injected at runtime. Nonce-based style CSP is out of scope.
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
 
-  // Fonts: Google Fonts glyphs are served from gstatic.com;
-  // data: URIs are used by bundled icon sets.
+  // Fonts: Google Fonts glyphs served from gstatic; data: for bundled icon sets.
   "font-src 'self' https://fonts.gstatic.com data: https://cdn.jsdelivr.net",
 
-  // Images: broad https: covers avatar/stock-photo CDNs;
-  // blob: and data: are needed for canvas exports and in-browser previews.
+  // Images: https: allows avatar / stock-photo CDNs; blob: and data: for canvas
+  // exports and in-browser image previews.
   "img-src 'self' data: https: blob:",
 
   // Fetch / XHR: enumerate every external API the client calls.
-  //   - data: is required by @react-pdf/renderer (yoga-wasm loads via data: URI).
-  //   - https://*.supabase.co: database + auth.
-  //   - https://*.nebius.cloud / https://api.tokenfactory.nebius.com: AI inference.
-  //   - https://generativelanguage.googleapis.com: Gemini API.
-  //   - https://api.mistral.ai: Mistral AI.
-  //   - https://api.stripe.com: Stripe server-side calls from the client.
-  //   - https://latexonline.cc / https://latex.ytotech.com: LaTeX rendering.
-  //   - https://cdn.jsdelivr.net: CDN-hosted WASM and assets.
+  //   data:                             @react-pdf/renderer yoga-wasm (data: URI)
+  //   https://*.supabase.co             database + auth
+  //   https://*.nebius.cloud            AI inference
+  //   https://api.tokenfactory.nebius.com Nebius token factory
+  //   https://generativelanguage.googleapis.com  Gemini API
+  //   https://api.mistral.ai            Mistral AI
+  //   https://api.stripe.com            Stripe server-side calls from the client
+  //   https://latexonline.cc / https://latex.ytotech.com  LaTeX rendering
+  //   https://cdn.jsdelivr.net          CDN-hosted WASM and assets
   "connect-src 'self' data: https://*.supabase.co https://*.nebius.cloud https://api.stripe.com https://generativelanguage.googleapis.com https://api.mistral.ai https://api.tokenfactory.nebius.com https://latexonline.cc https://latex.ytotech.com https://cdn.jsdelivr.net",
 
-  // Frames: blob: is needed for PDF previews;
-  // Stripe renders the card-input widget inside an iframe.
+  // Frames: blob: for PDF previews; Stripe card-input widget runs in an iframe.
   "frame-src 'self' blob: https://js.stripe.com",
 
-  // Restrict <object> and <embed>; blob: is needed for PDF previews.
+  // Restrict <object> and <embed>; blob: for PDF previews.
   "object-src 'self' blob:",
 
   // Service workers and web workers run same-origin or from blob: URLs.
   "worker-src 'self' blob:",
 
-  // Restrict the <base> element to same-origin to prevent base-tag injection.
+  // Restrict <base> to same-origin to block base-tag injection.
   "base-uri 'self'",
 
   // Limit form submissions to same-origin to block reflected-input attacks.
@@ -71,5 +69,59 @@ export const CSP_DIRECTIVES: string[] = [
   "frame-ancestors 'none'",
 ];
 
-/** Full CSP header value ready to be used as Content-Security-Policy. */
+// ---------------------------------------------------------------------------
+// Static CSP (used by next.config.js for non-HTML responses and as a fallback)
+//
+// Retains 'unsafe-inline' and 'unsafe-eval' because next.config.js headers
+// are applied to all route responses, including static asset requests where
+// Next.js uses eval for chunk loading in development.
+// ---------------------------------------------------------------------------
+
+export const CSP_DIRECTIVES: string[] = [
+  // Scripts: unsafe-inline and unsafe-eval retained here because this variant
+  // is served as a static header (cannot carry per-request nonces).
+  //   unsafe-eval:   required by Next.js HMR/webpack in development.
+  //   unsafe-inline: fallback for routes not covered by middleware nonces.
+  //   https://js.stripe.com: Stripe.js payment widget.
+  //   https://cdn.jsdelivr.net: UI library bundles.
+  //   https://plausible.io: privacy-first analytics script.
+  "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://js.stripe.com https://cdn.jsdelivr.net https://plausible.io",
+  ...SHARED_DIRECTIVES,
+];
+
+/** Full CSP header value for static/fallback use (next.config.js, netlify.toml). */
 export const CSP_HEADER: string = CSP_DIRECTIVES.join('; ');
+
+// ---------------------------------------------------------------------------
+// Nonce-based CSP (generated per request by middleware for HTML page routes)
+//
+// Replaces 'unsafe-inline' with 'nonce-{value}' in script-src so only
+// scripts that carry the matching nonce attribute are executed. This prevents
+// scripts injected by XSS from running even if they appear inline.
+//
+// 'unsafe-eval' is removed in production (Next.js SWC does not need it).
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a CSP header string where 'unsafe-inline' in script-src is replaced
+ * by a per-request nonce. Call this from middleware when rendering HTML pages.
+ *
+ * @param nonce - A cryptographically random base64 string generated per request.
+ */
+export function buildCspWithNonce(nonce: string): string {
+  const isDev = process.env.NODE_ENV === 'development';
+
+  const scriptSrc = [
+    "'self'",
+    // Allow the nonce-carrying inline scripts (theme, analytics init, etc.)
+    `'nonce-${nonce}'`,
+    // unsafe-eval: only in development (Next.js HMR / webpack needs it).
+    ...(isDev ? ["'unsafe-eval'"] : []),
+    // Third-party scripts loaded via <script src="..."> remain whitelisted.
+    'https://js.stripe.com',
+    'https://cdn.jsdelivr.net',
+    'https://plausible.io',
+  ].join(' ');
+
+  return [`script-src ${scriptSrc}`, ...SHARED_DIRECTIVES].join('; ');
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { CSP_HEADER } from '@/lib/csp';
+import { CSP_HEADER, buildCspWithNonce } from '@/lib/csp';
 
 const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS ?? 'http://localhost:3000')
   .split(',')
@@ -89,8 +89,16 @@ function secHdrs(r: NextResponse) {
   r.headers.set('X-XSS-Protection', '1; mode=block');
   r.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   r.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
-  // Source of truth: lib/csp.ts
-  r.headers.set('Content-Security-Policy', CSP_HEADER);
+}
+
+/**
+ * Generate a cryptographically random nonce for per-request CSP.
+ * The nonce is a base64url-encoded 128-bit random value.
+ */
+function generateNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64');
 }
 
 export function middleware(req: NextRequest) {
@@ -156,8 +164,19 @@ export function middleware(req: NextRequest) {
   }
 
   if (!pathname.includes('.')) {
-    const r = NextResponse.next();
+    // Generate a per-request nonce for HTML page responses.
+    // The nonce is passed to the server component via a request header so that
+    // app/layout.tsx can apply it to inline scripts, eliminating unsafe-inline.
+    const nonce = generateNonce();
+
+    const requestHeaders = new Headers(req.headers);
+    requestHeaders.set('x-nonce', nonce);
+
+    const r = NextResponse.next({ request: { headers: requestHeaders } });
     secHdrs(r);
+    // Use nonce-based CSP (removes unsafe-inline from script-src).
+    // Source of truth: lib/csp.ts -> buildCspWithNonce()
+    r.headers.set('Content-Security-Policy', buildCspWithNonce(nonce));
     r.headers.set('X-DNS-Prefetch-Control', 'on');
     r.headers.set('Cache-Control', 'public,max-age=300,stale-while-revalidate=3600');
     r.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
@@ -172,6 +191,7 @@ export function middleware(req: NextRequest) {
 
   const r = NextResponse.next();
   secHdrs(r);
+  r.headers.set('Content-Security-Policy', CSP_HEADER);
   r.headers.set('Cache-Control', 'public,max-age=300,stale-while-revalidate=3600');
   return r;
 }


### PR DESCRIPTION
Closes #736

## Summary

- Eliminates `unsafe-inline` from `script-src` for all HTML page responses by generating a cryptographically random nonce per request in middleware
- Removes `unsafe-eval` from production builds (Next.js SWC does not require it; retained only in development for HMR)
- Inline scripts that legitimately need to run (theme flash-prevention, analytics init) now carry the nonce attribute and pass CSP without `unsafe-inline`

## Changes

**`lib/csp.ts`**
- Extracted `SHARED_DIRECTIVES` (all directives except `script-src`) into a shared constant
- `CSP_DIRECTIVES` / `CSP_HEADER` retain `unsafe-inline` and `unsafe-eval` for the static fallback used by `next.config.js` (cannot carry per-request nonces)
- New `buildCspWithNonce(nonce)` export: produces a nonce-based CSP replacing `unsafe-inline` with `'nonce-{value}'`, and omits `unsafe-eval` in production

**`middleware.ts`**
- Added `generateNonce()`: uses `crypto.getRandomValues()` for a 128-bit base64-encoded nonce
- Page routes (no file extension) now generate a nonce, inject it into request headers as `x-nonce`, and set the nonce-based CSP on the response via `buildCspWithNonce()`
- Non-page routes continue to use the static `CSP_HEADER`

**`app/layout.tsx`**
- Made `RootLayout` async to support `await headers()`
- Reads `x-nonce` from incoming request headers
- Applies `nonce` attribute to the blocking theme-detection `<script>` tag
- Passes `scriptProps={{ nonce }}` to `PlausibleProvider` so the inline analytics init snippet is also covered

## Security impact

| Directive | Before | After (page routes) |
|---|---|---|
| `script-src unsafe-inline` | present | removed |
| `script-src unsafe-eval` | present in prod | removed in prod |
| `script-src nonce-{value}` | absent | added per request |

XSS-injected inline scripts can no longer execute on page routes because they cannot obtain the per-request nonce.

## Test plan

- [ ] Load the home page; verify the blocking theme script executes correctly (no FOUC)
- [ ] Inspect the `Content-Security-Policy` response header on a page route and confirm `nonce-...` is present and `unsafe-inline` is absent
- [ ] Confirm Plausible analytics still loads (script tag carries matching nonce)
- [ ] Check a static asset route (`.js`, `.css`) and confirm it still serves the static CSP_HEADER fallback
- [ ] Test in development mode: confirm `unsafe-eval` is present for HMR
- [ ] Test in production build: confirm `unsafe-eval` is absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Per-request CSP nonces added to allowlist inline scripts (including analytics), and CSP headers now vary per-page for stronger inline-script protection.
* **Tests**
  * Added a local Redis mock and updated test mapping so unit tests use the in-process mock reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->