### PR TITLE
Add LinkedIn profile consent controls

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -39,11 +39,11 @@
         if (hostname.includes('leetcode.com')) return 'leetcode';
         if (hostname.includes('hackerrank.com')) return 'hackerrank';
         if (hostname.includes('codeforces.com')) return 'codeforces';
+        if (hostname.includes('linkedin.com/jobs')) return 'linkedin-jobs';
         if (hostname.includes('geeksforgeeks.org')) return 'geeksforgeeks';
         if (hostname.includes('linkedin.com')) return 'linkedin';
         
         // Job portals
-        if (hostname.includes('linkedin.com/jobs')) return 'linkedin-jobs';
         if (hostname.includes('indeed.com')) return 'indeed';
         if (hostname.includes('wellfound.com') || hostname.includes('angel.co')) return 'wellfound';
         if (hostname.includes('glassdoor.com')) return 'glassdoor';
@@ -51,6 +51,48 @@
         return null;
     }
     
+    const LINKEDIN_CONSENT_KEY = 'draftdeckai_linkedin_profile_consent';
+    const AUTO_DETECT_DISABLED_KEY = 'draftdeckai_auto_detection_disabled';
+
+    function getStoredValue(key) {
+        return new Promise((resolve) => {
+            try {
+                chrome.storage.local.get([key], (result) => {
+                    resolve(result?.[key]);
+                });
+            } catch (error) {
+                console.warn('DraftDeckAI storage read failed:', error);
+                resolve(undefined);
+            }
+        });
+    }
+
+    function setStoredValue(key, value) {
+        return new Promise((resolve) => {
+            try {
+                chrome.storage.local.set({ [key]: value }, resolve);
+            } catch (error) {
+                console.warn('DraftDeckAI storage write failed:', error);
+                resolve();
+            }
+        });
+    }
+
+    function removeStoredValue(key) {
+        return new Promise((resolve) => {
+            try {
+                chrome.storage.local.remove(key, resolve);
+            } catch (error) {
+                console.warn('DraftDeckAI storage remove failed:', error);
+                resolve();
+            }
+        });
+    }
+
+    async function isAutoDetectionDisabled() {
+        return getStoredValue(AUTO_DETECT_DISABLED_KEY);
+    }
+
     function injectHelper(platform) {
         // Create floating helper button
         const helperButton = document.createElement('div');
@@ -65,7 +107,11 @@
         document.body.appendChild(helperButton);
         
         // Add click handler
-        helperButton.querySelector('.draftdeckai-btn').addEventListener('click', () => {
+        helperButton.querySelector('.draftdeckai-btn').addEventListener('click', async () => {
+            if (platform === 'linkedin') {
+                const consented = await ensureLinkedInConsent();
+                if (!consented) return;
+            }
             const problemData = extractProblemData(platform);
             showHelpModal(problemData);
         });
@@ -190,6 +236,79 @@
             url: window.location.href,
             timestamp: new Date().toISOString()
         };
+    }
+
+    async function ensureLinkedInConsent() {
+        const storedConsent = await getStoredValue(LINKEDIN_CONSENT_KEY);
+        if (storedConsent === true) return true;
+        if (storedConsent === false) return false;
+
+        return showLinkedInConsentPrompt();
+    }
+
+    function showLinkedInConsentPrompt() {
+        return new Promise((resolve) => {
+            const existing = document.getElementById('draftdeckai-linkedin-consent');
+            if (existing) existing.remove();
+
+            const prompt = document.createElement('div');
+            prompt.id = 'draftdeckai-linkedin-consent';
+            prompt.style.cssText = `
+                position: fixed;
+                right: 20px;
+                bottom: 20px;
+                width: min(360px, calc(100vw - 32px));
+                padding: 18px;
+                border-radius: 14px;
+                background: white;
+                color: #111827;
+                box-shadow: 0 18px 55px rgba(0,0,0,0.28);
+                z-index: 9999999;
+                font-family: system-ui, -apple-system, sans-serif;
+            `;
+
+            prompt.innerHTML = `
+                <div style="font-weight: 800; font-size: 1rem; margin-bottom: 8px;">
+                    Allow LinkedIn profile analysis?
+                </div>
+                <div style="font-size: 0.9rem; line-height: 1.5; color: #4b5563; margin-bottom: 14px;">
+                    DraftDeckAI will read visible profile text only after you approve. You can disable auto-detection for future pages.
+                </div>
+                <label style="display: flex; align-items: center; gap: 8px; font-size: 0.85rem; color: #374151; margin-bottom: 14px;">
+                    <input id="draftdeckai-disable-auto-detect" type="checkbox" />
+                    Disable automatic detection prompts
+                </label>
+                <div style="display: flex; gap: 8px;">
+                    <button id="draftdeckai-consent-allow" style="flex: 1; padding: 10px; border: 0; border-radius: 8px; background: #0A66C2; color: white; font-weight: 700; cursor: pointer;">
+                        Allow
+                    </button>
+                    <button id="draftdeckai-consent-deny" style="flex: 1; padding: 10px; border: 1px solid #d1d5db; border-radius: 8px; background: white; color: #111827; font-weight: 700; cursor: pointer;">
+                        Not now
+                    </button>
+                </div>
+            `;
+
+            document.body.appendChild(prompt);
+
+            const disableAutoDetect = prompt.querySelector('#draftdeckai-disable-auto-detect');
+            prompt.querySelector('#draftdeckai-consent-allow')?.addEventListener('click', async () => {
+                await setStoredValue(LINKEDIN_CONSENT_KEY, true);
+                await setStoredValue(AUTO_DETECT_DISABLED_KEY, !!disableAutoDetect?.checked);
+                prompt.remove();
+                resolve(true);
+            });
+
+            prompt.querySelector('#draftdeckai-consent-deny')?.addEventListener('click', async () => {
+                if (disableAutoDetect?.checked) {
+                    await setStoredValue(LINKEDIN_CONSENT_KEY, false);
+                    await setStoredValue(AUTO_DETECT_DISABLED_KEY, true);
+                } else {
+                    await removeStoredValue(LINKEDIN_CONSENT_KEY);
+                }
+                prompt.remove();
+                resolve(false);
+            });
+        });
     }
     
     // Observe page changes for single-page applications
@@ -640,17 +759,46 @@
     
     // Auto-generate resume for job posting
     async function handleJobPosting() {
+        if (await isAutoDetectionDisabled()) return;
+
         const jobData = detectJobPosting();
         if (!jobData) return;
         
-        // Show floating action button
-        showJobAssistant(jobData);
+        showJobAssistantLauncher(jobData);
+    }
+
+    function showJobAssistantLauncher(jobData) {
+        const existing = document.getElementById('draftdeckai-job-assistant-launcher');
+        if (existing) existing.remove();
+
+        const launcher = document.createElement('button');
+        launcher.id = 'draftdeckai-job-assistant-launcher';
+        launcher.type = 'button';
+        launcher.style.cssText = `
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            z-index: 999999;
+            padding: 12px 16px;
+            border: none;
+            border-radius: 999px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            font-weight: 700;
+            font-family: system-ui, -apple-system, sans-serif;
+            box-shadow: 0 10px 35px rgba(0,0,0,0.28);
+            cursor: pointer;
+        `;
+        launcher.textContent = 'Open DraftDeckAI Job Assistant';
+        launcher.addEventListener('click', () => showJobAssistant(jobData));
+        document.body.appendChild(launcher);
     }
     
     function showJobAssistant(jobData) {
         // Remove existing assistant
         const existing = document.getElementById('draftdeckai-job-assistant');
         if (existing) existing.remove();
+        document.getElementById('draftdeckai-job-assistant-launcher')?.remove();
         
         const assistant = document.createElement('div');
         assistant.id = 'draftdeckai-job-assistant';

--- a/extension/content.js
+++ b/extension/content.js
@@ -35,11 +35,12 @@
     
     function detectPlatform() {
         const hostname = window.location.hostname;
+        const pathname = window.location.pathname;
         
         if (hostname.includes('leetcode.com')) return 'leetcode';
         if (hostname.includes('hackerrank.com')) return 'hackerrank';
         if (hostname.includes('codeforces.com')) return 'codeforces';
-        if (hostname.includes('linkedin.com/jobs')) return 'linkedin-jobs';
+        if (hostname.includes('linkedin.com') && pathname.startsWith('/jobs')) return 'linkedin-jobs';
         if (hostname.includes('geeksforgeeks.org')) return 'geeksforgeeks';
         if (hostname.includes('linkedin.com')) return 'linkedin';
         
@@ -58,6 +59,12 @@
         return new Promise((resolve) => {
             try {
                 chrome.storage.local.get([key], (result) => {
+                    if (chrome.runtime.lastError) {
+                        console.warn('DraftDeckAI storage read failed:', chrome.runtime.lastError);
+                        resolve(undefined);
+                        return;
+                    }
+
                     resolve(result?.[key]);
                 });
             } catch (error) {
@@ -70,7 +77,13 @@
     function setStoredValue(key, value) {
         return new Promise((resolve) => {
             try {
-                chrome.storage.local.set({ [key]: value }, resolve);
+                chrome.storage.local.set({ [key]: value }, () => {
+                    if (chrome.runtime.lastError) {
+                        console.warn('DraftDeckAI storage write failed:', chrome.runtime.lastError);
+                    }
+
+                    resolve();
+                });
             } catch (error) {
                 console.warn('DraftDeckAI storage write failed:', error);
                 resolve();
@@ -81,7 +94,13 @@
     function removeStoredValue(key) {
         return new Promise((resolve) => {
             try {
-                chrome.storage.local.remove(key, resolve);
+                chrome.storage.local.remove(key, () => {
+                    if (chrome.runtime.lastError) {
+                        console.warn('DraftDeckAI storage remove failed:', chrome.runtime.lastError);
+                    }
+
+                    resolve();
+                });
             } catch (error) {
                 console.warn('DraftDeckAI storage remove failed:', error);
                 resolve();
@@ -990,8 +1009,7 @@
     }
     
     // Check for job postings on page load
-    if (detectPlatform()?.includes('jobs') || detectPlatform()?.includes('indeed') || 
-        detectPlatform()?.includes('wellfound') || detectPlatform()?.includes('glassdoor')) {
+    if (platform && ['linkedin-jobs', 'indeed', 'wellfound', 'glassdoor'].includes(platform)) {
         setTimeout(handleJobPosting, 2000);
     }
     

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -162,6 +162,17 @@
 
                     <label class="preference-item">
                         <div class="preference-info">
+                            <h3>LinkedIn Profile Detection</h3>
+                            <p>Ask for consent before reading visible LinkedIn profile text</p>
+                        </div>
+                        <label class="switch">
+                            <input type="checkbox" id="linkedin-auto-detect" checked>
+                            <span class="slider"></span>
+                        </label>
+                    </label>
+
+                    <label class="preference-item">
+                        <div class="preference-info">
                             <h3>Show Notifications</h3>
                             <p>Get notified when solutions are ready</p>
                         </div>

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -7,7 +7,8 @@ const STORAGE_KEYS = {
     OPENAI_KEY: 'openai_api_key',
     MISTRAL_KEY: 'mistral_api_key',
     CLAUDE_KEY: 'claude_api_key',
-    SETTINGS: 'settings'
+    SETTINGS: 'settings',
+    LINKEDIN_AUTO_DETECT_DISABLED: 'draftdeckai_auto_detection_disabled'
 };
 
 // Load settings on page load
@@ -25,7 +26,8 @@ async function loadSettings() {
             STORAGE_KEYS.OPENAI_KEY,
             STORAGE_KEYS.MISTRAL_KEY,
             STORAGE_KEYS.CLAUDE_KEY,
-            STORAGE_KEYS.SETTINGS
+            STORAGE_KEYS.SETTINGS,
+            STORAGE_KEYS.LINKEDIN_AUTO_DETECT_DISABLED
         ]);
 
         // Load AI provider
@@ -47,6 +49,7 @@ async function loadSettings() {
         };
 
         document.getElementById('auto-detect').checked = settings.autoDetect;
+        document.getElementById('linkedin-auto-detect').checked = result[STORAGE_KEYS.LINKEDIN_AUTO_DETECT_DISABLED] !== true;
         document.getElementById('notifications').checked = settings.notifications;
         document.getElementById('hints-first').checked = settings.showHintsFirst;
         document.getElementById('default-language').value = settings.defaultLanguage;
@@ -111,6 +114,7 @@ async function saveSettings() {
             showHintsFirst: document.getElementById('hints-first').checked,
             defaultLanguage: document.getElementById('default-language').value
         };
+        const linkedinAutoDetectDisabled = !document.getElementById('linkedin-auto-detect').checked;
 
         // Save to storage
         await chrome.storage.local.set({
@@ -119,7 +123,8 @@ async function saveSettings() {
             [STORAGE_KEYS.OPENAI_KEY]: openaiKey,
             [STORAGE_KEYS.MISTRAL_KEY]: mistralKey,
             [STORAGE_KEYS.CLAUDE_KEY]: claudeKey,
-            [STORAGE_KEYS.SETTINGS]: settings
+            [STORAGE_KEYS.SETTINGS]: settings,
+            [STORAGE_KEYS.LINKEDIN_AUTO_DETECT_DISABLED]: linkedinAutoDetectDisabled
         });
 
         // Update status badges
@@ -203,6 +208,7 @@ async function resetSettings() {
         document.getElementById('claude-api-key').value = '';
 
         document.getElementById('auto-detect').checked = true;
+        document.getElementById('linkedin-auto-detect').checked = true;
         document.getElementById('notifications').checked = true;
         document.getElementById('hints-first').checked = true;
         document.getElementById('default-language').value = 'javascript';


### PR DESCRIPTION
## Summary
- add opt-in consent before reading visible LinkedIn profile data
- add a settings toggle to disable LinkedIn/job auto-detection prompts
- show a job assistant launcher first instead of opening the full assistant panel automatically
- fix LinkedIn job page platform detection order

Closes #892

## GSSoC
- Label: gssoc:approved
- Level: level:intermediate

## Validation
- node --check extension/content.js
- node --check extension/settings.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LinkedIn Profile Detection preference in settings to control profile data reading.
  * Introduced consent prompt for LinkedIn with option to disable future auto-detection.
  * Added floating launcher button for job assistant on job portal pages, replacing direct display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->