### PR TITLE
fix(global-error): remove <html>/<body> wrappers from client error co…

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -15,40 +15,38 @@ export default function GlobalError({
     console.error('Global application error:', error);
   }, [error]);
 
+  // Return a regular fragment / element tree — do not render <html> or <body>
+  // (those are provided by the app root layout in Next.js App Router).
   return (
-    <html lang="en">
-      <body style={{ fontFamily: 'system-ui, -apple-system, sans-serif' }}>
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-white to-gray-50 p-4">
-          <div className="w-full max-w-md">
-            <div className="bg-white rounded-2xl shadow-lg border border-red-200 p-8 text-center space-y-6">
-              <div className="w-16 h-16 bg-red-50 rounded-full flex items-center justify-center mx-auto">
-                <AlertTriangle className="w-8 h-8 text-red-600" />
-              </div>
-              <div className="space-y-2">
-                <h1 className="text-3xl font-bold text-gray-900">Critical Error</h1>
-                <p className="text-gray-600">
-                  We encountered a critical error. Our team has been notified.
-                </p>
-              </div>
-              {process.env.NODE_ENV === 'development' && (
-                <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-left">
-                  <p className="text-xs font-mono font-bold text-red-700 mb-2">Error Details:</p>
-                  <p className="text-xs text-red-600 break-words">{error.message}</p>
-                </div>
-              )}
-              <div className="flex flex-col gap-3 pt-2">
-                <Button onClick={() => reset()} size="lg" className="w-full">
-                  <RefreshCcw className="w-4 h-4 mr-2" /> Try Again
-                </Button>
-                <Button variant="outline" onClick={() => window.location.href = '/'} size="lg" className="w-full">
-                  <Home className="w-4 h-4 mr-2" /> Go to Homepage
-                </Button>
-              </div>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-white to-gray-50 p-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-lg border border-red-200 p-8 text-center space-y-6">
+          <div className="w-16 h-16 bg-red-50 rounded-full flex items-center justify-center mx-auto">
+            <AlertTriangle className="w-8 h-8 text-red-600" />
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold text-gray-900">Critical Error</h1>
+            <p className="text-gray-600">
+              We encountered a critical error. Our team has been notified.
+            </p>
+          </div>
+          {process.env.NODE_ENV === 'development' && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-left">
+              <p className="text-xs font-mono font-bold text-red-700 mb-2">Error Details:</p>
+              <p className="text-xs text-red-600 break-words">{error.message}</p>
             </div>
+          )}
+          <div className="flex flex-col gap-3 pt-2">
+            <Button onClick={() => reset()} size="lg" className="w-full">
+              <RefreshCcw className="w-4 h-4 mr-2" /> Try Again
+            </Button>
+            <Button variant="outline" onClick={() => (window.location.href = '/')} size="lg" className="w-full">
+              <Home className="w-4 h-4 mr-2" /> Go to Homepage
+            </Button>
           </div>
         </div>
-      </body>
-    </html>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Description
Summary: Remove the outer `<html>` and `<body>` wrappers from the client-side global error UI so the App Router root layout remains the single document root. This prevents duplicate document tags, hydration mismatches, and runtime warnings/errors when an error boundary is rendered.

Fixes # (replace with issue number)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes Made
- Removed the top-level `<html lang="en">` and `<body>` wrappers from `app/global-error.tsx`.
- Returned a normal React element tree (root `<div class="min-h-screen ...">...</div>`) so the root layout manages document tags.
- Kept `use client` and `useEffect` logging intact to preserve client-side behavior.

## Files changed
- `app/global-error.tsx`

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers/devices
- [ ] I have tested my changes in development mode (`npm run dev`)
- [ ] I have written or updated related tests, if necessary
- [ ] This is already assigned Issue to me, not an unassigned issue.
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error page rendering to properly display the critical error message and action buttons without injecting unnecessary document-level markup. Error details for developers remain visible in development environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Muneerali199/Draftdeckai/pull/822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->