### PR TITLE
Fix: Add authentication and input size limits to resume analysis endpoint

### DIFF
--- a/app/api/analyze/resume/route.ts
+++ b/app/api/analyze/resume/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
 
 export const runtime = 'nodejs';
+
+const MAX_FILE_BYTES = 1 * 1024 * 1024;
+const MAX_JD_CHARS = 10000;
 
 async function extractTextFromFile(file: File): Promise<string> {
   return await file.text();
@@ -199,6 +203,37 @@ export async function POST(request: Request) {
   }
 
   try {
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+      return NextResponse.json(
+        { error: 'Unauthorized - No token provided' },
+        { status: 401, headers }
+      );
+    }
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        global: {
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        }
+      }
+    );
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: 'Unauthorized - Please sign in' },
+        { status: 401, headers }
+      );
+    }
+
     const formData = await request.formData();
 
     const file = formData.get('file') as File | null;
@@ -213,6 +248,24 @@ export async function POST(request: Request) {
           error: 'Resume file and job description are required',
         },
         { status: 400, headers }
+      );
+    }
+
+    if (file.size > MAX_FILE_BYTES) {
+      return NextResponse.json(
+        {
+          error: `File too large. Maximum size is ${MAX_FILE_BYTES / 1024 / 1024} MB.`,
+        },
+        { status: 413, headers }
+      );
+    }
+
+    if (jobDescription.length > MAX_JD_CHARS) {
+      return NextResponse.json(
+        {
+          error: `Job description too long. Maximum length is ${MAX_JD_CHARS} characters.`,
+        },
+        { status: 413, headers }
       );
     }
 


### PR DESCRIPTION
## Summary
- Added Bearer token authentication check to prevent unauthorized API access
- Implemented 1 MB file size limit to prevent memory exhaustion attacks  
- Capped job description length at 10,000 characters to prevent regex DoS vulnerabilities
- Returns 401 for missing/invalid auth and 413 for oversized payloads

## Testing
- Auth bypass attempts (no token): Returns 401 Unauthorized
- File > 1 MB: Returns 413 Payload Too Large with error message
- Job description > 10k chars: Returns 413 Payload Too Large with error message
- Valid authenticated request with appropriate inputs: Processes normally

Resolves #919

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume analysis API now requires bearer token authentication.
  * Implemented file size limits for resume uploads and character length limits for job descriptions.
  * Error responses provide clear messaging with specific limit thresholds when constraints are exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->