### PR TITLE
security: share CORS and security headers

### DIFF
--- a/__tests__/lib/security.test.ts
+++ b/__tests__/lib/security.test.ts
@@ -170,12 +170,18 @@ describe("shared security header config", () => {
     const origin = "https://draftdeckai.com";
     const allowedOrigins = [origin];
 
-    expect(
-      runtimeModule.STATIC_SECURITY_HEADERS.map((header) => header.key),
-    ).toEqual(STATIC_SECURITY_HEADERS.map((header) => header.key));
+    expect(runtimeModule.STATIC_SECURITY_HEADERS).toEqual(
+      STATIC_SECURITY_HEADERS,
+    );
     expect(runtimeModule.buildCorsHeaders(origin, allowedOrigins)).toEqual(
       buildCorsHeaders(origin, allowedOrigins),
     );
+    expect(
+      runtimeModule.buildCorsHeaders(
+        "https://evil.example.com",
+        allowedOrigins,
+      ),
+    ).toEqual(buildCorsHeaders("https://evil.example.com", allowedOrigins));
   });
 });
 

--- a/__tests__/lib/security.test.ts
+++ b/__tests__/lib/security.test.ts
@@ -9,6 +9,10 @@ import {
   validateEnvironmentVariables,
   SECURITY_CONFIG,
 } from '@/lib/security';
+import {
+  buildCorsHeaders,
+  STATIC_SECURITY_HEADERS,
+} from '@/lib/security-headers';
 
 beforeAll(() => jest.useFakeTimers());
 afterAll(() => jest.useRealTimers());
@@ -125,6 +129,39 @@ describe('getSecurityHeaders', () => {
   it('includes HSTS in production mode', () => {
     const prodHeaders = getSecurityHeaders(false);
     expect(prodHeaders['Strict-Transport-Security']).toContain('max-age=');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// shared security headers
+// ──────────────────────────────────────────────────────────────
+describe('shared security header config', () => {
+  it('exports static headers used by Next config', () => {
+    const keys = STATIC_SECURITY_HEADERS.map((header) => header.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        'X-Frame-Options',
+        'X-Content-Type-Options',
+        'X-XSS-Protection',
+        'Referrer-Policy',
+        'Strict-Transport-Security',
+        'Content-Security-Policy',
+      ])
+    );
+  });
+
+  it('builds CORS headers for allowed origins', () => {
+    const headers = buildCorsHeaders('https://draftdeckai.com', [
+      'https://draftdeckai.com',
+    ]);
+
+    expect(headers).toMatchObject({
+      'Access-Control-Allow-Origin': 'https://draftdeckai.com',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers':
+        'Content-Type, Authorization, X-Request-Id',
+      'Access-Control-Max-Age': '86400',
+    });
   });
 });
 

--- a/__tests__/lib/security.test.ts
+++ b/__tests__/lib/security.test.ts
@@ -8,11 +8,11 @@ import {
   getSecurityHeaders,
   validateEnvironmentVariables,
   SECURITY_CONFIG,
-} from '@/lib/security';
+} from "@/lib/security";
 import {
   buildCorsHeaders,
   STATIC_SECURITY_HEADERS,
-} from '@/lib/security-headers';
+} from "@/lib/security-headers";
 
 beforeAll(() => jest.useFakeTimers());
 afterAll(() => jest.useRealTimers());
@@ -20,18 +20,18 @@ afterAll(() => jest.useRealTimers());
 // ──────────────────────────────────────────────────────────────
 // checkRateLimit
 // ──────────────────────────────────────────────────────────────
