### PR TITLE
Add inline validation to key forms

### DIFF
--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 import { useState, useEffect, Suspense, useCallback } from "react";
 import { useRouter } from "next/navigation";
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
+import { z } from "zod";
 
 // 1. Import our custom tracker
 import { useTrackEvent } from "@/hooks/useTrackEvent";
@@ -64,6 +65,26 @@ const GitHubIcon = () => (
   </svg>
 );
 
+const registerSchema = z
+  .object({
+    name: z.string().trim().min(2, "Full name must be at least 2 characters"),
+    email: z.string().trim().email("Please enter a valid email address"),
+    password: z
+      .string()
+      .min(8, "Password must be at least 8 characters long")
+      .regex(/[A-Z]/, "Password must include at least one uppercase letter")
+      .regex(/[a-z]/, "Password must include at least one lowercase letter")
+      .regex(/[0-9]/, "Password must include at least one number"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine((values) => values.password === values.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
+type RegisterField = keyof z.infer<typeof registerSchema>;
+type RegisterErrors = Partial<Record<RegisterField, string>>;
+
 function RegisterForm() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -79,10 +100,11 @@ function RegisterForm() {
   const [success, setSuccess] = useState(false);
   const [submittedEmail, setSubmittedEmail] = useState<string>("");
   const [referralCode, setReferralCode] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<RegisterErrors>({});
   const router = useRouter();
   const { toast } = useToast();
   const supabase = createClient();
-  
+
   // 2. Initialize the tracker
   const { trackEvent } = useTrackEvent();
 
@@ -108,10 +130,10 @@ function RegisterForm() {
   // OAuth Sign In Handler
   const handleOAuthSignIn = async (provider: "google" | "github") => {
     setIsOAuthLoading(provider);
-    
+
     // Track OAuth clicks
     trackEvent("OAuth Signup Clicked", { provider });
-    
+
     try {
       const redirectTo = `${window.location.origin}/auth/callback?type=signup${referralCode ? `&ref=${referralCode}` : ""}`;
 
@@ -143,37 +165,23 @@ function RegisterForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (password !== confirmPassword) {
-      toast({
-        title: "Passwords don't match",
-        description: "Please make sure both passwords are identical.",
-        variant: "destructive",
+    const validation = registerSchema.safeParse({
+      name,
+      email,
+      password,
+      confirmPassword,
+    });
+    if (!validation.success) {
+      const nextErrors: RegisterErrors = {};
+      validation.error.issues.forEach((issue) => {
+        const field = issue.path[0] as RegisterField;
+        nextErrors[field] = issue.message;
       });
+      setFieldErrors(nextErrors);
       return;
     }
 
-    if (password.length < 8) {
-      toast({
-        title: "Password too short",
-        description: "Password must be at least 8 characters long.",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    const hasUppercase = /[A-Z]/.test(password);
-    const hasLowercase = /[a-z]/.test(password);
-    const hasNumber = /[0-9]/.test(password);
-
-    if (!hasUppercase || !hasLowercase || !hasNumber) {
-      toast({
-        title: "Password too simple",
-        description: "Password must contain at least one uppercase letter, one lowercase letter, and one number.",
-        variant: "destructive",
-      });
-      return;
-    }
-
+    setFieldErrors({});
     setIsLoading(true);
 
     try {
@@ -228,7 +236,7 @@ function RegisterForm() {
           error.message.includes("User already exists") ||
           error.message.includes("email address is already registered") ||
           error.message.includes(
-            "duplicate key value violates unique constraint"
+            "duplicate key value violates unique constraint",
           )
         ) {
           userMessage =
@@ -265,35 +273,35 @@ function RegisterForm() {
     }
   };
 
-  const isFormValid =
-    name.trim() &&
-    email.trim() &&
-    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) &&
-    password.trim() &&
-    confirmPassword.trim() &&
-    password === confirmPassword &&
-    password.length >= 8 &&
-    /[A-Z]/.test(password) &&
-    /[a-z]/.test(password) &&
-    /[0-9]/.test(password);
+  const isFormValid = registerSchema.safeParse({
+    name,
+    email,
+    password,
+    confirmPassword,
+  }).success;
 
   // Memoized referral handler to prevent unnecessary re-renders
-  const handleReferral = useCallback((code: string | null) => {
-    setReferralCode(code);
-    if (code) {
-      toast({
-        title: "Referral Applied",
-        description: "Your referral code has been applied successfully.",
-      });
-    }
-  }, [toast]);
+  const handleReferral = useCallback(
+    (code: string | null) => {
+      setReferralCode(code);
+      if (code) {
+        toast({
+          title: "Referral Applied",
+          description: "Your referral code has been applied successfully.",
+        });
+      }
+    },
+    [toast],
+  );
 
   // Success view: show verification instructions
   if (success) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background relative overflow-hidden py-8">
         <div className="absolute inset-0 mesh-gradient opacity-20 animate-pulse-glow"></div>
-        <div className={`w-full max-w-md mx-4 relative z-10 transition-all duration-1000 ease-out ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}>
+        <div
+          className={`w-full max-w-md mx-4 relative z-10 transition-all duration-1000 ease-out ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}
+        >
           <div className="glass-effect p-6 sm:p-8 rounded-2xl shadow-2xl border border-yellow-400/20 relative overflow-hidden group backdrop-blur-xl">
             <div className="relative z-10 space-y-6">
               <div className="text-center">
@@ -304,8 +312,12 @@ function RegisterForm() {
                   Verify Your Email
                 </h1>
                 <p className="modern-body text-muted-foreground text-sm sm:text-base">
-                  We sent a verification link to <span className="font-medium text-foreground">{submittedEmail}</span>.
-                  Please check your inbox and confirm your email to complete signup.
+                  We sent a verification link to{" "}
+                  <span className="font-medium text-foreground">
+                    {submittedEmail}
+                  </span>
+                  . Please check your inbox and confirm your email to complete
+                  signup.
                 </p>
               </div>
 
@@ -314,16 +326,21 @@ function RegisterForm() {
                   className="w-full bolt-gradient text-white font-semibold py-4 rounded-xl"
                   onClick={async () => {
                     try {
-                      const { error } = await supabase.auth.resend({ type: "signup", email: submittedEmail });
+                      const { error } = await supabase.auth.resend({
+                        type: "signup",
+                        email: submittedEmail,
+                      });
                       if (error) throw error;
                       toast({
                         title: "Verification Email Resent",
-                        description: "Check your inbox (and spam folder) for the new link.",
+                        description:
+                          "Check your inbox (and spam folder) for the new link.",
                       });
                     } catch (err: any) {
                       toast({
                         title: "Couldn't resend email",
-                        description: err.message || "Please try again in a moment.",
+                        description:
+                          err.message || "Please try again in a moment.",
                         variant: "destructive",
                       });
                     }
@@ -343,12 +360,23 @@ function RegisterForm() {
               </div>
 
               <div className="text-center text-xs text-muted-foreground">
-                <p>If you don't see the email, check your spam or promotions folder.</p>
-                <p>Make sure your Supabase project allows redirects from your current domain.</p>
+                <p>
+                  If you don't see the email, check your spam or promotions
+                  folder.
+                </p>
+                <p>
+                  Make sure your Supabase project allows redirects from your
+                  current domain.
+                </p>
               </div>
 
               <div className="text-center">
-                <Link href="/auth/signin" className="text-sm font-medium bolt-gradient-text">Back to Sign In</Link>
+                <Link
+                  href="/auth/signin"
+                  className="text-sm font-medium bolt-gradient-text"
+                >
+                  Back to Sign In
+                </Link>
               </div>
             </div>
           </div>
@@ -381,8 +409,9 @@ function RegisterForm() {
       />
 
       <div
-        className={`w-full max-w-md mx-4 relative z-10 transition-all duration-1000 ease-out ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
-          }`}
+        className={`w-full max-w-md mx-4 relative z-10 transition-all duration-1000 ease-out ${
+          mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
+        }`}
       >
         {/* Enhanced card with advanced glass effect and magnetic cursor */}
         <div className="glass-effect p-6 sm:p-8 rounded-2xl shadow-2xl border border-yellow-400/20 relative overflow-hidden group hover:border-yellow-400/40 transition-all duration-500 hover:shadow-3xl backdrop-blur-xl">
@@ -409,10 +438,11 @@ function RegisterForm() {
           <div className="relative z-10">
             {/* Enhanced header with advanced animations */}
             <div
-              className={`text-center mb-6 sm:mb-8 transition-all duration-700 delay-200 ${mounted
-                ? "opacity-100 translate-y-0"
-                : "opacity-0 translate-y-4"
-                }`}
+              className={`text-center mb-6 sm:mb-8 transition-all duration-700 delay-200 ${
+                mounted
+                  ? "opacity-100 translate-y-0"
+                  : "opacity-0 translate-y-4"
+              }`}
             >
               {/* Professional badge with hover effects */}
               <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full glass-effect mb-4 badge-bg group hover:scale-105 transition-all duration-300 cursor-pointer">
@@ -439,13 +469,17 @@ function RegisterForm() {
             {/* Referral Badge */}
             {referralCode && (
               <div
-                className={`mb-4 transition-all duration-500 delay-250 ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-                  }`}
+                className={`mb-4 transition-all duration-500 delay-250 ${
+                  mounted
+                    ? "opacity-100 translate-y-0"
+                    : "opacity-0 translate-y-4"
+                }`}
               >
                 <div className="flex items-center gap-2 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
                   <Gift className="h-5 w-5 text-green-500" />
                   <span className="text-sm text-green-600 dark:text-green-400">
-                    You were referred! Your friend will get 5 bonus credits when you sign up.
+                    You were referred! Your friend will get 5 bonus credits when
+                    you sign up.
                   </span>
                 </div>
               </div>
@@ -453,8 +487,11 @@ function RegisterForm() {
 
             {/* OAuth Buttons */}
             <div
-              className={`space-y-3 mb-6 transition-all duration-500 delay-300 ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-                }`}
+              className={`space-y-3 mb-6 transition-all duration-500 delay-300 ${
+                mounted
+                  ? "opacity-100 translate-y-0"
+                  : "opacity-0 translate-y-4"
+              }`}
             >
               <Button
                 type="button"
@@ -489,35 +526,43 @@ function RegisterForm() {
 
             {/* Divider */}
             <div
-              className={`relative my-6 transition-all duration-500 delay-350 ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-                }`}
+              className={`relative my-6 transition-all duration-500 delay-350 ${
+                mounted
+                  ? "opacity-100 translate-y-0"
+                  : "opacity-0 translate-y-4"
+              }`}
             >
               <div className="absolute inset-0 flex items-center">
                 <div className="w-full border-t border-yellow-400/20"></div>
               </div>
               <div className="relative flex justify-center text-xs uppercase">
-                <span className="bg-background px-2 text-muted-foreground">Or continue with email</span>
+                <span className="bg-background px-2 text-muted-foreground">
+                  Or continue with email
+                </span>
               </div>
             </div>
 
             <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-5">
               {/* Enhanced Name field with advanced interactions */}
               <div
-                className={`space-y-2 transition-all duration-500 delay-400 ${mounted
-                  ? "opacity-100 translate-y-0"
-                  : "opacity-0 translate-y-4"
-                  }`}
+                className={`space-y-2 transition-all duration-500 delay-400 ${
+                  mounted
+                    ? "opacity-100 translate-y-0"
+                    : "opacity-0 translate-y-4"
+                }`}
               >
                 <Label
                   htmlFor="name"
-                  className={`text-sm font-medium flex items-center gap-2 professional-text transition-all duration-300 ${focusedField === "name" ? "text-yellow-600 scale-105" : ""
-                    }`}
+                  className={`text-sm font-medium flex items-center gap-2 professional-text transition-all duration-300 ${
+                    focusedField === "name" ? "text-yellow-600 scale-105" : ""
+                  }`}
                 >
                   <User
-                    className={`h-4 w-4 text-muted-foreground transition-all duration-300 ${focusedField === "name"
-                      ? "text-yellow-500 animate-pulse"
-                      : ""
-                      }`}
+                    className={`h-4 w-4 text-muted-foreground transition-all duration-300 ${
+                      focusedField === "name"
+                        ? "text-yellow-500 animate-pulse"
+                        : ""
+                    }`}
                   />
                   Full Name
                   {name && (
@@ -529,7 +574,10 @@ function RegisterForm() {
                     id="name"
                     type="text"
                     value={name}
-                    onChange={(e) => setName(e.target.value)}
+                    onChange={(e) => {
+                      setName(e.target.value);
+                      setFieldErrors((prev) => ({ ...prev, name: undefined }));
+                    }}
                     onFocus={() => setFocusedField("name")}
                     onBlur={() => setFocusedField(null)}
                     placeholder="Enter your full name"
@@ -538,36 +586,47 @@ function RegisterForm() {
                     disabled={isLoading || isOAuthLoading !== null}
                   />
                   <div
-                    className={`absolute inset-0 rounded-md border pointer-events-none transition-all duration-300 ${focusedField === "name"
-                      ? "border-yellow-400/40 shadow-lg shadow-yellow-400/20"
-                      : "border-yellow-400/20"
-                      }`}
+                    className={`absolute inset-0 rounded-md border pointer-events-none transition-all duration-300 ${
+                      focusedField === "name"
+                        ? "border-yellow-400/40 shadow-lg shadow-yellow-400/20"
+                        : "border-yellow-400/20"
+                    }`}
                   ></div>
                   {/* Progress indicator */}
                   <div
-                    className={`absolute bottom-0 left-0 h-0.5 bg-gradient-to-r from-yellow-400 to-blue-500 transition-all duration-300 ${name ? "w-full" : "w-0"
-                      }`}
+                    className={`absolute bottom-0 left-0 h-0.5 bg-gradient-to-r from-yellow-400 to-blue-500 transition-all duration-300 ${
+                      name ? "w-full" : "w-0"
+                    }`}
                   ></div>
                 </div>
+                {fieldErrors.name && (
+                  <p className="text-xs text-red-500 flex items-center gap-1 animate-fade-in-up">
+                    <User className="h-3 w-3" />
+                    {fieldErrors.name}
+                  </p>
+                )}
               </div>
 
               {/* Enhanced Email field with validation animations */}
               <div
-                className={`space-y-2 transition-all duration-500 delay-450 ${mounted
-                  ? "opacity-100 translate-y-0"
-                  : "opacity-0 translate-y-4"
-                  }`}
+                className={`space-y-2 transition-all duration-500 delay-450 ${
+                  mounted
+                    ? "opacity-100 translate-y-0"
+                    : "opacity-0 translate-y-4"
+                }`}
               >
                 <Label
                   htmlFor="email"
-                  className={`text-sm font-medium flex items-center gap-2 professional-text transition-all duration-300 ${focusedField === "email" ? "text-yellow-600 scale-105" : ""
-                    }`}
+                  className={`text-sm font-medium flex items-center gap-2 professional-text transition-all duration-300 ${
+                    focusedField === "email" ? "text-yellow-600 scale-105" : ""
+                  }`}
                 >
                   <Mail
-                    className={`h-4 w-4 text-muted-foreground transition-all duration-300 ${focusedField === "email"
-                      ? "text-yellow-500 animate-pulse"
-                      : ""
-                      }`}
+                    className={`h-4 w-4 text-muted-foreground transition-all duration-300 ${
+                      focusedField === "email"
+                        ? "text-yellow-500 animate-pulse"
+                        : ""
+                    }`}
                   />
                   Email Address
                   {email && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && (
@@ -579,46 +638,64 @@ function RegisterForm() {
                     id="email"
                     type="email"
                     value={email}
-                    onChange={(e) => setEmail(e.target.value)}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      setFieldErrors((prev) => ({ ...prev, email: undefined }));
+                    }}
                     onFocus={() => setFocusedField("email")}
                     onBlur={() => setFocusedField(null)}
                     placeholder="Enter your email"
                     required
-                    className={`glass-effect focus:ring-yellow-400/20 pl-4 pr-4 py-3 text-sm sm:text-base transition-all duration-300 group-hover:shadow-lg ${email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.length > 0
-                      ? "border-red-400/60 focus:border-red-400/80 hover:border-red-400/70"
-                      : "border-yellow-400/30 focus:border-yellow-400/60 hover:border-yellow-400/50"
-                      }`}
+                    className={`glass-effect focus:ring-yellow-400/20 pl-4 pr-4 py-3 text-sm sm:text-base transition-all duration-300 group-hover:shadow-lg ${
+                      email &&
+                      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) &&
+                      email.length > 0
+                        ? "border-red-400/60 focus:border-red-400/80 hover:border-red-400/70"
+                        : "border-yellow-400/30 focus:border-yellow-400/60 hover:border-yellow-400/50"
+                    }`}
                     disabled={isLoading || isOAuthLoading !== null}
                   />
                   <div
-                    className={`absolute inset-0 rounded-md border pointer-events-none transition-all duration-300 ${focusedField === "email"
-                      ? email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.length > 0
-                        ? "border-red-400/40 shadow-lg shadow-red-400/20"
-                        : "border-yellow-400/40 shadow-lg shadow-yellow-400/20"
-                      : email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.length > 0
-                        ? "border-red-400/20"
-                        : "border-yellow-400/20"
-                      }`}
+                    className={`absolute inset-0 rounded-md border pointer-events-none transition-all duration-300 ${
+                      focusedField === "email"
+                        ? email &&
+                          !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) &&
+                          email.length > 0
+                          ? "border-red-400/40 shadow-lg shadow-red-400/20"
+                          : "border-yellow-400/40 shadow-lg shadow-yellow-400/20"
+                        : email &&
+                            !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) &&
+                            email.length > 0
+                          ? "border-red-400/20"
+                          : "border-yellow-400/20"
+                    }`}
                   ></div>
                   {/* Progress indicator */}
                   <div
-                    className={`absolute bottom-0 left-0 h-0.5 transition-all duration-300 ${email && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
-                      ? "w-full bg-gradient-to-r from-green-400 to-blue-500"
-                      : email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.length > 0
-                        ? "w-full bg-gradient-to-r from-red-400 to-orange-500"
-                        : email
-                          ? "w-1/2 bg-gradient-to-r from-yellow-400 to-blue-500"
-                          : "w-0"
-                      }`}
+                    className={`absolute bottom-0 left-0 h-0.5 transition-all duration-300 ${
+                      email && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+                        ? "w-full bg-gradient-to-r from-green-400 to-blue-500"
+                        : email &&
+                            !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) &&
+                            email.length > 0
+                          ? "w-full bg-gradient-to-r from-red-400 to-orange-500"
+                          : email
+                            ? "w-1/2 bg-gradient-to-r from-yellow-400 to-blue-500"
+                            : "w-0"
+                    }`}
                   ></div>
                 </div>
 
                 {/* Email validation feedback */}
-                {email && email.length > 0 && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && (
+                {(fieldErrors.email ||
+                  (email &&
+                    email.length > 0 &&
+                    !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))) && (
                   <div className="animate-fade-in-up">
                     <p className="text-xs text-red-500 flex items-center gap-1 animate-bounce">
                       <Mail className="h-3 w-3" />
-                      Please enter a valid email address
+                      {fieldErrors.email ||
+                        "Please enter a valid email address"}
                     </p>
                   </div>
                 )}
@@ -626,24 +703,28 @@ function RegisterForm() {
 
               {/* Enhanced Password field with strength indicator */}
               <div
-                className={`space-y-2 transition-all duration-500 delay-500 ${mounted
-                  ? "opacity-100 translate-y-0"
-                  : "opacity-0 translate-y-4"
-                  }`}
+                className={`space-y-2 transition-all duration-500 delay-500 ${
+                  mounted
+                    ? "opacity-100 translate-y-0"
+                    : "opacity-0 translate-y-4"
+                }`}
               >
                 <Label
                   htmlFor="password"
-                  className={`text-sm font-medium flex items-center gap-2 professional-text transition-all duration-300 ${focusedField === "password"
-                    ? "text-yellow-600 scale-105"
-                    : ""
-                    }`}
+                  className={`text-sm font-medium flex items-center gap-2 professional-text transition-all duration-300 ${
+                    focusedField === "password"
+                      ? "text-yellow-600 scale-105"
+                      : ""
+                  }`}
                 >
                   <Lock
-                    className={`h-4 w-4 text-muted-foreground transition-all duration-300 ${focusedField === "password"
-                      ? "text-yellow-500 animate-pulse"
-                      : ""
-                      }`}
-                  />                  Password
+                    className={`h-4 w-4 text-muted-foreground transition-all duration-300 ${
+                      focusedField === "password"
+                        ? "text-yellow-500 animate-pulse"
+                        : ""
+                    }`}
+                  />{" "}
+                  Password
                   {passwordStrength >= 3 && (
                     <Shield className="h-3 w-3 text-green-500 animate-scale-in" />
                   )}
@@ -653,7 +734,14 @@ function RegisterForm() {
                     id="password"
                     type={showPassword ? "text" : "password"}
                     value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      setFieldErrors((prev) => ({
+                        ...prev,
+                        password: undefined,
+                        confirmPassword: undefined,
+                      }));
+                    }}
                     onFocus={() => setFocusedField("password")}
                     onBlur={() => setFocusedField(null)}
                     placeholder="Create a strong password (min. 8 characters)"
@@ -677,10 +765,11 @@ function RegisterForm() {
                     )}
                   </button>
                   <div
-                    className={`absolute inset-0 rounded-md border pointer-events-none transition-all duration-300 ${focusedField === "password"
-                      ? "border-yellow-400/40 shadow-lg shadow-yellow-400/20"
-                      : "border-yellow-400/20"
-                      }`}
+                    className={`absolute inset-0 rounded-md border pointer-events-none transition-all duration-300 ${
+                      focusedField === "password"
+                        ? "border-yellow-400/40 shadow-lg shadow-yellow-400/20"
+                        : "border-yellow-400/20"
+                    }`}
                   ></div>
                 </div>
 
@@ -691,24 +780,26 @@ function RegisterForm() {
                       {[...Array(5)].map((_, i) => (
                         <div
                           key={i}
-                          className={`h-1 flex-1 rounded-full transition-all duration-300 ${i < passwordStrength
-                            ? i < 2
-                              ? "bg-red-400"
-                              : i < 4
-                                ? "bg-yellow-400"
-                                : "bg-green-400"
-                            : "bg-gray-200 dark:bg-gray-700"
-                            }`}
+                          className={`h-1 flex-1 rounded-full transition-all duration-300 ${
+                            i < passwordStrength
+                              ? i < 2
+                                ? "bg-red-400"
+                                : i < 4
+                                  ? "bg-yellow-400"
+                                  : "bg-green-400"
+                              : "bg-gray-200 dark:bg-gray-700"
+                          }`}
                         />
                       ))}
                     </div>
                     <p
-                      className={`text-xs transition-all duration-300 ${passwordStrength < 2
-                        ? "text-red-500"
-                        : passwordStrength < 4
-                          ? "text-yellow-500"
-                          : "text-green-500"
-                        }`}
+                      className={`text-xs transition-all duration-300 ${
+                        passwordStrength < 2
+                          ? "text-red-500"
+                          : passwordStrength < 4
+                            ? "text-yellow-500"
+                            : "text-green-500"
+                      }`}
                     >
                       {passwordStrength < 2 && "Weak password"}
                       {passwordStrength >= 2 &&
@@ -718,27 +809,36 @@ function RegisterForm() {
                     </p>
                   </div>
                 )}
+                {fieldErrors.password && (
+                  <p className="text-xs text-red-500 flex items-center gap-1 animate-fade-in-up">
+                    <Lock className="h-3 w-3" />
+                    {fieldErrors.password}
+                  </p>
+                )}
               </div>
 
               {/* Enhanced Confirm Password field with advanced validation */}
               <div
-                className={`space-y-2 transition-all duration-500 delay-550 ${mounted
-                  ? "opacity-100 translate-y-0"
-                  : "opacity-0 translate-y-4"
-                  }`}
+                className={`space-y-2 transition-all duration-500 delay-550 ${
+                  mounted
+                    ? "opacity-100 translate-y-0"
+                    : "opacity-0 translate-y-4"
+                }`}
               >
                 <Label
                   htmlFor="confirmPassword"
-                  className={`text-sm font-medium flex items-center gap-2 professional-text transition-all duration-300 ${focusedField === "confirmPassword"
-                    ? "text-yellow-600 scale-105"
-                    : ""
-                    }`}
+                  className={`text-sm font-medium flex items-center gap-2 professional-text transition-all duration-300 ${
+                    focusedField === "confirmPassword"
+                      ? "text-yellow-600 scale-105"
+                      : ""
+                  }`}
                 >
                   <Shield
-                    className={`h-4 w-4 text-muted-foreground transition-all duration-300 ${focusedField === "confirmPassword"
-                      ? "text-yellow-500 animate-pulse"
-                      : ""
-                      }`}
+                    className={`h-4 w-4 text-muted-foreground transition-all duration-300 ${
+                      focusedField === "confirmPassword"
+                        ? "text-yellow-500 animate-pulse"
+                        : ""
+                    }`}
                   />
                   Confirm Password
                   {confirmPassword && password === confirmPassword && (
@@ -750,15 +850,22 @@ function RegisterForm() {
                     id="confirmPassword"
                     type={showConfirmPassword ? "text" : "password"}
                     value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    onChange={(e) => {
+                      setConfirmPassword(e.target.value);
+                      setFieldErrors((prev) => ({
+                        ...prev,
+                        confirmPassword: undefined,
+                      }));
+                    }}
                     onFocus={() => setFocusedField("confirmPassword")}
                     onBlur={() => setFocusedField(null)}
                     placeholder="Confirm your password"
                     required
-                    className={`glass-effect focus:ring-yellow-400/20 pl-4 pr-12 py-3 text-sm sm:text-base transition-all duration-300 group-hover:shadow-lg ${confirmPassword && password !== confirmPassword
-                      ? "border-red-400/60 focus:border-red-400/80 hover:border-red-400/70"
-                      : "border-yellow-400/30 focus:border-yellow-400/60 hover:border-yellow-400/50"
-                      }`}
+                    className={`glass-effect focus:ring-yellow-400/20 pl-4 pr-12 py-3 text-sm sm:text-base transition-all duration-300 group-hover:shadow-lg ${
+                      confirmPassword && password !== confirmPassword
+                        ? "border-red-400/60 focus:border-red-400/80 hover:border-red-400/70"
+                        : "border-yellow-400/30 focus:border-yellow-400/60 hover:border-yellow-400/50"
+                    }`}
                     disabled={isLoading || isOAuthLoading !== null}
                   />
                   <button
@@ -779,30 +886,33 @@ function RegisterForm() {
                     )}
                   </button>
                   <div
-                    className={`absolute inset-0 rounded-md border pointer-events-none transition-all duration-300 ${focusedField === "confirmPassword"
-                      ? confirmPassword && password !== confirmPassword
-                        ? "border-red-400/40 shadow-lg shadow-red-400/20"
-                        : "border-yellow-400/40 shadow-lg shadow-yellow-400/20"
-                      : confirmPassword && password !== confirmPassword
-                        ? "border-red-400/20"
-                        : "border-yellow-400/20"
-                      }`}
+                    className={`absolute inset-0 rounded-md border pointer-events-none transition-all duration-300 ${
+                      focusedField === "confirmPassword"
+                        ? confirmPassword && password !== confirmPassword
+                          ? "border-red-400/40 shadow-lg shadow-red-400/20"
+                          : "border-yellow-400/40 shadow-lg shadow-yellow-400/20"
+                        : confirmPassword && password !== confirmPassword
+                          ? "border-red-400/20"
+                          : "border-yellow-400/20"
+                    }`}
                   ></div>
                   {/* Progress indicator */}
                   <div
-                    className={`absolute bottom-0 left-0 h-0.5 transition-all duration-300 ${confirmPassword && password === confirmPassword
-                      ? "w-full bg-gradient-to-r from-green-400 to-blue-500"
-                      : confirmPassword && password !== confirmPassword
-                        ? "w-full bg-gradient-to-r from-red-400 to-orange-500"
-                        : "w-0"
-                      }`}
+                    className={`absolute bottom-0 left-0 h-0.5 transition-all duration-300 ${
+                      confirmPassword && password === confirmPassword
+                        ? "w-full bg-gradient-to-r from-green-400 to-blue-500"
+                        : confirmPassword && password !== confirmPassword
+                          ? "w-full bg-gradient-to-r from-red-400 to-orange-500"
+                          : "w-0"
+                    }`}
                   ></div>
                 </div>
 
                 {/* Enhanced password match indicator */}
-                {confirmPassword && (
+                {(fieldErrors.confirmPassword || confirmPassword) && (
                   <div className="animate-fade-in-up">
-                    {password === confirmPassword ? (
+                    {!fieldErrors.confirmPassword &&
+                    password === confirmPassword ? (
                       <p className="text-xs text-green-500 flex items-center gap-1 animate-scale-in">
                         <Check className="h-3 w-3" />
                         Passwords match perfectly!
@@ -810,7 +920,7 @@ function RegisterForm() {
                     ) : (
                       <p className="text-xs text-red-500 flex items-center gap-1 animate-bounce">
                         <Shield className="h-3 w-3" />
-                        Passwords don't match
+                        {fieldErrors.confirmPassword || "Passwords don't match"}
                       </p>
                     )}
                   </div>
@@ -819,28 +929,35 @@ function RegisterForm() {
 
               {/* Email verification notice */}
               <div
-                className={`transition-all duration-500 delay-600 ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
-                  }`}
+                className={`transition-all duration-500 delay-600 ${
+                  mounted
+                    ? "opacity-100 translate-y-0"
+                    : "opacity-0 translate-y-4"
+                }`}
               >
                 <div className="glass-effect p-3 rounded-lg border border-yellow-400/20 flex items-start gap-2">
                   <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0" />
                   <p className="text-xs sm:text-sm text-muted-foreground">
-                    Email verification is required. After you sign up, we'll send you a
-                    verification link. Please confirm your email before signing in.
+                    Email verification is required. After you sign up, we'll
+                    send you a verification link. Please confirm your email
+                    before signing in.
                   </p>
                 </div>
               </div>
 
               {/* Enhanced submit button with advanced animations */}
               <div
-                className={`transition-all duration-500 delay-650 ${mounted
-                  ? "opacity-100 translate-y-0"
-                  : "opacity-0 translate-y-4"
-                  }`}
+                className={`transition-all duration-500 delay-650 ${
+                  mounted
+                    ? "opacity-100 translate-y-0"
+                    : "opacity-0 translate-y-4"
+                }`}
               >
                 <Button
                   type="submit"
-                  disabled={isLoading || isOAuthLoading !== null || !isFormValid}
+                  disabled={
+                    isLoading || isOAuthLoading !== null || !isFormValid
+                  }
                   className="w-full bolt-gradient text-white font-semibold py-4 sm:py-5 rounded-xl relative text-lg sm:text-xl disabled:opacity-50 disabled:cursor-not-allowed shadow-lg hover:scale-105 transition-all duration-300 focus:ring-4 focus:ring-blue-300 focus:outline-none"
                   aria-label="Create your DraftDeckAI account"
                 >
@@ -891,10 +1008,11 @@ function RegisterForm() {
 
             {/* Enhanced footer with advanced styling */}
             <div
-              className={`mt-6 sm:mt-8 text-center transition-all duration-500 delay-700 ${mounted
-                ? "opacity-100 translate-y-0"
-                : "opacity-0 translate-y-4"
-                }`}
+              className={`mt-6 sm:mt-8 text-center transition-all duration-500 delay-700 ${
+                mounted
+                  ? "opacity-100 translate-y-0"
+                  : "opacity-0 translate-y-4"
+              }`}
             >
               <div className="glass-effect p-4 rounded-xl border border-yellow-400/10 hover:border-yellow-400/20 transition-all duration-300 group hover:scale-105">
                 <p className="professional-text text-sm text-muted-foreground mb-3">
@@ -917,10 +1035,11 @@ function RegisterForm() {
 
             {/* Enhanced navigation link */}
             <div
-              className={`mt-4 text-center transition-all duration-500 delay-750 ${mounted
-                ? "opacity-100 translate-y-0"
-                : "opacity-0 translate-y-4"
-                }`}
+              className={`mt-4 text-center transition-all duration-500 delay-750 ${
+                mounted
+                  ? "opacity-100 translate-y-0"
+                  : "opacity-0 translate-y-4"
+              }`}
             >
               <Link
                 href="/"
@@ -941,11 +1060,13 @@ function RegisterForm() {
 
 export default function Register() {
   return (
-    <Suspense fallback={
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <Loader2 className="h-8 w-8 animate-spin text-yellow-500" />
-      </div>
-    }>
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-background">
+          <Loader2 className="h-8 w-8 animate-spin text-yellow-500" />
+        </div>
+      }
+    >
       <RegisterForm />
     </Suspense>
   );

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -181,6 +181,7 @@ function RegisterForm() {
       return;
     }
 
+    const validatedData = validation.data;
     setFieldErrors({});
     setIsLoading(true);
 
@@ -202,7 +203,13 @@ function RegisterForm() {
       const res = await fetch("/api/auth/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, email, password, referralCode, utmData }),
+        body: JSON.stringify({
+          name: validatedData.name,
+          email: validatedData.email,
+          password: validatedData.password,
+          referralCode,
+          utmData,
+        }),
       });
 
       const result = await res.json();
@@ -251,7 +258,7 @@ function RegisterForm() {
           error.message.includes("Password is too short")
         ) {
           userMessage =
-            "Password is too short. Please use at least 6 characters.";
+            "Password is too short. Please use at least 8 characters.";
         } else if (
           error.message.includes("rate limit") ||
           error.message.includes("Too many requests")

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -61,9 +61,17 @@ export default function ContactForm() {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [errors, setErrors] = useState<ContactErrors>({});
 
-  // Email validation function
   const isValidEmail = (email: string) =>
-    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    contactSchema.shape.email.safeParse(email).success;
+
+  const validateField = (name: ContactField, value: string) => {
+    const fieldSchema = contactSchema.shape[name];
+    const validation = fieldSchema.safeParse(value);
+
+    return validation.success
+      ? undefined
+      : validation.error.issues[0]?.message || "Invalid value";
+  };
 
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -73,7 +81,10 @@ export default function ContactForm() {
       ...prev,
       [name]: value,
     }));
-    setErrors((prev) => ({ ...prev, [name]: undefined }));
+    setErrors((prev) => ({
+      ...prev,
+      [name]: validateField(name as ContactField, value),
+    }));
   };
 
   const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,7 @@
-"use client"
-import React, { useState } from 'react';
-import { 
+"use client";
+import React, { useState } from "react";
+import { z } from "zod";
+import {
   Mail,
   Phone,
   User,
@@ -21,64 +22,124 @@ import {
   HelpCircle,
   Bug,
   Lightbulb,
-  Settings
+  Settings,
 } from "lucide-react";
 
+const contactSchema = z.object({
+  name: z.string().trim().min(2, "Name must be at least 2 characters"),
+  email: z.string().trim().email("Please enter a valid email address"),
+  phone: z
+    .string()
+    .trim()
+    .optional()
+    .refine(
+      (value) => !value || /^[+()\-\s\d]{7,20}$/.test(value),
+      "Please enter a valid phone number",
+    ),
+  userType: z
+    .string()
+    .min(1, "Please choose whether you are a student or professional"),
+  helpType: z.string().min(1, "Please choose how we can help you"),
+  message: z.string().trim().min(10, "Message must be at least 10 characters"),
+});
+
+type ContactFormData = z.infer<typeof contactSchema>;
+type ContactField = keyof ContactFormData;
+type ContactErrors = Partial<Record<ContactField, string>>;
+
 export default function ContactForm() {
-  const [formData, setFormData] = useState({
-    name: '',
-    email: '',
-    phone: '',
-    userType: '',
-    helpType: '',
-    message: ''
+  const [formData, setFormData] = useState<ContactFormData>({
+    name: "",
+    email: "",
+    phone: "",
+    userType: "",
+    helpType: "",
+    message: "",
   });
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [errors, setErrors] = useState<ContactErrors>({});
 
   // Email validation function
-  const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  const isValidEmail = (email: string) =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
   const handleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { name, value } = e.target;
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      [name]: value
+      [name]: value,
     }));
+    setErrors((prev) => ({ ...prev, [name]: undefined }));
   };
 
-  const handleSubmit = async (e: React.FormEvent<HTMLButtonElement>) => {
+  const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    
-    // Validate email before submission
-    if (!isValidEmail(formData.email)) {
+
+    const validation = contactSchema.safeParse(formData);
+    if (!validation.success) {
+      const nextErrors: ContactErrors = {};
+      validation.error.issues.forEach((issue) => {
+        const field = issue.path[0] as ContactField;
+        nextErrors[field] = issue.message;
+      });
+      setErrors(nextErrors);
       return;
     }
-    
+
+    setErrors({});
     setIsSubmitting(true);
-    
+
     // Simulate form submission
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
     setIsSubmitting(false);
     setIsSubmitted(true);
   };
 
   const userTypes = [
-    { value: 'student', label: 'Student', icon: <GraduationCap className="h-4 w-4" /> },
-    { value: 'professional', label: 'Professional', icon: <Briefcase className="h-4 w-4" /> }
+    {
+      value: "student",
+      label: "Student",
+      icon: <GraduationCap className="h-4 w-4" />,
+    },
+    {
+      value: "professional",
+      label: "Professional",
+      icon: <Briefcase className="h-4 w-4" />,
+    },
   ];
 
   const helpTypes = [
-    { value: 'general', label: 'General Inquiry', icon: <HelpCircle className="h-4 w-4" /> },
-    { value: 'technical', label: 'Technical Support', icon: <Settings className="h-4 w-4" /> },
-    { value: 'bug', label: 'Report a Bug', icon: <Bug className="h-4 w-4" /> },
-    { value: 'feedback', label: 'Feature Request', icon: <Lightbulb className="h-4 w-4" /> },
-    { value: 'billing', label: 'Billing Question', icon: <FileText className="h-4 w-4" /> },
-    { value: 'partnership', label: 'Partnership', icon: <Users className="h-4 w-4" /> }
+    {
+      value: "general",
+      label: "General Inquiry",
+      icon: <HelpCircle className="h-4 w-4" />,
+    },
+    {
+      value: "technical",
+      label: "Technical Support",
+      icon: <Settings className="h-4 w-4" />,
+    },
+    { value: "bug", label: "Report a Bug", icon: <Bug className="h-4 w-4" /> },
+    {
+      value: "feedback",
+      label: "Feature Request",
+      icon: <Lightbulb className="h-4 w-4" />,
+    },
+    {
+      value: "billing",
+      label: "Billing Question",
+      icon: <FileText className="h-4 w-4" />,
+    },
+    {
+      value: "partnership",
+      label: "Partnership",
+      icon: <Users className="h-4 w-4" />,
+    },
   ];
 
   if (isSubmitted) {
@@ -97,19 +158,21 @@ export default function ContactForm() {
                   Message Sent Successfully!
                 </h2>
                 <p className="text-muted-foreground mb-6">
-                  Thank you for reaching out. We'll get back to you within 24 hours.
+                  Thank you for reaching out. We'll get back to you within 24
+                  hours.
                 </p>
-                <button 
+                <button
                   onClick={() => {
                     setIsSubmitted(false);
                     setFormData({
-                      name: '',
-                      email: '',
-                      phone: '',
-                      userType: '',
-                      helpType: '',
-                      message: ''
+                      name: "",
+                      email: "",
+                      phone: "",
+                      userType: "",
+                      helpType: "",
+                      message: "",
                     });
+                    setErrors({});
                   }}
                   className="professional-button w-full"
                 >
@@ -131,9 +194,9 @@ export default function ContactForm() {
         <div className="floating-orb w-40 h-40 sm:w-64 sm:h-64 bolt-gradient opacity-15 top-20 -left-20 sm:-left-32"></div>
         <div className="floating-orb w-32 h-32 sm:w-48 sm:h-48 bolt-gradient opacity-20 -top-10 right-10 sm:right-20"></div>
         <div className="floating-orb w-48 h-48 sm:w-72 sm:h-72 bolt-gradient opacity-10 bottom-10 left-1/3"></div>
-        
+
         {/* Grid pattern overlay */}
-        <div 
+        <div
           className="absolute inset-0 opacity-[0.02]"
           style={{
             backgroundImage: `url("data:image/svg+xml,%3csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3e%3cg fill='none' fill-rule='evenodd'%3e%3cg fill='%23000000' fill-opacity='1'%3e%3ccircle cx='30' cy='30' r='1'/%3e%3c/g%3e%3c/g%3e%3c/svg%3e")`,
@@ -156,47 +219,70 @@ export default function ContactForm() {
             {/* Badge */}
             <div className="inline-flex items-center gap-2 px-4 sm:px-6 py-2 sm:py-3 rounded-full glass-effect mb-6 sm:mb-8 shimmer">
               <Mail className="h-4 w-4 sm:h-5 sm:w-5 text-blue-500 animate-pulse" />
-              <span className="text-sm sm:text-base font-medium">Get In Touch</span>
+              <span className="text-sm sm:text-base font-medium">
+                Get In Touch
+              </span>
               <Sparkles className="h-4 w-4 sm:h-5 sm:w-5 text-yellow-500 animate-pulse" />
             </div>
-            
+
             {/* Main Heading */}
             <h1 className="modern-display text-3xl sm:text-4xl md:text-5xl lg:text-6xl text-center mb-6 sm:mb-8">
               How can we{" "}
               <span className="bolt-gradient-text relative inline-block">
                 help you?
                 <div className="absolute -top-1 sm:-top-2 -right-1 sm:-right-2">
-                  <Star className="h-5 w-5 sm:h-6 sm:w-6 lg:h-8 lg:w-8 text-yellow-500 animate-spin" style={{animationDuration: '3s'}} />
+                  <Star
+                    className="h-5 w-5 sm:h-6 sm:w-6 lg:h-8 lg:w-8 text-yellow-500 animate-spin"
+                    style={{ animationDuration: "3s" }}
+                  />
                 </div>
               </span>
             </h1>
-            
+
             {/* Subtitle */}
             <p className="modern-body text-base sm:text-lg lg:text-xl text-muted-foreground max-w-2xl lg:max-w-3xl mx-auto px-4 sm:px-0">
               Have a question about our{" "}
-              <span className="font-semibold text-blue-600">AI-powered platform</span>?{" "}
-              Need help creating{" "}
-              <span className="font-semibold text-yellow-600">professional documents</span>?{" "}
-              We're here to help with{" "}
-              <span className="font-semibold bolt-gradient-text">magical support</span>
+              <span className="font-semibold text-blue-600">
+                AI-powered platform
+              </span>
+              ? Need help creating{" "}
+              <span className="font-semibold text-yellow-600">
+                professional documents
+              </span>
+              ? We're here to help with{" "}
+              <span className="font-semibold bolt-gradient-text">
+                magical support
+              </span>
             </p>
 
             {/* Response Time Stats */}
             <div className="mt-8 sm:mt-12 flex flex-wrap justify-center gap-4 sm:gap-8">
               <div className="glass-effect px-4 sm:px-6 py-2 sm:py-3 rounded-full hover:scale-105 transition-transform duration-300">
                 <Clock className="inline h-4 w-4 text-green-500 mr-2" />
-                <span className="bolt-gradient-text font-bold text-sm sm:text-base">&lt;24h</span>
-                <span className="text-muted-foreground text-xs sm:text-sm ml-1">Response Time</span>
+                <span className="bolt-gradient-text font-bold text-sm sm:text-base">
+                  &lt;24h
+                </span>
+                <span className="text-muted-foreground text-xs sm:text-sm ml-1">
+                  Response Time
+                </span>
               </div>
               <div className="glass-effect px-4 sm:px-6 py-2 sm:py-3 rounded-full hover:scale-105 transition-transform duration-300">
                 <Shield className="inline h-4 w-4 text-blue-500 mr-2" />
-                <span className="bolt-gradient-text font-bold text-sm sm:text-base">100%</span>
-                <span className="text-muted-foreground text-xs sm:text-sm ml-1">Secure</span>
+                <span className="bolt-gradient-text font-bold text-sm sm:text-base">
+                  100%
+                </span>
+                <span className="text-muted-foreground text-xs sm:text-sm ml-1">
+                  Secure
+                </span>
               </div>
               <div className="glass-effect px-4 sm:px-6 py-2 sm:py-3 rounded-full hover:scale-105 transition-transform duration-300">
                 <Zap className="inline h-4 w-4 text-yellow-500 mr-2" />
-                <span className="bolt-gradient-text font-bold text-sm sm:text-base">24/7</span>
-                <span className="text-muted-foreground text-xs sm:text-sm ml-1">Available</span>
+                <span className="bolt-gradient-text font-bold text-sm sm:text-base">
+                  24/7
+                </span>
+                <span className="text-muted-foreground text-xs sm:text-sm ml-1">
+                  Available
+                </span>
               </div>
             </div>
           </div>
@@ -206,12 +292,15 @@ export default function ContactForm() {
             <div className="professional-card p-6 sm:p-8 lg:p-10 rounded-2xl relative overflow-hidden">
               {/* Background shimmer effect */}
               <div className="absolute inset-0 shimmer opacity-20"></div>
-              
+
               <div className="relative z-10">
                 <div className="space-y-6 sm:space-y-8">
                   {/* Name Field */}
                   <div className="space-y-2">
-                    <label htmlFor="name" className="flex items-center gap-2 text-sm sm:text-base font-medium text-foreground">
+                    <label
+                      htmlFor="name"
+                      className="flex items-center gap-2 text-sm sm:text-base font-medium text-foreground"
+                    >
                       <User className="h-4 w-4 text-blue-500" />
                       Your Name
                     </label>
@@ -225,11 +314,20 @@ export default function ContactForm() {
                       className="w-full px-4 py-3 sm:py-4 rounded-xl glass-effect border border-border/50 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 transition-all duration-300 text-sm sm:text-base placeholder:text-muted-foreground/60"
                       placeholder="Enter your full name"
                     />
+                    {errors.name && (
+                      <p className="text-xs text-red-500 flex items-center gap-1">
+                        <User className="h-3 w-3" />
+                        {errors.name}
+                      </p>
+                    )}
                   </div>
 
                   {/* Email Field */}
                   <div className="space-y-2">
-                    <label htmlFor="email" className="flex items-center gap-2 text-sm sm:text-base font-medium text-foreground">
+                    <label
+                      htmlFor="email"
+                      className="flex items-center gap-2 text-sm sm:text-base font-medium text-foreground"
+                    >
                       <Mail className="h-4 w-4 text-green-500" />
                       Email Address
                       {formData.email && isValidEmail(formData.email) && (
@@ -244,23 +342,31 @@ export default function ContactForm() {
                       onChange={handleInputChange}
                       required
                       className={`w-full px-4 py-3 sm:py-4 rounded-xl glass-effect border transition-all duration-300 text-sm sm:text-base placeholder:text-muted-foreground/60 ${
-                        formData.email && !isValidEmail(formData.email) && formData.email.length > 0
+                        formData.email &&
+                        !isValidEmail(formData.email) &&
+                        formData.email.length > 0
                           ? "border-red-500/50 focus:border-red-500/70 focus:ring-2 focus:ring-red-500/20"
                           : "border-border/50 focus:border-green-500/50 focus:ring-2 focus:ring-green-500/20"
                       }`}
                       placeholder="your.email@example.com"
                     />
-                    {formData.email && formData.email.length > 0 && !isValidEmail(formData.email) && (
+                    {(errors.email ||
+                      (formData.email &&
+                        formData.email.length > 0 &&
+                        !isValidEmail(formData.email))) && (
                       <p className="text-xs text-red-500 flex items-center gap-1">
                         <Mail className="h-3 w-3" />
-                        Please enter a valid email address
+                        {errors.email || "Please enter a valid email address"}
                       </p>
                     )}
                   </div>
 
                   {/* Phone Field */}
                   <div className="space-y-2">
-                    <label htmlFor="phone" className="flex items-center gap-2 text-sm sm:text-base font-medium text-foreground">
+                    <label
+                      htmlFor="phone"
+                      className="flex items-center gap-2 text-sm sm:text-base font-medium text-foreground"
+                    >
                       <Phone className="h-4 w-4 text-purple-500" />
                       Phone Number (Optional)
                     </label>
@@ -273,17 +379,25 @@ export default function ContactForm() {
                       className="w-full px-4 py-3 sm:py-4 rounded-xl glass-effect border border-border/50 focus:border-purple-500/50 focus:ring-2 focus:ring-purple-500/20 transition-all duration-300 text-sm sm:text-base placeholder:text-muted-foreground/60"
                       placeholder="+1 (555) 123-4567"
                     />
+                    {errors.phone && (
+                      <p className="text-xs text-red-500 flex items-center gap-1">
+                        <Phone className="h-3 w-3" />
+                        {errors.phone}
+                      </p>
+                    )}
                   </div>
 
                   {/* User Type Selection */}
                   <div className="space-y-3">
                     <label className="flex items-center gap-2 text-sm sm:text-base font-medium text-foreground">
-                      <Users className="h-4 w-4 text-yellow-500" />
-                      I am a
+                      <Users className="h-4 w-4 text-yellow-500" />I am a
                     </label>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                       {userTypes.map((type) => (
-                        <label key={type.value} className="relative cursor-pointer">
+                        <label
+                          key={type.value}
+                          className="relative cursor-pointer"
+                        >
                           <input
                             type="radio"
                             name="userType"
@@ -293,18 +407,26 @@ export default function ContactForm() {
                             required
                             className="sr-only"
                           />
-                          <div className={`p-4 rounded-xl border-2 transition-all duration-300 ${
-                            formData.userType === type.value
-                              ? 'border-blue-500/50 bg-blue-500/10 professional-card'
-                              : 'border-border/30 glass-effect hover:border-border/50'
-                          }`}>
+                          <div
+                            className={`p-4 rounded-xl border-2 transition-all duration-300 ${
+                              formData.userType === type.value
+                                ? "border-blue-500/50 bg-blue-500/10 professional-card"
+                                : "border-border/30 glass-effect hover:border-border/50"
+                            }`}
+                          >
                             <div className="flex items-center gap-3">
-                              <div className={`${formData.userType === type.value ? 'text-blue-500' : 'text-muted-foreground'}`}>
+                              <div
+                                className={`${formData.userType === type.value ? "text-blue-500" : "text-muted-foreground"}`}
+                              >
                                 {type.icon}
                               </div>
-                              <span className={`text-sm sm:text-base font-medium ${
-                                formData.userType === type.value ? 'bolt-gradient-text' : 'text-foreground'
-                              }`}>
+                              <span
+                                className={`text-sm sm:text-base font-medium ${
+                                  formData.userType === type.value
+                                    ? "bolt-gradient-text"
+                                    : "text-foreground"
+                                }`}
+                              >
                                 {type.label}
                               </span>
                             </div>
@@ -312,6 +434,12 @@ export default function ContactForm() {
                         </label>
                       ))}
                     </div>
+                    {errors.userType && (
+                      <p className="text-xs text-red-500 flex items-center gap-1">
+                        <Users className="h-3 w-3" />
+                        {errors.userType}
+                      </p>
+                    )}
                   </div>
 
                   {/* Help Type Selection */}
@@ -322,7 +450,10 @@ export default function ContactForm() {
                     </label>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                       {helpTypes.map((type) => (
-                        <label key={type.value} className="relative cursor-pointer">
+                        <label
+                          key={type.value}
+                          className="relative cursor-pointer"
+                        >
                           <input
                             type="radio"
                             name="helpType"
@@ -332,18 +463,26 @@ export default function ContactForm() {
                             required
                             className="sr-only"
                           />
-                          <div className={`p-3 sm:p-4 rounded-xl border-2 transition-all duration-300 ${
-                            formData.helpType === type.value
-                              ? 'border-orange-500/50 bg-orange-500/10 professional-card'
-                              : 'border-border/30 glass-effect hover:border-border/50'
-                          }`}>
+                          <div
+                            className={`p-3 sm:p-4 rounded-xl border-2 transition-all duration-300 ${
+                              formData.helpType === type.value
+                                ? "border-orange-500/50 bg-orange-500/10 professional-card"
+                                : "border-border/30 glass-effect hover:border-border/50"
+                            }`}
+                          >
                             <div className="flex items-center gap-2 sm:gap-3">
-                              <div className={`${formData.helpType === type.value ? 'text-orange-500' : 'text-muted-foreground'}`}>
+                              <div
+                                className={`${formData.helpType === type.value ? "text-orange-500" : "text-muted-foreground"}`}
+                              >
                                 {type.icon}
                               </div>
-                              <span className={`text-xs sm:text-sm font-medium ${
-                                formData.helpType === type.value ? 'bolt-gradient-text' : 'text-foreground'
-                              }`}>
+                              <span
+                                className={`text-xs sm:text-sm font-medium ${
+                                  formData.helpType === type.value
+                                    ? "bolt-gradient-text"
+                                    : "text-foreground"
+                                }`}
+                              >
                                 {type.label}
                               </span>
                             </div>
@@ -351,11 +490,20 @@ export default function ContactForm() {
                         </label>
                       ))}
                     </div>
+                    {errors.helpType && (
+                      <p className="text-xs text-red-500 flex items-center gap-1">
+                        <HelpCircle className="h-3 w-3" />
+                        {errors.helpType}
+                      </p>
+                    )}
                   </div>
 
                   {/* Message Field */}
                   <div className="space-y-2">
-                    <label htmlFor="message" className="flex items-center gap-2 text-sm sm:text-base font-medium text-foreground">
+                    <label
+                      htmlFor="message"
+                      className="flex items-center gap-2 text-sm sm:text-base font-medium text-foreground"
+                    >
                       <MessageSquare className="h-4 w-4 text-pink-500" />
                       Your Message
                     </label>
@@ -369,6 +517,12 @@ export default function ContactForm() {
                       className="w-full px-4 py-3 sm:py-4 rounded-xl glass-effect border border-border/50 focus:border-pink-500/50 focus:ring-2 focus:ring-pink-500/20 transition-all duration-300 text-sm sm:text-base placeholder:text-muted-foreground/60 resize-none"
                       placeholder="Tell us more about how we can help you. The more details you provide, the better we can assist you!"
                     />
+                    {errors.message && (
+                      <p className="text-xs text-red-500 flex items-center gap-1">
+                        <MessageSquare className="h-3 w-3" />
+                        {errors.message}
+                      </p>
+                    )}
                   </div>
 
                   {/* Submit Button */}
@@ -399,7 +553,8 @@ export default function ContactForm() {
                 <div className="mt-8 pt-6 border-t border-border/30">
                   <div className="text-center">
                     <p className="text-xs sm:text-sm text-muted-foreground mb-4">
-                      Your information is secure and will never be shared with third parties.
+                      Your information is secure and will never be shared with
+                      third parties.
                     </p>
                     <div className="flex flex-wrap justify-center gap-4 text-xs sm:text-sm text-muted-foreground">
                       <div className="flex items-center gap-1">
@@ -425,38 +580,50 @@ export default function ContactForm() {
 
       <style jsx>{`
         .modern-display {
-          font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+          font-family:
+            "Inter",
+            -apple-system,
+            BlinkMacSystemFont,
+            "Segoe UI",
+            system-ui,
+            sans-serif;
           font-weight: 800;
           line-height: 1.1;
           letter-spacing: -0.02em;
         }
-        
+
         .modern-body {
-          font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+          font-family:
+            "Inter",
+            -apple-system,
+            BlinkMacSystemFont,
+            "Segoe UI",
+            system-ui,
+            sans-serif;
           font-weight: 400;
           line-height: 1.6;
         }
-        
+
         .bolt-gradient-text {
           background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
           -webkit-background-clip: text;
           -webkit-text-fill-color: transparent;
           background-clip: text;
         }
-        
+
         .glass-effect {
           background: rgba(255, 255, 255, 0.05);
           backdrop-filter: blur(10px);
           border: 1px solid rgba(255, 255, 255, 0.1);
         }
-        
+
         .professional-card {
           background: rgba(255, 255, 255, 0.03);
           backdrop-filter: blur(20px);
           border: 1px solid rgba(255, 255, 255, 0.08);
           box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
         }
-        
+
         .professional-button {
           background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
           color: white;
@@ -465,38 +632,65 @@ export default function ContactForm() {
           transition: all 0.3s ease;
           box-shadow: 0 4px 20px rgba(102, 126, 234, 0.3);
         }
-        
+
         .professional-button:hover:not(:disabled) {
           transform: translateY(-2px);
           box-shadow: 0 8px 30px rgba(102, 126, 234, 0.4);
         }
-        
+
         .mesh-gradient {
-          background: radial-gradient(circle at 20% 80%, rgba(120, 119, 198, 0.3) 0%, transparent 50%),
-                      radial-gradient(circle at 80% 20%, rgba(255, 119, 198, 0.3) 0%, transparent 50%),
-                      radial-gradient(circle at 40% 40%, rgba(120, 219, 226, 0.3) 0%, transparent 50%);
+          background:
+            radial-gradient(
+              circle at 20% 80%,
+              rgba(120, 119, 198, 0.3) 0%,
+              transparent 50%
+            ),
+            radial-gradient(
+              circle at 80% 20%,
+              rgba(255, 119, 198, 0.3) 0%,
+              transparent 50%
+            ),
+            radial-gradient(
+              circle at 40% 40%,
+              rgba(120, 219, 226, 0.3) 0%,
+              transparent 50%
+            );
         }
-        
+
         .floating-orb {
           border-radius: 50%;
           filter: blur(40px);
           animation: float 6s ease-in-out infinite;
         }
-        
+
         .shimmer {
-          background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+          background: linear-gradient(
+            90deg,
+            transparent,
+            rgba(255, 255, 255, 0.1),
+            transparent
+          );
           background-size: 200% 100%;
           animation: shimmer 2s infinite;
         }
-        
+
         @keyframes float {
-          0%, 100% { transform: translateY(0px) rotate(0deg); }
-          50% { transform: translateY(-20px) rotate(180deg); }
+          0%,
+          100% {
+            transform: translateY(0px) rotate(0deg);
+          }
+          50% {
+            transform: translateY(-20px) rotate(180deg);
+          }
         }
-        
+
         @keyframes shimmer {
-          0% { background-position: -200% 0; }
-          100% { background-position: 200% 0; }
+          0% {
+            background-position: -200% 0;
+          }
+          100% {
+            background-position: 200% 0;
+          }
         }
       `}</style>
     </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -71,17 +71,28 @@ const profileSchema = z.object({
     .refine((value) => {
       if (!value) return true;
       try {
-        new URL(value);
-        return true;
+        const url = new URL(value);
+        return url.protocol === "http:" || url.protocol === "https:";
       } catch {
         return false;
       }
-    }, "Please enter a valid URL including https://"),
+    }, "Please enter a valid http(s) URL including https://"),
 });
 
 type ProfileFormData = z.infer<typeof profileSchema>;
 type ProfileField = keyof ProfileFormData;
 type ProfileErrors = Partial<Record<ProfileField, string>>;
+
+const isSafeHttpUrl = (value?: string | null) => {
+  if (!value) return false;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
 
 interface UserProfile {
   id: string;
@@ -122,6 +133,26 @@ export default function ProfilePage() {
   const router = useRouter();
   const supabase = useMemo(() => createClient(), []);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const validateProfileField = (name: ProfileField, value: string) => {
+    const fieldSchema = profileSchema.shape[name];
+    const validation = fieldSchema.safeParse(value);
+
+    return validation.success
+      ? undefined
+      : validation.error.issues[0]?.message || "Invalid value";
+  };
+
+  const handleProfileFieldChange = (name: ProfileField, value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    setFieldErrors((prev) => ({
+      ...prev,
+      [name]: validateProfileField(name, value),
+    }));
+  };
 
   const loadUserProfile = useCallback(async () => {
     try {
@@ -182,17 +213,30 @@ export default function ProfilePage() {
       }
 
       try {
-        // Try to get documents count and last activity
-        const documentsResult = await supabase
+        const documentsCountResult = await supabase
+          .from("documents")
+          .select("id", { count: "exact", head: true })
+          .eq("user_id", authUser.id);
+
+        if (documentsCountResult.error) {
+          throw documentsCountResult.error;
+        }
+
+        documentsCount = documentsCountResult.count || 0;
+
+        const latestDocumentResult = await supabase
           .from("documents")
           .select("id, created_at")
           .eq("user_id", authUser.id)
           .order("created_at", { ascending: false })
           .limit(1);
 
-        documentsCount = documentsResult.data?.length || 0;
+        if (latestDocumentResult.error) {
+          throw latestDocumentResult.error;
+        }
+
         lastActivity =
-          documentsResult.data?.[0]?.created_at || authUser.created_at;
+          latestDocumentResult.data?.[0]?.created_at || authUser.created_at;
       } catch (error) {
         console.warn("Documents table not found or accessible:", error);
       }
@@ -326,17 +370,18 @@ export default function ProfilePage() {
     }
 
     try {
+      const validatedData = validation.data;
       setFieldErrors({});
       setSaving(true);
 
       // Update user metadata
       const { error } = await supabase.auth.updateUser({
         data: {
-          name: formData.name,
-          bio: formData.bio,
-          location: formData.location,
-          phone: formData.phone,
-          website: formData.website,
+          name: validatedData.name,
+          bio: validatedData.bio,
+          location: validatedData.location,
+          phone: validatedData.phone,
+          website: validatedData.website,
         },
       });
 
@@ -347,14 +392,16 @@ export default function ProfilePage() {
         prev
           ? {
               ...prev,
-              name: formData.name,
-              bio: formData.bio,
-              location: formData.location,
-              phone: formData.phone,
-              website: formData.website,
+              name: validatedData.name,
+              bio: validatedData.bio,
+              location: validatedData.location,
+              phone: validatedData.phone,
+              website: validatedData.website,
             }
           : null,
       );
+
+      setFormData(validatedData);
 
       setEditing(false);
       toast({
@@ -536,14 +583,10 @@ export default function ProfilePage() {
                               id="name"
                               value={formData.name}
                               onChange={(e) => {
-                                setFormData((prev) => ({
-                                  ...prev,
-                                  name: e.target.value,
-                                }));
-                                setFieldErrors((prev) => ({
-                                  ...prev,
-                                  name: undefined,
-                                }));
+                                handleProfileFieldChange(
+                                  "name",
+                                  e.target.value,
+                                );
                               }}
                               placeholder="Enter your full name"
                             />
@@ -584,14 +627,10 @@ export default function ProfilePage() {
                               id="phone"
                               value={formData.phone}
                               onChange={(e) => {
-                                setFormData((prev) => ({
-                                  ...prev,
-                                  phone: e.target.value,
-                                }));
-                                setFieldErrors((prev) => ({
-                                  ...prev,
-                                  phone: undefined,
-                                }));
+                                handleProfileFieldChange(
+                                  "phone",
+                                  e.target.value,
+                                );
                               }}
                               placeholder="Enter your phone number"
                             />
@@ -622,14 +661,10 @@ export default function ProfilePage() {
                               id="location"
                               value={formData.location}
                               onChange={(e) => {
-                                setFormData((prev) => ({
-                                  ...prev,
-                                  location: e.target.value,
-                                }));
-                                setFieldErrors((prev) => ({
-                                  ...prev,
-                                  location: undefined,
-                                }));
+                                handleProfileFieldChange(
+                                  "location",
+                                  e.target.value,
+                                );
                               }}
                               placeholder="Enter your location"
                             />
@@ -661,14 +696,10 @@ export default function ProfilePage() {
                             id="website"
                             value={formData.website}
                             onChange={(e) => {
-                              setFormData((prev) => ({
-                                ...prev,
-                                website: e.target.value,
-                              }));
-                              setFieldErrors((prev) => ({
-                                ...prev,
-                                website: undefined,
-                              }));
+                              handleProfileFieldChange(
+                                "website",
+                                e.target.value,
+                              );
                             }}
                             placeholder="https://example.com"
                           />
@@ -680,7 +711,7 @@ export default function ProfilePage() {
                         </>
                       ) : (
                         <p className="mt-1 text-sm text-muted-foreground flex items-center">
-                          {user.website ? (
+                          {isSafeHttpUrl(user.website) ? (
                             <>
                               <Globe className="mr-2 h-4 w-4" />
                               <a
@@ -711,14 +742,7 @@ export default function ProfilePage() {
                           id="bio"
                           value={formData.bio}
                           onChange={(e) => {
-                            setFormData((prev) => ({
-                              ...prev,
-                              bio: e.target.value,
-                            }));
-                            setFieldErrors((prev) => ({
-                              ...prev,
-                              bio: undefined,
-                            }));
+                            handleProfileFieldChange("bio", e.target.value);
                           }}
                           placeholder="Tell us about yourself..."
                           rows={4}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,19 +1,32 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect, useRef } from 'react';
-import { createClient } from '@/lib/supabase/client';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Badge } from '@/components/ui/badge';
-import { Separator } from '@/components/ui/separator';
-import { useToast } from '@/hooks/use-toast';
-import { useRouter } from 'next/navigation';
-import { SiteHeader } from '@/components/site-header';
-import { ReferralSection } from '@/components/referral-section';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { useToast } from "@/hooks/use-toast";
+import { useRouter } from "next/navigation";
+import { SiteHeader } from "@/components/site-header";
+import { ReferralSection } from "@/components/referral-section";
+import { z } from "zod";
 import {
   User,
   Mail,
@@ -28,8 +41,47 @@ import {
   FileText,
   Activity,
   Camera,
-  Upload
-} from 'lucide-react';
+  Upload,
+} from "lucide-react";
+
+const profileSchema = z.object({
+  name: z.string().trim().min(2, "Full name must be at least 2 characters"),
+  bio: z
+    .string()
+    .trim()
+    .max(500, "Bio must be 500 characters or fewer")
+    .optional(),
+  location: z
+    .string()
+    .trim()
+    .max(120, "Location must be 120 characters or fewer")
+    .optional(),
+  phone: z
+    .string()
+    .trim()
+    .optional()
+    .refine(
+      (value) => !value || /^[+()\-\s\d]{7,20}$/.test(value),
+      "Please enter a valid phone number",
+    ),
+  website: z
+    .string()
+    .trim()
+    .optional()
+    .refine((value) => {
+      if (!value) return true;
+      try {
+        new URL(value);
+        return true;
+      } catch {
+        return false;
+      }
+    }, "Please enter a valid URL including https://"),
+});
+
+type ProfileFormData = z.infer<typeof profileSchema>;
+type ProfileField = keyof ProfileFormData;
+type ProfileErrors = Partial<Record<ProfileField, string>>;
 
 interface UserProfile {
   id: string;
@@ -57,57 +109,59 @@ export default function ProfilePage() {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [uploadingAvatar, setUploadingAvatar] = useState(false);
-  const [formData, setFormData] = useState({
-    name: '',
-    bio: '',
-    location: '',
-    phone: '',
-    website: ''
+  const [formData, setFormData] = useState<ProfileFormData>({
+    name: "",
+    bio: "",
+    location: "",
+    phone: "",
+    website: "",
   });
+  const [fieldErrors, setFieldErrors] = useState<ProfileErrors>({});
 
   const { toast } = useToast();
   const router = useRouter();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    loadUserProfile();
-  }, []);
-
-  const loadUserProfile = async () => {
+  const loadUserProfile = useCallback(async () => {
     try {
       setLoading(true);
 
       // Use getSession() for rate limit avoidance (reads from local cache)
-      const { data: { session } } = await supabase.auth.getSession();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
       const authUser = session?.user;
 
       if (!authUser) {
-        router.push('/auth/signin');
+        router.push("/auth/signin");
         return;
       }
 
       // Set user profile data
       const userProfile: UserProfile = {
         id: authUser.id,
-        email: authUser.email || '',
-        name: authUser.user_metadata?.name || authUser.user_metadata?.full_name || '',
-        avatar_url: authUser.user_metadata?.avatar_url || '',
-        bio: authUser.user_metadata?.bio || '',
-        location: authUser.user_metadata?.location || '',
-        phone: authUser.user_metadata?.phone || '',
-        website: authUser.user_metadata?.website || '',
+        email: authUser.email || "",
+        name:
+          authUser.user_metadata?.name ||
+          authUser.user_metadata?.full_name ||
+          "",
+        avatar_url: authUser.user_metadata?.avatar_url || "",
+        bio: authUser.user_metadata?.bio || "",
+        location: authUser.user_metadata?.location || "",
+        phone: authUser.user_metadata?.phone || "",
+        website: authUser.user_metadata?.website || "",
         created_at: authUser.created_at,
-        last_sign_in_at: authUser.last_sign_in_at || undefined
+        last_sign_in_at: authUser.last_sign_in_at || undefined,
       };
 
       setUser(userProfile);
       setFormData({
-        name: userProfile.name || '',
-        bio: userProfile.bio || '',
-        location: userProfile.location || '',
-        phone: userProfile.phone || '',
-        website: userProfile.website || ''
+        name: userProfile.name || "",
+        bio: userProfile.bio || "",
+        location: userProfile.location || "",
+        phone: userProfile.phone || "",
+        website: userProfile.website || "",
       });
 
       // Load real user statistics from database with error handling
@@ -118,68 +172,75 @@ export default function ProfilePage() {
       try {
         // Try to get templates count
         const templatesResult = await supabase
-          .from('templates')
-          .select('id')
-          .eq('user_id', authUser.id);
+          .from("templates")
+          .select("id")
+          .eq("user_id", authUser.id);
 
         templatesCount = templatesResult.data?.length || 0;
       } catch (error) {
-        console.warn('Templates table not found or accessible:', error);
+        console.warn("Templates table not found or accessible:", error);
       }
 
       try {
         // Try to get documents count and last activity
         const documentsResult = await supabase
-          .from('documents')
-          .select('id, created_at')
-          .eq('user_id', authUser.id)
-          .order('created_at', { ascending: false })
+          .from("documents")
+          .select("id, created_at")
+          .eq("user_id", authUser.id)
+          .order("created_at", { ascending: false })
           .limit(1);
 
         documentsCount = documentsResult.data?.length || 0;
-        lastActivity = documentsResult.data?.[0]?.created_at || authUser.created_at;
+        lastActivity =
+          documentsResult.data?.[0]?.created_at || authUser.created_at;
       } catch (error) {
-        console.warn('Documents table not found or accessible:', error);
+        console.warn("Documents table not found or accessible:", error);
       }
 
       setStats({
         templates_created: templatesCount,
         documents_generated: documentsCount,
-        last_activity: lastActivity
+        last_activity: lastActivity,
       });
-
     } catch (error) {
-      console.error('Error loading profile:', error);
+      console.error("Error loading profile:", error);
       toast({
-        title: 'Error',
-        description: 'Failed to load profile data',
-        variant: 'destructive'
+        title: "Error",
+        description: "Failed to load profile data",
+        variant: "destructive",
       });
     } finally {
       setLoading(false);
     }
-  };
+  }, [router, supabase, toast]);
 
-  const handleAvatarUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  useEffect(() => {
+    loadUserProfile();
+  }, [loadUserProfile]);
+
+  const handleAvatarUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
     const file = event.target.files?.[0];
     if (!file || !user) return;
 
     // Validate file type and size
-    const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+    const allowedTypes = ["image/jpeg", "image/png", "image/gif", "image/webp"];
     if (!allowedTypes.includes(file.type)) {
       toast({
-        title: 'Invalid file type',
-        description: 'Please upload a JPEG, PNG, GIF, or WebP image',
-        variant: 'destructive'
+        title: "Invalid file type",
+        description: "Please upload a JPEG, PNG, GIF, or WebP image",
+        variant: "destructive",
       });
       return;
     }
 
-    if (file.size > 5 * 1024 * 1024) { // 5MB limit
+    if (file.size > 5 * 1024 * 1024) {
+      // 5MB limit
       toast({
-        title: 'File too large',
-        description: 'Please upload an image smaller than 5MB',
-        variant: 'destructive'
+        title: "File too large",
+        description: "Please upload an image smaller than 5MB",
+        variant: "destructive",
       });
       return;
     }
@@ -188,59 +249,62 @@ export default function ProfilePage() {
       setUploadingAvatar(true);
 
       // Upload to Supabase Storage
-      const fileExt = file.name.split('.').pop();
+      const fileExt = file.name.split(".").pop();
       const fileName = `${user.id}-${Date.now()}.${fileExt}`;
       const filePath = `${fileName}`; // Remove avatars/ prefix since we're already in the avatars bucket
 
       const { error: uploadError } = await supabase.storage
-        .from('avatars')
+        .from("avatars")
         .upload(filePath, file);
 
       if (uploadError) {
         // Handle specific bucket not found error
-        if (uploadError.message?.includes('Bucket not found')) {
-          throw new Error('Storage bucket not configured. Please contact support or check the setup guide.');
+        if (uploadError.message?.includes("Bucket not found")) {
+          throw new Error(
+            "Storage bucket not configured. Please contact support or check the setup guide.",
+          );
         }
         throw uploadError;
       }
 
       // Get public URL
-      const { data: { publicUrl } } = supabase.storage
-        .from('avatars')
-        .getPublicUrl(filePath);
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from("avatars").getPublicUrl(filePath);
 
       // Update user metadata with new avatar URL
       const { error: updateError } = await supabase.auth.updateUser({
         data: {
-          avatar_url: publicUrl
-        }
+          avatar_url: publicUrl,
+        },
       });
 
       if (updateError) throw updateError;
 
       // Update local state
-      setUser(prev => prev ? { ...prev, avatar_url: publicUrl } : null);
+      setUser((prev) => (prev ? { ...prev, avatar_url: publicUrl } : null));
 
       toast({
-        title: 'Success',
-        description: 'Profile picture updated successfully'
+        title: "Success",
+        description: "Profile picture updated successfully",
       });
-
     } catch (error: any) {
-      console.error('Error uploading avatar:', error);
+      console.error("Error uploading avatar:", error);
 
-      let errorMessage = 'Failed to upload profile picture';
+      let errorMessage = "Failed to upload profile picture";
 
-      if (error.message?.includes('Storage bucket not configured')) {
-        errorMessage = 'Profile picture upload is not configured yet. Please check the setup guide.';
-      } else if (error.message?.includes('Bucket not found')) {
-        errorMessage = 'Storage bucket not found. Please create the "avatars" bucket in Supabase Storage.';
+      if (error.message?.includes("Storage bucket not configured")) {
+        errorMessage =
+          "Profile picture upload is not configured yet. Please check the setup guide.";
+      } else if (error.message?.includes("Bucket not found")) {
+        errorMessage =
+          'Storage bucket not found. Please create the "avatars" bucket in Supabase Storage.';
       }
 
       toast({
-        title: 'Error',
+        title: "Error",
         description: errorMessage,
-        variant: 'destructive'
+        variant: "destructive",
       });
     } finally {
       setUploadingAvatar(false);
@@ -250,7 +314,19 @@ export default function ProfilePage() {
   const handleSave = async () => {
     if (!user) return;
 
+    const validation = profileSchema.safeParse(formData);
+    if (!validation.success) {
+      const nextErrors: ProfileErrors = {};
+      validation.error.issues.forEach((issue) => {
+        const field = issue.path[0] as ProfileField;
+        nextErrors[field] = issue.message;
+      });
+      setFieldErrors(nextErrors);
+      return;
+    }
+
     try {
+      setFieldErrors({});
       setSaving(true);
 
       // Update user metadata
@@ -260,34 +336,37 @@ export default function ProfilePage() {
           bio: formData.bio,
           location: formData.location,
           phone: formData.phone,
-          website: formData.website
-        }
+          website: formData.website,
+        },
       });
 
       if (error) throw error;
 
       // Update local state
-      setUser(prev => prev ? {
-        ...prev,
-        name: formData.name,
-        bio: formData.bio,
-        location: formData.location,
-        phone: formData.phone,
-        website: formData.website
-      } : null);
+      setUser((prev) =>
+        prev
+          ? {
+              ...prev,
+              name: formData.name,
+              bio: formData.bio,
+              location: formData.location,
+              phone: formData.phone,
+              website: formData.website,
+            }
+          : null,
+      );
 
       setEditing(false);
       toast({
-        title: 'Success',
-        description: 'Profile updated successfully'
+        title: "Success",
+        description: "Profile updated successfully",
       });
-
     } catch (error) {
-      console.error('Error updating profile:', error);
+      console.error("Error updating profile:", error);
       toast({
-        title: 'Error',
-        description: 'Failed to update profile',
-        variant: 'destructive'
+        title: "Error",
+        description: "Failed to update profile",
+        variant: "destructive",
       });
     } finally {
       setSaving(false);
@@ -298,29 +377,30 @@ export default function ProfilePage() {
     if (!user) return;
 
     setFormData({
-      name: user.name || '',
-      bio: user.bio || '',
-      location: user.location || '',
-      phone: user.phone || '',
-      website: user.website || ''
+      name: user.name || "",
+      bio: user.bio || "",
+      location: user.location || "",
+      phone: user.phone || "",
+      website: user.website || "",
     });
+    setFieldErrors({});
     setEditing(false);
   };
 
   const getInitials = (name: string) => {
     return name
-      .split(' ')
-      .map(word => word[0])
-      .join('')
+      .split(" ")
+      .map((word) => word[0])
+      .join("")
       .toUpperCase()
       .slice(0, 2);
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
+    return new Date(dateString).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
     });
   };
 
@@ -380,7 +460,7 @@ export default function ProfilePage() {
               <div className="flex gap-2">
                 <Button onClick={handleSave} disabled={saving}>
                   <Save className="mr-2 h-4 w-4" />
-                  {saving ? 'Saving...' : 'Save'}
+                  {saving ? "Saving..." : "Save"}
                 </Button>
                 <Button variant="outline" onClick={handleCancel}>
                   <X className="mr-2 h-4 w-4" />
@@ -400,7 +480,11 @@ export default function ProfilePage() {
                       <Avatar className="h-20 w-20">
                         <AvatarImage src={user.avatar_url} alt={user.name} />
                         <AvatarFallback className="text-lg">
-                          {user.name ? getInitials(user.name) : <User className="h-8 w-8" />}
+                          {user.name ? (
+                            getInitials(user.name)
+                          ) : (
+                            <User className="h-8 w-8" />
+                          )}
                         </AvatarFallback>
                       </Avatar>
                       {editing && (
@@ -427,7 +511,9 @@ export default function ProfilePage() {
                       />
                     </div>
                     <div className="flex-1">
-                      <CardTitle className="text-2xl">{user.name || 'Anonymous User'}</CardTitle>
+                      <CardTitle className="text-2xl">
+                        {user.name || "Anonymous User"}
+                      </CardTitle>
                       <CardDescription className="flex items-center mt-1">
                         <Mail className="mr-2 h-4 w-4" />
                         {user.email}
@@ -438,26 +524,46 @@ export default function ProfilePage() {
                 <CardContent className="space-y-6">
                   {/* Basic Information */}
                   <div>
-                    <h3 className="text-lg font-semibold mb-4">Basic Information</h3>
+                    <h3 className="text-lg font-semibold mb-4">
+                      Basic Information
+                    </h3>
                     <div className="grid gap-4 md:grid-cols-2">
                       <div>
                         <Label htmlFor="name">Full Name</Label>
                         {editing ? (
-                          <Input
-                            id="name"
-                            value={formData.name}
-                            onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
-                            placeholder="Enter your full name"
-                          />
+                          <>
+                            <Input
+                              id="name"
+                              value={formData.name}
+                              onChange={(e) => {
+                                setFormData((prev) => ({
+                                  ...prev,
+                                  name: e.target.value,
+                                }));
+                                setFieldErrors((prev) => ({
+                                  ...prev,
+                                  name: undefined,
+                                }));
+                              }}
+                              placeholder="Enter your full name"
+                            />
+                            {fieldErrors.name && (
+                              <p className="mt-1 text-xs text-red-500">
+                                {fieldErrors.name}
+                              </p>
+                            )}
+                          </>
                         ) : (
                           <p className="mt-1 text-sm text-muted-foreground">
-                            {user.name || 'Not provided'}
+                            {user.name || "Not provided"}
                           </p>
                         )}
                       </div>
                       <div>
                         <Label htmlFor="email">Email</Label>
-                        <p className="mt-1 text-sm text-muted-foreground">{user.email}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {user.email}
+                        </p>
                       </div>
                     </div>
                   </div>
@@ -466,17 +572,35 @@ export default function ProfilePage() {
 
                   {/* Contact Information */}
                   <div>
-                    <h3 className="text-lg font-semibold mb-4">Contact Information</h3>
+                    <h3 className="text-lg font-semibold mb-4">
+                      Contact Information
+                    </h3>
                     <div className="grid gap-4 md:grid-cols-2">
                       <div>
                         <Label htmlFor="phone">Phone</Label>
                         {editing ? (
-                          <Input
-                            id="phone"
-                            value={formData.phone}
-                            onChange={(e) => setFormData(prev => ({ ...prev, phone: e.target.value }))}
-                            placeholder="Enter your phone number"
-                          />
+                          <>
+                            <Input
+                              id="phone"
+                              value={formData.phone}
+                              onChange={(e) => {
+                                setFormData((prev) => ({
+                                  ...prev,
+                                  phone: e.target.value,
+                                }));
+                                setFieldErrors((prev) => ({
+                                  ...prev,
+                                  phone: undefined,
+                                }));
+                              }}
+                              placeholder="Enter your phone number"
+                            />
+                            {fieldErrors.phone && (
+                              <p className="mt-1 text-xs text-red-500">
+                                {fieldErrors.phone}
+                              </p>
+                            )}
+                          </>
                         ) : (
                           <p className="mt-1 text-sm text-muted-foreground flex items-center">
                             {user.phone ? (
@@ -485,7 +609,7 @@ export default function ProfilePage() {
                                 {user.phone}
                               </>
                             ) : (
-                              'Not provided'
+                              "Not provided"
                             )}
                           </p>
                         )}
@@ -493,12 +617,28 @@ export default function ProfilePage() {
                       <div>
                         <Label htmlFor="location">Location</Label>
                         {editing ? (
-                          <Input
-                            id="location"
-                            value={formData.location}
-                            onChange={(e) => setFormData(prev => ({ ...prev, location: e.target.value }))}
-                            placeholder="Enter your location"
-                          />
+                          <>
+                            <Input
+                              id="location"
+                              value={formData.location}
+                              onChange={(e) => {
+                                setFormData((prev) => ({
+                                  ...prev,
+                                  location: e.target.value,
+                                }));
+                                setFieldErrors((prev) => ({
+                                  ...prev,
+                                  location: undefined,
+                                }));
+                              }}
+                              placeholder="Enter your location"
+                            />
+                            {fieldErrors.location && (
+                              <p className="mt-1 text-xs text-red-500">
+                                {fieldErrors.location}
+                              </p>
+                            )}
+                          </>
                         ) : (
                           <p className="mt-1 text-sm text-muted-foreground flex items-center">
                             {user.location ? (
@@ -507,7 +647,7 @@ export default function ProfilePage() {
                                 {user.location}
                               </>
                             ) : (
-                              'Not provided'
+                              "Not provided"
                             )}
                           </p>
                         )}
@@ -516,23 +656,44 @@ export default function ProfilePage() {
                     <div className="mt-4">
                       <Label htmlFor="website">Website</Label>
                       {editing ? (
-                        <Input
-                          id="website"
-                          value={formData.website}
-                          onChange={(e) => setFormData(prev => ({ ...prev, website: e.target.value }))}
-                          placeholder="Enter your website URL"
-                        />
+                        <>
+                          <Input
+                            id="website"
+                            value={formData.website}
+                            onChange={(e) => {
+                              setFormData((prev) => ({
+                                ...prev,
+                                website: e.target.value,
+                              }));
+                              setFieldErrors((prev) => ({
+                                ...prev,
+                                website: undefined,
+                              }));
+                            }}
+                            placeholder="https://example.com"
+                          />
+                          {fieldErrors.website && (
+                            <p className="mt-1 text-xs text-red-500">
+                              {fieldErrors.website}
+                            </p>
+                          )}
+                        </>
                       ) : (
                         <p className="mt-1 text-sm text-muted-foreground flex items-center">
                           {user.website ? (
                             <>
                               <Globe className="mr-2 h-4 w-4" />
-                              <a href={user.website} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                              <a
+                                href={user.website}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:underline"
+                              >
                                 {user.website}
                               </a>
                             </>
                           ) : (
-                            'Not provided'
+                            "Not provided"
                           )}
                         </p>
                       )}
@@ -545,16 +706,41 @@ export default function ProfilePage() {
                   <div>
                     <Label htmlFor="bio">Bio</Label>
                     {editing ? (
-                      <Textarea
-                        id="bio"
-                        value={formData.bio}
-                        onChange={(e) => setFormData(prev => ({ ...prev, bio: e.target.value }))}
-                        placeholder="Tell us about yourself..."
-                        rows={4}
-                      />
+                      <>
+                        <Textarea
+                          id="bio"
+                          value={formData.bio}
+                          onChange={(e) => {
+                            setFormData((prev) => ({
+                              ...prev,
+                              bio: e.target.value,
+                            }));
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              bio: undefined,
+                            }));
+                          }}
+                          placeholder="Tell us about yourself..."
+                          rows={4}
+                        />
+                        <div className="mt-1 flex items-center justify-between text-xs">
+                          {fieldErrors.bio ? (
+                            <span className="text-red-500">
+                              {fieldErrors.bio}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">
+                              500 characters max
+                            </span>
+                          )}
+                          <span className="text-muted-foreground">
+                            {formData.bio?.length || 0}/500
+                          </span>
+                        </div>
+                      </>
                     ) : (
                       <p className="mt-1 text-sm text-muted-foreground">
-                        {user.bio || 'No bio provided'}
+                        {user.bio || "No bio provided"}
                       </p>
                     )}
                   </div>
@@ -574,12 +760,20 @@ export default function ProfilePage() {
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="flex items-center justify-between">
-                    <span className="text-sm text-muted-foreground">Templates Created</span>
-                    <Badge variant="secondary">{stats?.templates_created || 0}</Badge>
+                    <span className="text-sm text-muted-foreground">
+                      Templates Created
+                    </span>
+                    <Badge variant="secondary">
+                      {stats?.templates_created || 0}
+                    </Badge>
                   </div>
                   <div className="flex items-center justify-between">
-                    <span className="text-sm text-muted-foreground">Documents Generated</span>
-                    <Badge variant="secondary">{stats?.documents_generated || 0}</Badge>
+                    <span className="text-sm text-muted-foreground">
+                      Documents Generated
+                    </span>
+                    <Badge variant="secondary">
+                      {stats?.documents_generated || 0}
+                    </Badge>
                   </div>
                 </CardContent>
               </Card>
@@ -605,7 +799,9 @@ export default function ProfilePage() {
                   </div>
                   {user.last_sign_in_at && (
                     <div>
-                      <Label className="text-sm font-medium">Last Sign In</Label>
+                      <Label className="text-sm font-medium">
+                        Last Sign In
+                      </Label>
                       <p className="text-sm text-muted-foreground flex items-center mt-1">
                         <Calendar className="mr-2 h-4 w-4" />
                         {formatDate(user.last_sign_in_at)}
@@ -624,15 +820,27 @@ export default function ProfilePage() {
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-2">
-                  <Button variant="outline" className="w-full justify-start" onClick={() => router.push('/templates')}>
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start"
+                    onClick={() => router.push("/templates")}
+                  >
                     <FileText className="mr-2 h-4 w-4" />
                     Browse Templates
                   </Button>
-                  <Button variant="outline" className="w-full justify-start" onClick={() => router.push('/resume')}>
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start"
+                    onClick={() => router.push("/resume")}
+                  >
                     <FileText className="mr-2 h-4 w-4" />
                     Create Resume
                   </Button>
-                  <Button variant="outline" className="w-full justify-start" onClick={() => router.push('/settings')}>
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start"
+                    onClick={() => router.push("/settings")}
+                  >
                     <Shield className="mr-2 h-4 w-4" />
                     Account Settings
                   </Button>


### PR DESCRIPTION
Closes #872

GSSoC labels/level: `gssoc:approved`, `level:intermediate`

## Summary
- Add Zod-backed inline validation to the contact form with field-level errors for contact details, user/help type, and message length.
- Add inline signup validation for name, email, password complexity, and password confirmation while preserving OAuth/referral behavior.
- Add profile edit validation for name, phone, location, website URL, and bio length before saving metadata.

## Validation
- `npx eslint app/contact/page.tsx app/auth/register/page.tsx app/profile/page.tsx --max-warnings=0`
- Pre-commit hook: `eslint --fix --max-warnings=0`, `prettier --write`, `jest --findRelatedTests --passWithNoTests`
- `npm run typecheck:changed` was attempted by the pre-push hook but failed with `TS18003: No inputs were found` from its generated Windows temp tsconfig include paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time, per-field validation and inline error messages on Register, Contact, and Profile forms; submit buttons disable until valid or while loading
  * Contact form: card-style selectable options for user type/help type and resettable "Send Another Message" flow
  * Profile: avatar upload improvements and a live character counter for the bio

* **Bug Fixes / UX**
  * Clear field-specific errors while typing and show contextual helper/error text on inputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->