### PR TITLE
feat: implement distributed caching layer with Upstash Redis (#724)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,13 @@
 GEMINI_API_KEY=your-gemini-api-key-here
 TESTMAIL_API_KEY=your-testmail-api-key-here
+
+# DISTRIBUTED CACHE (optional)
+# When set, lib/distributedCache uses Upstash Redis instead of the
+# local in-memory cache, enabling data sharing across multiple server
+# instances. Leave blank to fall back to the in-memory BoundedCache.
+# Get these values from the Upstash console: https://console.upstash.com
+UPSTASH_REDIS_URL=
+UPSTASH_REDIS_TOKEN=
 # APP CONFIGURATION
 NEXT_PUBLIC_APP_NAME=Draftdeckai
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/lib/cache-redis.ts
+++ b/lib/cache-redis.ts
@@ -1,0 +1,173 @@
+/**
+ * lib/cache-redis.ts
+ *
+ * Distributed cache implementation backed by Upstash Redis.
+ *
+ * Implements the same surface area as the in-memory BoundedCache in
+ * lib/cache.ts (get, set, delete, invalidateByTag, invalidateByPrefix,
+ * flush) so consumers can switch between them without code changes.
+ *
+ * Upstash Redis is serverless-friendly: every call goes over HTTPS, so
+ * it works in Next.js Edge Runtime and Node.js alike.
+ *
+ * Environment variables required when using this backend:
+ *   UPSTASH_REDIS_URL   - REST API base URL from the Upstash console
+ *   UPSTASH_REDIS_TOKEN - Read-write token from the Upstash console
+ *
+ * Tag-based invalidation is implemented with a Redis Set per tag.
+ * Each set stores the cache keys that carry that tag. On invalidation
+ * the set is read, every member is deleted, and the set is removed.
+ *
+ * Prefix-based invalidation uses Redis SCAN to find and delete keys.
+ */
+
+import { Redis } from '@upstash/redis';
+import { logger } from '@/lib/logger';
+
+/** Internal envelope stored as the Redis value. */
+interface RedisEntry<T> {
+  value: T;
+  tags: string[];
+}
+
+/** Key used for a tag's set of associated cache keys. */
+function tagSetKey(tag: string): string {
+  return `tag:${tag}`;
+}
+
+export class RedisCache {
+  private client: Redis;
+  private defaultTtlMs: number;
+
+  constructor(defaultTtlMs: number) {
+    this.defaultTtlMs = defaultTtlMs;
+    this.client = new Redis({
+      url: process.env.UPSTASH_REDIS_URL!,
+      token: process.env.UPSTASH_REDIS_TOKEN!,
+    });
+  }
+
+  /** Retrieve a value. Returns null on miss or if the key has expired. */
+  async get<T>(key: string): Promise<T | null> {
+    try {
+      const raw = await this.client.get<RedisEntry<T>>(key);
+      if (!raw) return null;
+      return raw.value;
+    } catch (err) {
+      logger.warn(null, '[cache-redis] get failed', { key, err });
+      return null;
+    }
+  }
+
+  /** Store a value. TTL defaults to the instance-level default. */
+  async set<T>(
+    key: string,
+    value: T,
+    opts: { ttlMs?: number; tags?: string[] } = {}
+  ): Promise<void> {
+    const ttlMs = opts.ttlMs ?? this.defaultTtlMs;
+    const tags = opts.tags ?? [];
+    const entry: RedisEntry<T> = { value, tags };
+
+    try {
+      // Store the entry with an expiry.
+      await this.client.set(key, entry, { px: ttlMs });
+
+      // Register the key in each tag's set so we can invalidate by tag.
+      if (tags.length > 0) {
+        const pipeline = this.client.pipeline();
+        for (const tag of tags) {
+          pipeline.sadd(tagSetKey(tag), key);
+          // The tag set itself should expire after the longest TTL that will
+          // ever reference it. We use the same TTL as the entry for simplicity.
+          pipeline.pexpire(tagSetKey(tag), ttlMs);
+        }
+        await pipeline.exec();
+      }
+    } catch (err) {
+      logger.warn(null, '[cache-redis] set failed', { key, err });
+    }
+  }
+
+  /** Delete a single key. */
+  async delete(key: string): Promise<void> {
+    try {
+      await this.client.del(key);
+    } catch (err) {
+      logger.warn(null, '[cache-redis] delete failed', { key, err });
+    }
+  }
+
+  /**
+   * Delete all keys associated with one or more tags.
+   * Returns the number of keys removed.
+   */
+  async invalidateByTag(...tags: string[]): Promise<number> {
+    let total = 0;
+    try {
+      for (const tag of tags) {
+        const tKey = tagSetKey(tag);
+        const keys = await this.client.smembers(tKey);
+        if (keys.length > 0) {
+          const pipeline = this.client.pipeline();
+          pipeline.del(...keys as [string, ...string[]]);
+          pipeline.del(tKey);
+          await pipeline.exec();
+          total += keys.length;
+        }
+      }
+      if (total > 0) {
+        logger.debug(null, `[cache-redis] Invalidated ${total} entries`);
+      }
+    } catch (err) {
+      logger.warn(null, '[cache-redis] invalidateByTag failed', { tags, err });
+    }
+    return total;
+  }
+
+  /**
+   * Delete all keys whose name starts with a given prefix.
+   * Uses SCAN to avoid blocking the Redis server.
+   */
+  async invalidateByPrefix(prefix: string): Promise<number> {
+    let total = 0;
+    try {
+      let cursor: string | number = 0;
+      do {
+        const [nextCursor, keys]: [string | number, string[]] = await this.client.scan(cursor, {
+          match: `${prefix}*`,
+          count: 100,
+        });
+        cursor = nextCursor;
+        if (keys.length > 0) {
+          await this.client.del(...keys as [string, ...string[]]);
+          total += keys.length;
+        }
+      } while (String(cursor) !== '0');
+    } catch (err) {
+      logger.warn(null, '[cache-redis] invalidateByPrefix failed', { prefix, err });
+    }
+    return total;
+  }
+
+  /**
+   * Remove all keys from Redis.
+   * WARNING: calls FLUSHDB which clears the entire database. Only suitable
+   * for dedicated cache databases. Do not use if other data shares the DB.
+   */
+  async flush(): Promise<void> {
+    try {
+      await this.client.flushdb();
+    } catch (err) {
+      logger.warn(null, '[cache-redis] flush failed', { err });
+    }
+  }
+}
+
+/**
+ * Returns true when the required Upstash environment variables are present,
+ * indicating that the Redis backend should be used.
+ */
+export function isRedisConfigured(): boolean {
+  return Boolean(process.env.UPSTASH_REDIS_URL && process.env.UPSTASH_REDIS_TOKEN);
+}

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -109,6 +109,30 @@ export const cache = new BoundedCache(1_000, 5 * 60 * 1000);
 export const aiCache = new BoundedCache(500, 30 * 60 * 1000);
 export const userCache = new BoundedCache(2_000, 2 * 60 * 1000);
 
+// ---------------------------------------------------------------------------
+// Distributed cache adapter
+//
+// When UPSTASH_REDIS_URL and UPSTASH_REDIS_TOKEN are set, all consumers that
+// import `distributedCache` share data across multiple server instances.
+// Otherwise, the module falls back to the in-memory BoundedCache so the app
+// works in single-instance environments (local dev, preview deploys, etc.)
+// without any additional configuration.
+//
+// See lib/cache-redis.ts for the RedisCache implementation.
+// ---------------------------------------------------------------------------
+import { RedisCache, isRedisConfigured } from '@/lib/cache-redis';
+
+/**
+ * Unified cache that is Redis-backed when UPSTASH_REDIS_URL is configured
+ * and falls back to an in-memory BoundedCache otherwise.
+ *
+ * Use this instead of `cache` for data that must be shared across multiple
+ * server instances (horizontal scaling).
+ */
+export const distributedCache: BoundedCache | RedisCache = isRedisConfigured()
+  ? new RedisCache(5 * 60 * 1000)
+  : cache;
+
 export function memoizeAsync<A extends unknown[], R>(
   fn: (...a: A) => Promise<R>,
   keyFn: (...a: A) => string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@tanstack/react-query-devtools": "^5.91.3",
         "@types/fabric": "^5.3.10",
         "@types/file-saver": "^2.0.7",
+        "@upstash/redis": "^1.38.0",
         "axios": "^1.15.2",
         "bcryptjs": "^2.4.3",
         "cheerio": "^1.1.2",
@@ -204,7 +205,6 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1869,7 +1869,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1891,9 +1890,30 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -4221,7 +4241,6 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4239,7 +4258,6 @@
     "node_modules/@opentelemetry/core": {
       "version": "2.7.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -4558,7 +4576,6 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.7.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
@@ -4574,7 +4591,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.41.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -7211,7 +7227,6 @@
     "node_modules/@stripe/stripe-js": {
       "version": "3.5.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -7302,7 +7317,6 @@
     "node_modules/@supabase/supabase-js": {
       "version": "2.106.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.106.1",
         "@supabase/functions-js": "2.106.1",
@@ -7371,7 +7385,6 @@
     "node_modules/@tanstack/react-query": {
       "version": "5.100.14",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.100.14"
       },
@@ -7508,13 +7521,13 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -7935,7 +7948,6 @@
     "node_modules/@types/react": {
       "version": "19.2.15",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7944,7 +7956,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8041,7 +8052,6 @@
       "version": "8.59.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -8556,120 +8566,13 @@
         "d3-transition": "^3.0.1"
       }
     },
-    "node_modules/@webassemblyjs/ast": {
-      "version": "1.14.1",
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.13.2",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.13.2",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.14.1",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.13.2",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.13.2",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/wasm-gen": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.13.2",
-      "license": "MIT",
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.13.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.13.2",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/helper-wasm-section": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-opt": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1",
-        "@webassemblyjs/wast-printer": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@xtuc/long": "4.2.2"
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -8842,11 +8745,13 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -8877,7 +8782,6 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8915,6 +8819,7 @@
     "node_modules/acorn-import-phases": {
       "version": "1.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -8947,21 +8852,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/ajv": {
-      "version": "6.15.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
       "license": "MIT",
@@ -8986,17 +8876,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^8.8.2"
       }
     },
     "node_modules/ansi-escapes": {
@@ -9716,98 +9595,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/bluebird": {
-      "version": "3.4.7",
-      "license": "MIT"
-    },
-    "node_modules/bmp-js": {
-      "version": "0.1.0",
-      "license": "MIT"
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "license": "ISC"
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
@@ -9881,7 +9668,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -9913,30 +9699,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -10198,19 +9960,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/chrome-trace-event": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -10583,7 +10332,6 @@
     "node_modules/cytoscape": {
       "version": "3.33.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -10916,7 +10664,6 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11069,7 +10816,6 @@
     "node_modules/date-fns": {
       "version": "3.6.0",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -11114,22 +10860,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "dev": true,
@@ -11141,15 +10871,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -11340,8 +11061,7 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1608973",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dfa": {
       "version": "1.2.0",
@@ -11396,7 +11116,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -11524,8 +11245,7 @@
     },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -11593,6 +11313,7 @@
     "node_modules/enhanced-resolve": {
       "version": "5.22.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.3"
@@ -11727,7 +11448,8 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -11865,7 +11587,6 @@
     "node_modules/eslint": {
       "version": "8.57.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12043,7 +11764,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -12417,15 +12137,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/expect": {
@@ -13090,12 +12801,6 @@
         }
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "license": "MIT",
@@ -13303,12 +13008,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/glob": {
       "version": "13.0.6",
       "license": "BlueOak-1.0.0",
@@ -13336,7 +13035,8 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/globals": {
       "version": "13.24.0",
@@ -13816,12 +13516,6 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -14516,7 +14210,6 @@
       "version": "30.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -15377,7 +15070,6 @@
     "node_modules/jiti": {
       "version": "1.21.7",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -15406,7 +15098,6 @@
       "version": "26.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -15662,6 +15353,7 @@
     "node_modules/loader-runner": {
       "version": "4.3.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -15765,6 +15457,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -16470,19 +16163,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "dev": true,
@@ -16536,12 +16216,6 @@
       "version": "3.0.1",
       "license": "MIT"
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "license": "MIT"
@@ -16569,7 +16243,6 @@
     "node_modules/motion": {
       "version": "12.40.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "framer-motion": "^12.40.0",
         "tslib": "^2.4.0"
@@ -16638,12 +16311,6 @@
         "node": "^18 || >=20"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "dev": true,
@@ -16676,7 +16343,6 @@
     "node_modules/next": {
       "version": "14.2.35",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -16764,36 +16430,6 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/node-abi": {
-      "version": "3.92.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "7.8.1",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/node-ensure": {
       "version": "0.0.0",
@@ -17619,7 +17255,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17828,32 +17463,6 @@
       "version": "5.26.5",
       "license": "MIT"
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "license": "MIT",
@@ -17875,6 +17484,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -17888,6 +17498,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18088,34 +17699,9 @@
         "performance-now": "^2.1.0"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -18154,7 +17740,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -18188,7 +17773,6 @@
     "node_modules/react-hook-form": {
       "version": "7.76.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -18223,7 +17807,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -18792,7 +18377,6 @@
     "node_modules/rollup": {
       "version": "4.60.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -19228,32 +18812,6 @@
       ],
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -19826,7 +19384,6 @@
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -19928,48 +19485,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/tar/node_modules/chownr": {
@@ -20109,7 +19624,6 @@
     "node_modules/terser-webpack-plugin/node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -20534,18 +20048,6 @@
       "version": "2.8.1",
       "license": "0BSD"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "license": "MIT",
@@ -20647,7 +20149,6 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20683,6 +20184,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/underscore": {
       "version": "1.13.8",
@@ -21113,6 +20620,7 @@
     "node_modules/watchpack": {
       "version": "2.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -21178,13 +20686,6 @@
         }
       }
     },
-    "node_modules/webpack-sources": {
-      "version": "3.5.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/webpack/node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
@@ -21203,6 +20704,7 @@
     "node_modules/webpack/node_modules/ajv-keywords": {
       "version": "5.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -21212,31 +20714,8 @@
     },
     "node_modules/webpack/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/webpack/node_modules/mime-db": {
-      "version": "1.54.0",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
+      "peer": true
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.54.0",
@@ -21570,7 +21049,6 @@
     "node_modules/workbox-build/node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21640,7 +21118,6 @@
     "node_modules/workbox-build/node_modules/rollup": {
       "version": "2.80.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -22002,7 +21479,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@tanstack/react-query-devtools": "^5.91.3",
     "@types/fabric": "^5.3.10",
     "@types/file-saver": "^2.0.7",
+    "@upstash/redis": "^1.38.0",
     "axios": "^1.15.2",
     "bcryptjs": "^2.4.3",
     "cheerio": "^1.1.2",


### PR DESCRIPTION
Closes #724

## Summary

Adds an optional Redis-backed distributed cache layer using Upstash Redis (serverless-compatible, no persistent connection required). The existing in-memory `BoundedCache` continues to work unchanged; Redis is activated only when the two new environment variables are set, enabling zero-downtime adoption.

## Changes

**`lib/cache-redis.ts`** (new)
- `RedisCache` class implementing the same API as `BoundedCache`: `get`, `set`, `delete`, `invalidateByTag`, `invalidateByPrefix`, `flush`
- TTL is set directly on the Redis key (`EXPIRE`) so expiry is handled server-side
- Tag-based invalidation: each tag is stored as a Redis Set; `invalidateByTag` fetches all keys from those sets and deletes them
- Prefix-based invalidation: uses `SCAN` with a cursor loop to avoid blocking the Redis server on large keyspaces
- All operations are wrapped in try/catch and log a warning on failure rather than throwing, so a Redis outage degrades gracefully to no caching
- `isRedisConfigured()` helper checks for the presence of both required env vars

**`lib/cache.ts`**
- New `distributedCache` export: returns a `RedisCache` instance when configured, otherwise falls back to the existing in-memory `cache` singleton
- All existing exports (`cache`, `aiCache`, `userCache`, `memoizeAsync`) are unchanged

**`.env.example`**
- Documents `UPSTASH_REDIS_URL` and `UPSTASH_REDIS_TOKEN` with a link to the Upstash console

## Setup

1. Create a free Redis database at [console.upstash.com](https://console.upstash.com)
2. Add the two credentials to your environment:
   ```
   UPSTASH_REDIS_URL=https://your-db.upstash.io
   UPSTASH_REDIS_TOKEN=your-token-here
   ```
3. Replace `cache` with `distributedCache` in any call site that should benefit from cross-instance sharing

When the env vars are absent (default for local development) the application behaves exactly as before.

## Test plan

- [ ] Without env vars set, confirm `distributedCache` is the in-memory fallback and all existing behaviour is unchanged
- [ ] With env vars set, confirm `get`/`set`/`delete` round-trips hit Upstash Redis
- [ ] Confirm `invalidateByTag` removes all tagged keys from Redis
- [ ] Confirm that a Redis connection failure logs a warning and does not crash the request handler