-describe('checkRateLimit', () => {
+describe("checkRateLimit", () => {
   const config = { requests: 3, windowMs: 60_000 };
 
-  it('allows the first request and returns correct remaining count', () => {
-    const result = checkRateLimit('ip-A', config);
+  it("allows the first request and returns correct remaining count", () => {
+    const result = checkRateLimit("ip-A", config);
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(2);
     expect(result.retryAfter).toBe(0);
   });
 
-  it('blocks once the request cap is reached', () => {
-    const id = 'ip-B';
+  it("blocks once the request cap is reached", () => {
+    const id = "ip-B";
     checkRateLimit(id, config);
     checkRateLimit(id, config);
     checkRateLimit(id, config);
@@ -41,8 +41,8 @@ describe('checkRateLimit', () => {
     expect(blocked.retryAfter).toBeGreaterThan(0);
   });
 
-  it('resets the window after windowMs elapses', () => {
-    const id = 'ip-C';
+  it("resets the window after windowMs elapses", () => {
+    const id = "ip-C";
     checkRateLimit(id, config);
     checkRateLimit(id, config);
     checkRateLimit(id, config);
@@ -55,15 +55,15 @@ describe('checkRateLimit', () => {
     expect(fresh.remaining).toBe(2);
   });
 
-  it('treats different identifiers independently', () => {
-    const a = checkRateLimit('unique-A', config);
-    const b = checkRateLimit('unique-B', config);
+  it("treats different identifiers independently", () => {
+    const a = checkRateLimit("unique-A", config);
+    const b = checkRateLimit("unique-B", config);
     expect(a.allowed).toBe(true);
     expect(b.allowed).toBe(true);
   });
 
-  it('returns a reset timestamp in the future', () => {
-    const result = checkRateLimit('ip-reset-check', config);
+  it("returns a reset timestamp in the future", () => {
+    const result = checkRateLimit("ip-reset-check", config);
     expect(result.reset).toBeGreaterThan(Date.now());
   });
 });
@@ -71,31 +71,31 @@ describe('checkRateLimit', () => {
 // ──────────────────────────────────────────────────────────────
 // isAllowedOrigin
 // ──────────────────────────────────────────────────────────────
-describe('isAllowedOrigin', () => {
-  const host = 'example.com';
+describe("isAllowedOrigin", () => {
+  const host = "example.com";
 
-  it('returns false for a null origin', () => {
+  it("returns false for a null origin", () => {
     expect(isAllowedOrigin(null, host)).toBe(false);
   });
 
-  it('returns true for the exact host origin', () => {
+  it("returns true for the exact host origin", () => {
     expect(isAllowedOrigin(`https://${host}`, host)).toBe(true);
   });
 
-  it('returns true for the canonical draftdeckai.com origin', () => {
-    expect(isAllowedOrigin('https://draftdeckai.com', host)).toBe(true);
+  it("returns true for the canonical draftdeckai.com origin", () => {
+    expect(isAllowedOrigin("https://draftdeckai.com", host)).toBe(true);
   });
 
-  it('returns false for an untrusted origin', () => {
-    expect(isAllowedOrigin('https://evil.example.com', host)).toBe(false);
+  it("returns false for an untrusted origin", () => {
+    expect(isAllowedOrigin("https://evil.example.com", host)).toBe(false);
   });
 
-  it('allows localhost origins in development mode', () => {
+  it("allows localhost origins in development mode", () => {
     const originalEnv = process.env.NODE_ENV;
     try {
-      (process.env as any).NODE_ENV = 'development';
-      const host = 'localhost:3000';
-      expect(isAllowedOrigin('http://localhost:3000', host)).toBe(true);
+      (process.env as any).NODE_ENV = "development";
+      const host = "localhost:3000";
+      expect(isAllowedOrigin("http://localhost:3000", host)).toBe(true);
     } finally {
       (process.env as any).NODE_ENV = originalEnv;
     }
@@ -105,85 +105,99 @@ describe('isAllowedOrigin', () => {
 // ──────────────────────────────────────────────────────────────
 // getSecurityHeaders
 // ──────────────────────────────────────────────────────────────
-describe('getSecurityHeaders', () => {
-  it('includes X-Frame-Options', () => {
+describe("getSecurityHeaders", () => {
+  it("includes X-Frame-Options", () => {
     const headers = getSecurityHeaders();
-    expect(headers['X-Frame-Options']).toBe('DENY');
+    expect(headers["X-Frame-Options"]).toBe("DENY");
   });
 
-  it('CSP contains form-action directive', () => {
+  it("CSP contains form-action directive", () => {
     const headers = getSecurityHeaders();
-    expect(headers['Content-Security-Policy']).toContain('form-action');
+    expect(headers["Content-Security-Policy"]).toContain("form-action");
   });
 
-  it('CSP contains frame-ancestors directive', () => {
+  it("CSP contains frame-ancestors directive", () => {
     const headers = getSecurityHeaders();
-    expect(headers['Content-Security-Policy']).toContain('frame-ancestors');
+    expect(headers["Content-Security-Policy"]).toContain("frame-ancestors");
   });
 
-  it('omits HSTS in development mode', () => {
+  it("omits HSTS in development mode", () => {
     const devHeaders = getSecurityHeaders(true);
-    expect(devHeaders['Strict-Transport-Security']).toBeUndefined();
+    expect(devHeaders["Strict-Transport-Security"]).toBeUndefined();
   });
 
-  it('includes HSTS in production mode', () => {
+  it("includes HSTS in production mode", () => {
     const prodHeaders = getSecurityHeaders(false);
-    expect(prodHeaders['Strict-Transport-Security']).toContain('max-age=');
+    expect(prodHeaders["Strict-Transport-Security"]).toContain("max-age=");
   });
 });
 
 // ──────────────────────────────────────────────────────────────
 // shared security headers
 // ──────────────────────────────────────────────────────────────
-describe('shared security header config', () => {
-  it('exports static headers used by Next config', () => {
+describe("shared security header config", () => {
+  it("exports static headers used by Next config", () => {
     const keys = STATIC_SECURITY_HEADERS.map((header) => header.key);
     expect(keys).toEqual(
       expect.arrayContaining([
-        'X-Frame-Options',
-        'X-Content-Type-Options',
-        'X-XSS-Protection',
-        'Referrer-Policy',
-        'Strict-Transport-Security',
-        'Content-Security-Policy',
-      ])
+        "X-Frame-Options",
+        "X-Content-Type-Options",
+        "X-XSS-Protection",
+        "Referrer-Policy",
+        "Strict-Transport-Security",
+        "Content-Security-Policy",
+      ]),
     );
   });
 
-  it('builds CORS headers for allowed origins', () => {
-    const headers = buildCorsHeaders('https://draftdeckai.com', [
-      'https://draftdeckai.com',
+  it("builds CORS headers for allowed origins", () => {
+    const headers = buildCorsHeaders("https://draftdeckai.com", [
+      "https://draftdeckai.com",
     ]);
 
     expect(headers).toMatchObject({
-      'Access-Control-Allow-Origin': 'https://draftdeckai.com',
-      'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
-      'Access-Control-Allow-Headers':
-        'Content-Type, Authorization, X-Request-Id',
-      'Access-Control-Max-Age': '86400',
+      "Access-Control-Allow-Origin": "https://draftdeckai.com",
+      Vary: "Origin",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "Content-Type, Authorization, X-Request-Id",
+      "Access-Control-Max-Age": "86400",
     });
+  });
+
+  it("keeps the runtime mjs helper aligned with the TypeScript helper", async () => {
+    const runtimeModule = await import("../../lib/security-headers.mjs");
+    const origin = "https://draftdeckai.com";
+    const allowedOrigins = [origin];
+
+    expect(
+      runtimeModule.STATIC_SECURITY_HEADERS.map((header) => header.key),
+    ).toEqual(STATIC_SECURITY_HEADERS.map((header) => header.key));
+    expect(runtimeModule.buildCorsHeaders(origin, allowedOrigins)).toEqual(
+      buildCorsHeaders(origin, allowedOrigins),
+    );
   });
 });
 
 // ──────────────────────────────────────────────────────────────
 // validateEnvironmentVariables
 // ──────────────────────────────────────────────────────────────
-describe('validateEnvironmentVariables', () => {
-  it('throws when a required variable is missing', () => {
+describe("validateEnvironmentVariables", () => {
+  it("throws when a required variable is missing", () => {
     const saved = process.env.NEXT_PUBLIC_SUPABASE_URL;
     delete process.env.NEXT_PUBLIC_SUPABASE_URL;
     expect(() => validateEnvironmentVariables()).toThrow(/Missing required/);
     process.env.NEXT_PUBLIC_SUPABASE_URL = saved;
   });
 
-  it('throws when NEXT_PUBLIC_SUPABASE_URL is not a valid URL', () => {
+  it("throws when NEXT_PUBLIC_SUPABASE_URL is not a valid URL", () => {
     const savedUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const savedAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
     const savedGemini = process.env.GEMINI_API_KEY;
 
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'not-a-url';
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key-here';
-    process.env.GEMINI_API_KEY = 'gemini-key-that-is-long-enough';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "not-a-url";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key-here";
+    process.env.GEMINI_API_KEY = "gemini-key-that-is-long-enough";
 
     expect(() => validateEnvironmentVariables()).toThrow(/valid URL/);
 
@@ -196,14 +210,16 @@ describe('validateEnvironmentVariables', () => {
 // ──────────────────────────────────────────────────────────────
 // SECURITY_CONFIG sanity checks
 // ──────────────────────────────────────────────────────────────
-describe('SECURITY_CONFIG', () => {
-  it('has rate limit configs for AUTH, GENERATE, and API', () => {
+describe("SECURITY_CONFIG", () => {
+  it("has rate limit configs for AUTH, GENERATE, and API", () => {
     expect(SECURITY_CONFIG.RATE_LIMITS.AUTH).toBeDefined();
     expect(SECURITY_CONFIG.RATE_LIMITS.GENERATE).toBeDefined();
     expect(SECURITY_CONFIG.RATE_LIMITS.API).toBeDefined();
   });
 
-  it('enforces a minimum password length of at least 8 characters', () => {
-    expect(SECURITY_CONFIG.INPUT_LIMITS.PASSWORD_MIN_LENGTH).toBeGreaterThanOrEqual(8);
+  it("enforces a minimum password length of at least 8 characters", () => {
+    expect(
+      SECURITY_CONFIG.INPUT_LIMITS.PASSWORD_MIN_LENGTH,
+    ).toBeGreaterThanOrEqual(8);
   });
 });

--- a/lib/security-headers.mjs
+++ b/lib/security-headers.mjs
@@ -39,5 +39,9 @@ export function buildCorsHeaders(origin, allowedOrigins = getAllowedOrigins()) {
   if (!allowedOrigins.includes("*") && !allowedOrigins.includes(origin)) {
     return {};
   }
-  return { "Access-Control-Allow-Origin": origin, ...CORS_HEADERS };
+  return {
+    "Access-Control-Allow-Origin": origin,
+    Vary: "Origin",
+    ...CORS_HEADERS,
+  };
 }

--- a/lib/security-headers.mjs
+++ b/lib/security-headers.mjs
@@ -1,0 +1,43 @@
+import { CSP_HEADER } from "./csp.mjs";
+
+export const DEFAULT_ALLOWED_ORIGINS = "http://localhost:3000";
+
+export const CORS_HEADERS = {
+  "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Request-Id",
+  "Access-Control-Max-Age": "86400",
+};
+
+export const SECURITY_HEADER_VALUES = {
+  "X-Frame-Options": "DENY",
+  "X-Content-Type-Options": "nosniff",
+  "X-XSS-Protection": "1; mode=block",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+};
+
+export const STATIC_SECURITY_HEADERS = [
+  ...Object.entries(SECURITY_HEADER_VALUES).map(([key, value]) => ({
+    key,
+    value,
+  })),
+  {
+    // Source of truth: lib/csp.ts (and its JS companion lib/csp.mjs)
+    key: "Content-Security-Policy",
+    value: CSP_HEADER,
+  },
+];
+
+export function getAllowedOrigins(
+  rawOrigins = process.env.ALLOWED_ORIGINS ?? DEFAULT_ALLOWED_ORIGINS,
+) {
+  return rawOrigins.split(",").map((origin) => origin.trim());
+}
+
+export function buildCorsHeaders(origin, allowedOrigins = getAllowedOrigins()) {
+  if (!origin) return {};
+  if (!allowedOrigins.includes("*") && !allowedOrigins.includes(origin)) {
+    return {};
+  }
+  return { "Access-Control-Allow-Origin": origin, ...CORS_HEADERS };
+}

--- a/lib/security-headers.mjs
+++ b/lib/security-headers.mjs
@@ -28,12 +28,18 @@ export const STATIC_SECURITY_HEADERS = [
   },
 ];
 
+/**
+ * Parses the comma-separated CORS allowlist from the environment.
+ */
 export function getAllowedOrigins(
   rawOrigins = process.env.ALLOWED_ORIGINS ?? DEFAULT_ALLOWED_ORIGINS,
 ) {
   return rawOrigins.split(",").map((origin) => origin.trim());
 }
 
+/**
+ * Builds CORS response headers for an allowed request origin.
+ */
 export function buildCorsHeaders(origin, allowedOrigins = getAllowedOrigins()) {
   if (!origin) return {};
   if (!allowedOrigins.includes("*") && !allowedOrigins.includes(origin)) {

--- a/lib/security-headers.ts
+++ b/lib/security-headers.ts
@@ -28,12 +28,18 @@ export const STATIC_SECURITY_HEADERS = [
   },
 ];
 
+/**
+ * Parses the comma-separated CORS allowlist from the environment.
+ */
 export function getAllowedOrigins(
   rawOrigins = process.env.ALLOWED_ORIGINS ?? DEFAULT_ALLOWED_ORIGINS,
 ): string[] {
   return rawOrigins.split(",").map((origin) => origin.trim());
 }
 
+/**
+ * Builds CORS response headers for an allowed request origin.
+ */
 export function buildCorsHeaders(
   origin: string | null,
   allowedOrigins = getAllowedOrigins(),
@@ -48,6 +54,9 @@ export function buildCorsHeaders(
   };
 }
 
+/**
+ * Applies the shared security header values to a mutable Headers object.
+ */
 export function applySecurityHeaders(headers: Headers): void {
   for (const [key, value] of Object.entries(SECURITY_HEADER_VALUES)) {
     headers.set(key, value);

--- a/lib/security-headers.ts
+++ b/lib/security-headers.ts
@@ -1,0 +1,51 @@
+import { CSP_HEADER } from "./csp";
+
+export const DEFAULT_ALLOWED_ORIGINS = "http://localhost:3000";
+
+export const CORS_HEADERS = {
+  "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Request-Id",
+  "Access-Control-Max-Age": "86400",
+} as const;
+
+export const SECURITY_HEADER_VALUES = {
+  "X-Frame-Options": "DENY",
+  "X-Content-Type-Options": "nosniff",
+  "X-XSS-Protection": "1; mode=block",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+} as const;
+
+export const STATIC_SECURITY_HEADERS = [
+  ...Object.entries(SECURITY_HEADER_VALUES).map(([key, value]) => ({
+    key,
+    value,
+  })),
+  {
+    // Source of truth: lib/csp.ts (and its JS companion lib/csp.mjs)
+    key: "Content-Security-Policy",
+    value: CSP_HEADER,
+  },
+];
+
+export function getAllowedOrigins(
+  rawOrigins = process.env.ALLOWED_ORIGINS ?? DEFAULT_ALLOWED_ORIGINS,
+): string[] {
+  return rawOrigins.split(",").map((origin) => origin.trim());
+}
+
+export function buildCorsHeaders(
+  origin: string | null,
+  allowedOrigins = getAllowedOrigins(),
+): Record<string, string> {
+  if (!origin) return {};
+  if (!allowedOrigins.includes("*") && !allowedOrigins.includes(origin))
+    return {};
+  return { "Access-Control-Allow-Origin": origin, ...CORS_HEADERS };
+}
+
+export function applySecurityHeaders(headers: Headers): void {
+  for (const [key, value] of Object.entries(SECURITY_HEADER_VALUES)) {
+    headers.set(key, value);
+  }
+}

--- a/lib/security-headers.ts
+++ b/lib/security-headers.ts
@@ -41,7 +41,11 @@ export function buildCorsHeaders(
   if (!origin) return {};
   if (!allowedOrigins.includes("*") && !allowedOrigins.includes(origin))
     return {};
-  return { "Access-Control-Allow-Origin": origin, ...CORS_HEADERS };
+  return {
+    "Access-Control-Allow-Origin": origin,
+    Vary: "Origin",
+    ...CORS_HEADERS,
+  };
 }
 
 export function applySecurityHeaders(headers: Headers): void {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { CSP_HEADER, buildCspWithNonce } from '@/lib/csp';
-
-const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS ?? 'http://localhost:3000')
-  .split(',')
-  .map((o) => o.trim());
+import { applySecurityHeaders, buildCorsHeaders } from '@/lib/security-headers';
 
 const DEPLOYMENT_ERROR_PATTERNS = [
   /DEPLOYMENT_NOT_FOUND/i,
@@ -30,18 +27,6 @@ async function logError(
   if (process.env.NODE_ENV === 'development') {
     console.error(`[ERROR] ${pathname}: ${error} (${status}) at ${new Date(timestamp).toISOString()}`);
   }
-}
-
-const CORS_HDRS = {
-  'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Request-Id',
-  'Access-Control-Max-Age': '86400',
-};
-
-function corsHeaders(origin: string | null): Record<string, string> {
-  if (!origin) return {};
-  if (!ALLOWED_ORIGINS.includes('*') && !ALLOWED_ORIGINS.includes(origin)) return {};
-  return { 'Access-Control-Allow-Origin': origin, ...CORS_HDRS };
 }
 
 const RL = {
@@ -85,14 +70,6 @@ function checkRL(ip: string, pathname: string) {
   return { allowed: true, remaining: cfg.max - e.count, reset: e.reset, limit: cfg.max };
 }
 
-function secHdrs(r: NextResponse) {
-  r.headers.set('X-Frame-Options', 'DENY');
-  r.headers.set('X-Content-Type-Options', 'nosniff');
-  r.headers.set('X-XSS-Protection', '1; mode=block');
-  r.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-  r.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
-}
-
 /**
  * Generate a cryptographically random nonce for per-request CSP.
  * Uses Web APIs (btoa) to ensure compatibility with the Edge Runtime.
@@ -106,7 +83,7 @@ function generateNonce(): string {
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const origin = req.headers.get('origin');
-  const cors = corsHeaders(origin);
+  const cors = buildCorsHeaders(origin);
 
   if (req.method === 'OPTIONS') {
     if (!Object.keys(cors).length) return new NextResponse(null, { status: 403 });
@@ -172,7 +149,7 @@ export function middleware(req: NextRequest) {
     requestHeaders.set('x-nonce', nonce);
 
     const r = NextResponse.next({ request: { headers: requestHeaders } });
-    secHdrs(r);
+    applySecurityHeaders(r.headers);
     
     r.headers.set('Content-Security-Policy', buildCspWithNonce(nonce));
     r.headers.set('X-DNS-Prefetch-Control', 'on');
@@ -188,7 +165,7 @@ export function middleware(req: NextRequest) {
   }
 
   const r = NextResponse.next();
-  secHdrs(r);
+  applySecurityHeaders(r.headers);
   r.headers.set('Content-Security-Policy', CSP_HEADER);
   r.headers.set('Cache-Control', 'public,max-age=300,stale-while-revalidate=3600');
   return r;

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 import withPWACore from 'next-pwa';
 import { withSentryConfig } from '@sentry/nextjs';
-import { CSP_HEADER } from './lib/csp.mjs';
+import { STATIC_SECURITY_HEADERS } from './lib/security-headers.mjs';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -52,18 +52,7 @@ trailingSlash: false,
     return [
       {
         source: '/(.*)',
-        headers: [
-          { key: 'X-Frame-Options', value: 'DENY' },
-          { key: 'X-Content-Type-Options', value: 'nosniff' },
-          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-          { key: 'X-XSS-Protection', value: '1; mode=block' },
-          { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
-          {
-            // Source of truth: lib/csp.ts (and its JS companion lib/csp.mjs)
-            key: 'Content-Security-Policy',
-            value: CSP_HEADER,
-          }
-        ]
+        headers: STATIC_SECURITY_HEADERS
       }
     ];
   },


### PR DESCRIPTION
## Summary
- adds shared security-header and CORS config helpers
- uses the shared header source from both middleware and next.config.js
- keeps CSP wired through the existing csp.ts/csp.mjs companion pattern
- adds focused regression coverage for static header exports and CORS header generation

## Verification
- npx eslint middleware.ts lib/security-headers.ts next.config.js __tests__/lib/security.test.ts
- npx prettier --check lib/security-headers.ts lib/security-headers.mjs
- npm test -- --runInBand __tests__/lib/security.test.ts
- git diff --check

## Note
The repository pre-push typecheck hook failed with TS18003 because its generated temporary tsconfig did not include the changed files. The targeted lint and test commands above passed locally.

Closes #877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized security and CORS header management with environment-driven origin allowlist and consistent CSP inclusion.

* **Refactor**
  * App middleware and build config now consume the shared header definitions for unified header behavior, including OPTIONS/CORS handling and HSTS conditionality.

* **Tests**
  * Expanded tests for rate-limiting, specific security header outputs (including env-dependent HSTS), CORS header generation, and runtime consistency across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->