### PR TITLE
fix: replace console.warn with logger and fix SearchBar stale closure

### DIFF
--- a/__mocks__/@upstash/redis.ts
+++ b/__mocks__/@upstash/redis.ts
@@ -1,0 +1,49 @@
+/**
+ * Jest manual mock for @upstash/redis.
+ *
+ * The real @upstash/redis package ships ESM-only transitive deps (e.g.
+ * uncrypto) that Jest cannot transform out of the box. Since the unit
+ * tests only exercise the in-process BoundedCache, a lightweight stub
+ * is sufficient for the test suite to compile and run without error.
+ */
+
+export class Redis {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async get<T>(_key: string): Promise<T | null> {
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async set(_key: string, _value: unknown, _opts?: unknown): Promise<void> {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async del(..._keys: string[]): Promise<void> {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async smembers(_key: string): Promise<string[]> {
+    return [];
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async sadd(_key: string, ..._members: string[]): Promise<void> {}
+
+  async scan(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _cursor: string | number,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _opts?: unknown,
+  ): Promise<[string | number, string[]]> {
+    return ['0', []];
+  }
+
+  async flushdb(): Promise<void> {}
+
+  pipeline() {
+    const self = this;
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      del: (..._keys: string[]) => self.pipeline(),
+      exec: async () => [],
+    };
+  }
+}

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -93,7 +93,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           if (doc.type === 'presentation') mappedCategory = 'presentation'
           else if (doc.type === 'letter') mappedCategory = 'letter'
           else if (doc.type !== 'resume' && doc.type !== 'cv') {
-            console.warn(`Unknown document type: ${doc.type}, defaulting to resume`)
+            logger.warn({ route: 'app/api/search/route.ts', docType: doc.type }, 'Unknown document type, defaulting to resume')
           }
 
           const textContent = extractTextFromContent(doc.content)

--- a/components/search/SearchBar.tsx
+++ b/components/search/SearchBar.tsx
@@ -66,7 +66,7 @@ export default function SearchBar() {
       if (requestId !== latestRequestId.current) return
       setLoading(false)
     }
-  }, [category, loading])
+  }, [category])
 
   // Debounced search trigger as user types
   useEffect(() => {

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -14,7 +14,10 @@ const createJestConfig = nextJest({ dir: './' });
 const config = {
   testEnvironment: 'jsdom',
   testMatch: ['**/__tests__/**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
-  moduleNameMapper: { '^@/(.*)$': '<rootDir>/$1' },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+    '^@upstash/redis$': '<rootDir>/__mocks__/@upstash/redis.ts',
+  },
   setupFiles: ['<rootDir>/jest.polyfills.cjs'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   collectCoverageFrom: ['lib/**/*.ts', 'app/api/**/*.ts', '!**/__tests__/**'],


### PR DESCRIPTION
## Summary

Closes #661

The database integration in the search API was already in place (real Supabase queries, auth guard, pagination). This PR addresses two remaining issues:

**1. console.warn leaks raw document-type values to server logs**

`app/api/search/route.ts` called `console.warn(\`Unknown document type: ${doc.type}...\`)` which writes unstructured text containing raw DB field values to server logs. Replaced with `logger.warn` (already imported) using the structured object signature consistent with the rest of the file.

**2. Stale closure in SearchBar causes a duplicate fetch after every search**

`handleSearch` in `components/search/SearchBar.tsx` listed `loading` in its `useCallback` dependency array even though `loading` is never read inside the callback. Because `loading` flips `true` then `false` on every request, a new `handleSearch` reference was created twice per search, and the `useEffect([query, handleSearch])` debounce timer re-armed each time, firing an extra API call after every search completed. Removing the unused `loading` dependency stops the loop.

## Changes

- `app/api/search/route.ts`: `console.warn` replaced with `logger.warn`
- `components/search/SearchBar.tsx`: removed `loading` from `handleSearch` deps

## Test plan

- [ ] Typing in the search box fires exactly one request per debounce interval (not two)
- [ ] Changing category filter re-runs search once
- [ ] Unknown document types are logged via the structured logger, not `console.warn`

Could you please add the appropriate GSSoC labels (`gssoc26`, `type:bug`, `level:intermediate`) when you get a chance? Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved logging to use a centralized logger for clearer, structured warnings.
  * Optimized search behavior by reducing unnecessary hook dependencies, improving stability.

* **Tests**
  * Added a local mock for the Redis client and configured test mapping to use it, enabling more reliable unit tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->