### PR TITLE
docs: add security.txt and vulnerability disclosure policy (#734)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ Join our official WhatsApp group to connect with other contributors, get help wi
 
 ---
 
+## Security
+
+If you discover any security vulnerabilities, please refer to our [Security Policy](SECURITY.md) for information on how to responsibly disclose them. Please do not report security vulnerabilities via public GitHub issues.
+
 ## 👥 Contributors
 
 We appreciate all contributors who help improve DraftDeckAI ❤️

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+We take the security of Draftdeckai seriously. We appreciate your efforts to responsibly disclose your findings, and we will make every effort to acknowledge your contributions.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability within this project, please **do not** create a public GitHub issue. If you discover a security vulnerability within this project, please **do not** create a public GitHub issue. Instead, please report it via email to **[MAINTAINERS: PLEASE INSERT SECURITY EMAIL HERE]**.
+
+Please include the following details in your report:
+* Description of the location and potential impact of the vulnerability.
+* A detailed description of the steps required to reproduce the vulnerability (POC scripts, screenshots, and compressed packet captures are all helpful).
+* Any relevant background information or technical details.
+
+## Expected Response Time
+
+We aim to respond to all vulnerability reports within **48 hours** of receipt. We will keep you informed of our progress as we investigate and resolve the issue. We aim to triage and fix critical vulnerabilities within 7 days.
+
+## Scope
+
+**In Scope:**
+* Authentication or authorization bypasses.
+* Cross-Site Scripting (XSS), SQL Injection (SQLi), or Cross-Site Request Forgery (CSRF).
+* Data exposure or data leaks.
+* Server-Side Request Forgery (SSRF).
+* Remote Code Execution (RCE).
+
+**Out of Scope:**
+* Volumetric vulnerabilities (e.g., Denial of Service / DDoS).
+* Spam or social engineering techniques (e.g., phishing).
+* Issues requiring physical access to a user's device.
+* Missing security headers that do not lead directly to a vulnerability.
+* Vulnerabilities in third-party integrations (e.g., Stripe, Supabase) unless they are caused by our specific implementation.

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,14 @@
+# Security Contact Information
+Contact: mailto:[MAINTAINERS-PLEASE-INSERT-EMAIL-HERE]
+
+# Link to the Vulnerability Disclosure Policy
+Policy: https://github.com/muneerali199/draftdeckai/blob/main/SECURITY.md
+
+# Preferred Languages for Communication
+Preferred-Languages: en
+
+# Canonical URI for this file
+Canonical: https://draftdeckai.com/.well-known/security.txt
+
+# File Expiry Date (Requires annual renewal)
+Expires: 2027-05-31T00:00:00.000Z


### PR DESCRIPTION
Description
This PR introduces a standard vulnerability disclosure policy and an RFC 9116 compliant security.txt file to establish a secure reporting channel for security researchers.

Fixes #734

🚨 MAINTAINER ACTION REQUIRED BEFORE MERGE: 🚨
As an external contributor, I do not have access to your internal security email. I have left placeholder text in two files. Please update the following lines with your actual security email before or immediately after merging:

Line 6 in SECURITY.md

Line 2 in public/.well-known/security.txt

Changes Made
Added SECURITY.md to the root directory outlining the scope, out-of-scope items, expected response times, and reporting procedures.

Added public/.well-known/security.txt containing the RFC 9116 required fields.

Updated README.md to prominently link to the new security policy.

Testing & Verification
[x] Verified that .well-known/security.txt is placed in the public directory for automatic Next.js static routing.

[x] Verified SECURITY.md renders correctly and matches GitHub's standard security tab format.