### PR TITLE
fix: Add 'use client' directive to client components

### DIFF
--- a/components/delete-dialog.tsx
+++ b/components/delete-dialog.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from 'react';
 import { Button } from '@/components/ui/button';
 import {

--- a/components/templates/share-template-dialog.tsx
+++ b/components/templates/share-template-dialog.tsx
@@ -1,4 +1,6 @@
-import { useState } from "react";
+"use client";
+
+import { useEffect, useState } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -31,9 +33,14 @@ export function ShareTemplateDialog({
   const [canEdit, setCanEdit] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
+  const [origin, setOrigin] = useState("");
   const { toast } = useToast();
 
-  const shareableLink = `${window.location.origin}/templates/${templateId}/shared`;
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
+
+  const shareableLink = origin ? `${origin}/templates/${templateId}/shared` : "";
 
   const handleShare = async () => {
     if (!email) return;
@@ -75,6 +82,7 @@ export function ShareTemplateDialog({
   };
 
   const copyToClipboard = () => {
+    if (!shareableLink) return;
     navigator.clipboard.writeText(shareableLink);
     setIsCopied(true);
     setTimeout(() => setIsCopied(false), 2000);
@@ -145,7 +153,7 @@ export function ShareTemplateDialog({
                 variant="outline"
                 size="icon"
                 onClick={copyToClipboard}
-                disabled={isCopied}
+                disabled={isCopied || !shareableLink}
               >
                 {isCopied ? (
                   <Check className="h-4 w-4 text-green-500" />

--- a/components/templates/template-card.tsx
+++ b/components/templates/template-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";

--- a/components/templates/template-form.tsx
+++ b/components/templates/template-form.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';


### PR DESCRIPTION
## Description

Added missing `"use client"` directives to interactive components using React hooks and browser APIs in the Next.js App Router.

These components were unintentionally treated as Server Components, causing runtime/build issues in template-related flows such as create, edit, share, and delete actions.

Fixes #785 

---

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify): ____________________

---

## Changes Made

- Added `"use client"` directive to:
  - `components/templates/template-card.tsx`
  - `components/templates/share-template-dialog.tsx`
  - `components/templates/template-form.tsx`
  - `components/delete-dialog.tsx`

- Fixed improper client-side API usage in:
  - `share-template-dialog.tsx`

- Ensured components using:
  - `useState`
  - `useRouter`
  - `useForm`
  - `window.location`

  are properly rendered as Client Components.

- Prevented:
  - hydration issues
  - runtime rendering failures
  - App Router server/client boundary errors

---

## Dependencies

- No new dependencies added.
- No version updates required.

---

## Add Screenshots

N/A — no visual UI changes introduced.

---

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers/devices
- [x] I have tested my changes in development mode (`npm run dev`)
- [ ] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of template sharing dialog to handle URL generation more reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->