### PR TITLE
Send Gemini API key via request header

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -239,12 +239,11 @@ async function callAI(provider, apiKey, prompt) {
 
 // Gemini AI API Call
 async function callGeminiAPI(apiKey, prompt) {
-    const url = `${API_URLS.gemini}?key=${apiKey}`;
-
-    const response = await fetch(url, {
+    const response = await fetch(API_URLS.gemini, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
+            'x-goog-api-key': apiKey,
         },
         body: JSON.stringify({
             contents: [{
@@ -255,11 +254,11 @@ async function callGeminiAPI(apiKey, prompt) {
 
     if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.error ? .message || 'Gemini API request failed');
+        throw new Error(error.error?.message || 'Gemini API request failed');
     }
 
     const data = await response.json();
-    const text = data.candidates[0] ? .content ? .parts[0] ? .text || '';
+    const text = data.candidates[0]?.content?.parts[0]?.text || '';
 
     return parseAIResponse(text);
 }
@@ -284,11 +283,11 @@ async function callOpenAIAPI(apiKey, prompt) {
 
     if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.error ? .message || 'OpenAI API request failed');
+        throw new Error(error.error?.message || 'OpenAI API request failed');
     }
 
     const data = await response.json();
-    const text = data.choices[0] ? .message ? .content || '';
+    const text = data.choices[0]?.message?.content || '';
 
     return parseAIResponse(text);
 }
@@ -316,7 +315,7 @@ async function callMistralAPI(apiKey, prompt) {
     }
 
     const data = await response.json();
-    const text = data.choices[0] ? .message ? .content || '';
+    const text = data.choices[0]?.message?.content || '';
 
     return parseAIResponse(text);
 }
@@ -342,11 +341,11 @@ async function callClaudeAPI(apiKey, prompt) {
 
     if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.error ? .message || 'Claude API request failed');
+        throw new Error(error.error?.message || 'Claude API request failed');
     }
 
     const data = await response.json();
-    const text = data.content[0] ? .text || '';
+    const text = data.content[0]?.text || '';
 
     return parseAIResponse(text);
 }

--- a/extension/background.js
+++ b/extension/background.js
@@ -258,7 +258,7 @@ async function callGeminiAPI(apiKey, prompt) {
     }
 
     const data = await response.json();
-    const text = data.candidates[0]?.content?.parts[0]?.text || '';
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
 
     return parseAIResponse(text);
 }
@@ -287,7 +287,7 @@ async function callOpenAIAPI(apiKey, prompt) {
     }
 
     const data = await response.json();
-    const text = data.choices[0]?.message?.content || '';
+    const text = data.choices?.[0]?.message?.content || '';
 
     return parseAIResponse(text);
 }
@@ -315,7 +315,7 @@ async function callMistralAPI(apiKey, prompt) {
     }
 
     const data = await response.json();
-    const text = data.choices[0]?.message?.content || '';
+    const text = data.choices?.[0]?.message?.content || '';
 
     return parseAIResponse(text);
 }
@@ -345,7 +345,7 @@ async function callClaudeAPI(apiKey, prompt) {
     }
 
     const data = await response.json();
-    const text = data.content[0]?.text || '';
+    const text = data.content?.[0]?.text || '';
 
     return parseAIResponse(text);
 }


### PR DESCRIPTION
Closes #890

GSSoC labels/level: `gssoc:approved`, `level:intermediate`

## Summary
- Remove the Gemini API key from the request URL query string.
- Send the key with the `x-goog-api-key` request header instead.
- Normalize existing optional-chaining syntax in the AI response/error parsing paths so the background script parses cleanly.

## Validation
- `node --check extension/background.js`

## Reference
- Google Gemini API documentation supports sending the API key with the `x-goog-api-key` header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized and fixed API error handling and response parsing across AI provider integrations, improving reliability.
* **Security**
  * Updated Gemini authentication to a more secure method for credential handling.
* **Other**
  * Improved startup readiness logging for clearer operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->