### PR TITLE
Throttle MCP auto scanning

### DIFF
--- a/extension/mcp-server.js
+++ b/extension/mcp-server.js
@@ -11,6 +11,7 @@ class MCPServer {
         this.analysisCache = new Map();
         
         this.config = {
+            configVersion: 2,
             scanInterval: 10000,
             inputDebounceMs: 1500,
             maxCacheSize: 100,
@@ -50,7 +51,16 @@ class MCPServer {
     async loadConfig() {
         const stored = await chrome.storage.local.get(['mcp_config']);
         if (stored.mcp_config) {
-            this.config = { ...this.config, ...stored.mcp_config };
+            const storedConfig = { ...stored.mcp_config };
+            const needsMigration = !storedConfig.configVersion || storedConfig.scanInterval === 2000;
+
+            if (needsMigration) {
+                storedConfig.configVersion = this.config.configVersion;
+                storedConfig.scanInterval = this.config.scanInterval;
+                await chrome.storage.local.set({ mcp_config: storedConfig });
+            }
+
+            this.config = { ...this.config, ...storedConfig };
         }
     }
     
@@ -82,6 +92,9 @@ class MCPServer {
     
     async scanCurrentPage() {
         if (this.isScanning) return;
+        if (!this.isRunning) return;
+
+        this.isScanning = true;
 
         try {
             const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -103,7 +116,6 @@ class MCPServer {
             }
             
             // Inject content scanner
-            this.isScanning = true;
             const result = await chrome.tabs.sendMessage(tab.id, {
                 type: 'MCP_SCAN_PAGE'
             });
@@ -121,12 +133,15 @@ class MCPServer {
     }
 
     scheduleDebouncedScan() {
+        if (!this.isRunning) return;
+
         if (this.debounceTimer) {
             clearTimeout(this.debounceTimer);
         }
 
         this.debounceTimer = setTimeout(() => {
             this.debounceTimer = null;
+            if (!this.isRunning) return;
             this.scanCurrentPage();
         }, this.config.inputDebounceMs);
     }

--- a/extension/mcp-server.js
+++ b/extension/mcp-server.js
@@ -5,11 +5,14 @@ class MCPServer {
     constructor() {
         this.isRunning = false;
         this.scanInterval = null;
+        this.debounceTimer = null;
+        this.isScanning = false;
         this.lastScannedContent = null;
         this.analysisCache = new Map();
         
         this.config = {
-            scanInterval: 2000,
+            scanInterval: 10000,
+            inputDebounceMs: 1500,
             maxCacheSize: 100,
             enableAutoScan: true,
             enableContextAnalysis: true,
@@ -59,6 +62,7 @@ class MCPServer {
         if (this.scanInterval) return;
         
         console.log('🔍 Starting auto-scan...');
+        this.scanCurrentPage();
         this.scanInterval = setInterval(() => {
             this.scanCurrentPage();
         }, this.config.scanInterval);
@@ -69,9 +73,16 @@ class MCPServer {
             clearInterval(this.scanInterval);
             this.scanInterval = null;
         }
+
+        if (this.debounceTimer) {
+            clearTimeout(this.debounceTimer);
+            this.debounceTimer = null;
+        }
     }
     
     async scanCurrentPage() {
+        if (this.isScanning) return;
+
         try {
             const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
             if (!tabs[0]) return;
@@ -81,8 +92,18 @@ class MCPServer {
             
             // Check if it's a supported platform
             if (!this.isSupportedPlatform(url)) return;
+
+            const pageState = await this.getPageScanState(tab.id);
+            if (pageState?.visibilityState === 'hidden') return;
+
+            const lastInputAt = pageState?.lastInputAt || 0;
+            if (lastInputAt && Date.now() - lastInputAt < this.config.inputDebounceMs) {
+                this.scheduleDebouncedScan();
+                return;
+            }
             
             // Inject content scanner
+            this.isScanning = true;
             const result = await chrome.tabs.sendMessage(tab.id, {
                 type: 'MCP_SCAN_PAGE'
             });
@@ -94,6 +115,51 @@ class MCPServer {
         } catch (error) {
             // Silent fail - page might not be ready
             console.debug('Scan failed:', error.message);
+        } finally {
+            this.isScanning = false;
+        }
+    }
+
+    scheduleDebouncedScan() {
+        if (this.debounceTimer) {
+            clearTimeout(this.debounceTimer);
+        }
+
+        this.debounceTimer = setTimeout(() => {
+            this.debounceTimer = null;
+            this.scanCurrentPage();
+        }, this.config.inputDebounceMs);
+    }
+
+    async getPageScanState(tabId) {
+        try {
+            const [result] = await chrome.scripting.executeScript({
+                target: { tabId },
+                func: () => {
+                    if (!window.__draftDeckAIInputTrackingInstalled) {
+                        window.__draftDeckAIInputTrackingInstalled = true;
+                        window.__draftDeckAILastInputAt = 0;
+
+                        const markInput = () => {
+                            window.__draftDeckAILastInputAt = Date.now();
+                        };
+
+                        document.addEventListener('input', markInput, true);
+                        document.addEventListener('keydown', markInput, true);
+                        document.addEventListener('pointerdown', markInput, true);
+                    }
+
+                    return {
+                        visibilityState: document.visibilityState,
+                        lastInputAt: window.__draftDeckAILastInputAt || 0
+                    };
+                }
+            });
+
+            return result?.result || null;
+        } catch (error) {
+            console.debug('Page state check failed:', error.message);
+            return null;
         }
     }
     


### PR DESCRIPTION
Closes #885

GSSoC labels/level: `gssoc:approved`, `level:intermediate`

## Summary
- Increase MCP auto-scan interval from 2 seconds to 10 seconds.
- Add a debounce window after user input before scanning resumes.
- Skip scans while the active page is hidden.
- Prevent duplicate overlapping scans with an in-flight guard.

## Validation
- `node --check extension/mcp-server.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart input-aware scanning: debounces re-scans while users interact
  * Page-visibility optimization: skips scanning on inactive tabs to save resources
  * Immediate scan when auto-scanning starts for faster responsiveness
  * Seamless migration of older scan settings to the new configuration

* **Bug Fixes**
  * Prevents leftover scheduled scans after auto-scan is stopped
<!-- end of auto-generated comment: release notes by coderabbit.ai -->