### PR TITLE
feat: add usage dashboard with visual analytics breakdown (fixes #847)

### DIFF
--- a/app/api/usage-dashboard/route.ts
+++ b/app/api/usage-dashboard/route.ts
@@ -1,0 +1,169 @@
+import { logger } from '@/lib/logger';
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+/**
+ * GET /api/usage-dashboard
+ * Returns aggregated usage data for the authenticated user:
+ *  - AI credit consumption (total, used, remaining)
+ *  - Credit usage over time (daily/weekly/monthly)
+ *  - Breakdown by document type
+ *  - Most used templates and AI models
+ *  - Recent generation history
+ */
+export async function GET(request: Request) {
+  try {
+    const authHeader = request.headers.get('Authorization');
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized - No token provided' }, { status: 401 });
+    }
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized - Invalid token' }, { status: 401 });
+    }
+
+    const url = new URL(request.url);
+    const range = url.searchParams.get('range') || '30d';
+
+    // Calculate date range
+    const now = new Date();
+    const daysBack = range === '7d' ? 7 : range === '90d' ? 90 : 30;
+    const since = new Date(now.getTime() - daysBack * 24 * 60 * 60 * 1000).toISOString();
+
+    // Run all queries in parallel for performance
+    const [creditsResult, documentsResult, creditLogResult] = await Promise.all([
+      // Credit info
+      supabase
+        .from('user_credits')
+        .select('tier, credits_used, credits_total, credits_reset_at, subscription_status')
+        .eq('user_id', user.id)
+        .single(),
+
+      // All user documents
+      supabase
+        .from('documents')
+        .select('id, title, type, created_at, template_id')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false }),
+
+      // Credit usage log within range
+      supabase
+        .from('credit_usage_log')
+        .select('credits_used, action_type, created_at, metadata')
+        .eq('user_id', user.id)
+        .gte('created_at', since)
+        .order('created_at', { ascending: true }),
+    ]);
+
+    const credits = creditsResult.data;
+    const documents = documentsResult.data || [];
+    const creditLog = creditLogResult.data || [];
+
+    // --- Credit summary ---
+    const creditsTotal = credits?.credits_total ?? 0;
+    const creditsUsed = credits?.credits_used ?? 0;
+    const creditsRemaining = creditsTotal - creditsUsed;
+
+    // --- Document breakdown by type ---
+    const docsByType: Record<string, number> = {};
+    for (const doc of documents) {
+      const type = doc.type || 'unknown';
+      docsByType[type] = (docsByType[type] || 0) + 1;
+    }
+    const documentTypeBreakdown = Object.entries(docsByType).map(([type, count]) => ({
+      type,
+      count,
+    }));
+
+    // --- Credit usage over time (grouped by day) ---
+    const usageByDay: Record<string, number> = {};
+    for (const entry of creditLog) {
+      const day = entry.created_at.slice(0, 10); // YYYY-MM-DD
+      usageByDay[day] = (usageByDay[day] || 0) + (entry.credits_used || 0);
+    }
+
+    // Fill in missing days with 0 for a continuous timeline
+    const creditUsageOverTime: { date: string; credits: number }[] = [];
+    for (let i = daysBack - 1; i >= 0; i--) {
+      const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+      const dayStr = d.toISOString().slice(0, 10);
+      creditUsageOverTime.push({ date: dayStr, credits: usageByDay[dayStr] || 0 });
+    }
+
+    // --- Most used AI models ---
+    const modelCounts: Record<string, number> = {};
+    for (const entry of creditLog) {
+      const model: string = (entry.metadata as { model?: string })?.model || 'gemini';
+      modelCounts[model] = (modelCounts[model] || 0) + 1;
+    }
+    const topModels = Object.entries(modelCounts)
+      .map(([model, count]) => ({ model, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    // --- Most used action types ---
+    const actionCounts: Record<string, number> = {};
+    for (const entry of creditLog) {
+      const action = entry.action_type || 'unknown';
+      actionCounts[action] = (actionCounts[action] || 0) + 1;
+    }
+    const topActions = Object.entries(actionCounts)
+      .map(([action, count]) => ({ action, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    // --- Recent generation history (last 20 documents) ---
+    const generationHistory = documents.slice(0, 20).map((doc) => ({
+      id: doc.id,
+      title: doc.title,
+      type: doc.type,
+      created_at: doc.created_at,
+      template_id: doc.template_id,
+    }));
+
+    // --- Most used templates ---
+    const templateCounts: Record<string, number> = {};
+    for (const doc of documents) {
+      if (doc.template_id) {
+        templateCounts[doc.template_id] = (templateCounts[doc.template_id] || 0) + 1;
+      }
+    }
+    const topTemplates = Object.entries(templateCounts)
+      .map(([templateId, count]) => ({ templateId, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    return NextResponse.json({
+      credits: {
+        tier: credits?.tier || 'free',
+        total: creditsTotal,
+        used: creditsUsed,
+        remaining: creditsRemaining,
+        resetAt: credits?.credits_reset_at,
+        subscriptionStatus: credits?.subscription_status || 'active',
+      },
+      totalDocuments: documents.length,
+      documentTypeBreakdown,
+      creditUsageOverTime,
+      topModels,
+      topActions,
+      generationHistory,
+      topTemplates,
+      range,
+    });
+  } catch (error: unknown) {
+    logger.error({ route: 'app/api/usage-dashboard/route.ts' }, 'Usage dashboard API error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/usage-dashboard/route.ts
+++ b/app/api/usage-dashboard/route.ts
@@ -33,28 +33,32 @@ export async function GET(request: Request) {
     const url = new URL(request.url);
     const range = url.searchParams.get('range') || '30d';
 
-    // Calculate date range
-    const now = new Date();
     const daysBack = range === '7d' ? 7 : range === '90d' ? 90 : 30;
-    const since = new Date(now.getTime() - daysBack * 24 * 60 * 60 * 1000).toISOString();
+
+    // FIX 1: Align query window to UTC calendar-day boundaries so the fetched
+    // rows exactly match the daily buckets rendered in the chart.
+    // We want `daysBack` complete UTC days, starting at midnight UTC today-daysBack.
+    const nowUtc = new Date();
+    const todayUtc = new Date(
+      Date.UTC(nowUtc.getUTCFullYear(), nowUtc.getUTCMonth(), nowUtc.getUTCDate())
+    );
+    const sinceUtc = new Date(todayUtc.getTime() - (daysBack - 1) * 24 * 60 * 60 * 1000);
+    const since = sinceUtc.toISOString(); // midnight UTC on the first bucket day
 
     // Run all queries in parallel for performance
     const [creditsResult, documentsResult, creditLogResult] = await Promise.all([
-      // Credit info
       supabase
         .from('user_credits')
         .select('tier, credits_used, credits_total, credits_reset_at, subscription_status')
         .eq('user_id', user.id)
         .single(),
 
-      // All user documents
       supabase
         .from('documents')
         .select('id, title, type, created_at, template_id')
         .eq('user_id', user.id)
         .order('created_at', { ascending: false }),
 
-      // Credit usage log within range
       supabase
         .from('credit_usage_log')
         .select('credits_used, action_type, created_at, metadata')
@@ -63,9 +67,28 @@ export async function GET(request: Request) {
         .order('created_at', { ascending: true }),
     ]);
 
+    // FIX 2: Surface Supabase query errors instead of silently falling back to
+    // empty arrays, which would misreport backend failures as "no usage".
+    if (documentsResult.error) {
+      logger.error(
+        { route: 'app/api/usage-dashboard/route.ts' },
+        'Failed to fetch documents:',
+        documentsResult.error
+      );
+      return NextResponse.json({ error: 'Failed to load documents' }, { status: 500 });
+    }
+    if (creditLogResult.error) {
+      logger.error(
+        { route: 'app/api/usage-dashboard/route.ts' },
+        'Failed to fetch credit log:',
+        creditLogResult.error
+      );
+      return NextResponse.json({ error: 'Failed to load credit history' }, { status: 500 });
+    }
+
     const credits = creditsResult.data;
-    const documents = documentsResult.data || [];
-    const creditLog = creditLogResult.data || [];
+    const documents = documentsResult.data ?? [];
+    const creditLog = creditLogResult.data ?? [];
 
     // --- Credit summary ---
     const creditsTotal = credits?.credits_total ?? 0;
@@ -83,25 +106,29 @@ export async function GET(request: Request) {
       count,
     }));
 
-    // --- Credit usage over time (grouped by day) ---
+    // --- Credit usage over time (grouped by UTC day) ---
     const usageByDay: Record<string, number> = {};
     for (const entry of creditLog) {
-      const day = entry.created_at.slice(0, 10); // YYYY-MM-DD
+      // created_at from Supabase is an ISO string; slice to UTC date
+      const day = entry.created_at.slice(0, 10); // YYYY-MM-DD (UTC)
       usageByDay[day] = (usageByDay[day] || 0) + (entry.credits_used || 0);
     }
 
-    // Fill in missing days with 0 for a continuous timeline
+    // Fill in missing UTC calendar days with 0 for a continuous timeline.
+    // Iterate from todayUtc backwards to sinceUtc to match the query window exactly.
     const creditUsageOverTime: { date: string; credits: number }[] = [];
-    for (let i = daysBack - 1; i >= 0; i--) {
-      const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
-      const dayStr = d.toISOString().slice(0, 10);
+    for (let i = 0; i < daysBack; i++) {
+      const d = new Date(sinceUtc.getTime() + i * 24 * 60 * 60 * 1000);
+      const dayStr = d.toISOString().slice(0, 10); // YYYY-MM-DD UTC
       creditUsageOverTime.push({ date: dayStr, credits: usageByDay[dayStr] || 0 });
     }
 
     // --- Most used AI models ---
     const modelCounts: Record<string, number> = {};
     for (const entry of creditLog) {
-      const model: string = (entry.metadata as { model?: string })?.model || 'gemini';
+      // FIX 3: Don't attribute missing model metadata to 'gemini'; use 'unknown'
+      // to avoid inflating any specific model's count.
+      const model: string = (entry.metadata as { model?: string } | null)?.model || 'unknown';
       modelCounts[model] = (modelCounts[model] || 0) + 1;
     }
     const topModels = Object.entries(modelCounts)
@@ -110,10 +137,15 @@ export async function GET(request: Request) {
       .slice(0, 5);
 
     // --- Most used action types ---
+    // FIX 5: Track the true total before slicing so the UI can display an
+    // accurate "AI Generations" count regardless of how many distinct action
+    // types exist.
     const actionCounts: Record<string, number> = {};
+    let totalGenerations = 0;
     for (const entry of creditLog) {
       const action = entry.action_type || 'unknown';
       actionCounts[action] = (actionCounts[action] || 0) + 1;
+      totalGenerations += 1;
     }
     const topActions = Object.entries(actionCounts)
       .map(([action, count]) => ({ action, count }))
@@ -151,6 +183,7 @@ export async function GET(request: Request) {
         subscriptionStatus: credits?.subscription_status || 'active',
       },
       totalDocuments: documents.length,
+      totalGenerations,
       documentTypeBreakdown,
       creditUsageOverTime,
       topModels,
@@ -160,9 +193,11 @@ export async function GET(request: Request) {
       range,
     });
   } catch (error: unknown) {
+    // FIX 4: Log the real error server-side but return a generic message to
+    // the client to avoid leaking internal implementation details.
     logger.error({ route: 'app/api/usage-dashboard/route.ts' }, 'Usage dashboard API error:', error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { error: 'An unexpected error occurred. Please try again later.' },
       { status: 500 }
     );
   }

--- a/app/dashboard/usage/page.tsx
+++ b/app/dashboard/usage/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from 'next';
+import UsageDashboard from '@/components/dashboard/usage-dashboard';
+
+export const metadata: Metadata = {
+  title: 'Usage Dashboard | DraftDeckAI',
+  description:
+    'Track your AI credit consumption, documents created, templates used, and generation history with visual analytics.',
+};
+
+/**
+ * /dashboard/usage – Visual analytics dashboard for usage tracking.
+ * Implements Issue #847: Add usage dashboard with visual analytics breakdown.
+ */
+export default function UsageDashboardPage() {
+  return <UsageDashboard />;
+}

--- a/components/dashboard/usage-dashboard.tsx
+++ b/components/dashboard/usage-dashboard.tsx
@@ -49,6 +49,9 @@ interface CreditInfo {
 interface UsageData {
   credits: CreditInfo;
   totalDocuments: number;
+  // FIX 5 (component): totalGenerations is supplied by the API and reflects ALL
+  // action types, not just the top-5 slice exposed in topActions.
+  totalGenerations: number;
   documentTypeBreakdown: { type: string; count: number }[];
   creditUsageOverTime: { date: string; credits: number }[];
   topModels: { model: string; count: number }[];
@@ -180,6 +183,14 @@ function CreditMeter({ credits }: { credits: CreditInfo }) {
   );
 }
 
+// ─── Supabase client ──────────────────────────────────────────────────────────
+// FIX 1 (component): Create the client once at module scope so it is a stable
+// reference. Calling createClient() inside the component body produced a new
+// object on every render, making `supabase` appear in the useCallback deps
+// array and causing fetchData — and therefore the useEffect — to re-run on
+// every render, creating an infinite refetch loop.
+const supabaseClient = createClient();
+
 // ─── Main Component ───────────────────────────────────────────────────────────
 
 export default function UsageDashboard() {
@@ -188,7 +199,6 @@ export default function UsageDashboard() {
   const [range, setRange] = useState("30d");
   const [isExporting, setIsExporting] = useState(false);
   const router = useRouter();
-  const supabase = createClient();
 
   const fetchData = useCallback(
     async (selectedRange: string) => {
@@ -196,7 +206,7 @@ export default function UsageDashboard() {
       try {
         const {
           data: { session },
-        } = await supabase.auth.getSession();
+        } = await supabaseClient.auth.getSession();
         if (!session) {
           router.push("/auth/signin");
           return;
@@ -215,7 +225,7 @@ export default function UsageDashboard() {
         setIsLoading(false);
       }
     },
-    [router, supabase]
+    [router]
   );
 
   useEffect(() => {
@@ -282,10 +292,14 @@ export default function UsageDashboard() {
       ? Math.round((data.credits.used / data.credits.total) * 100)
       : 0;
 
-  // Format date labels for chart
+  // FIX 3 (component): Parse YYYY-MM-DD strings in UTC so that toLocaleDateString
+  // does not shift the displayed day for users in negative UTC-offset timezones.
+  // The API derives all dates via toISOString().slice(0,10) (UTC), so we must
+  // interpret them as UTC midnight to keep chart labels consistent.
   const formatDate = (dateStr: string) => {
-    const d = new Date(dateStr);
-    return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    const [year, month, day] = dateStr.split("-").map(Number);
+    const d = new Date(Date.UTC(year, month - 1, day));
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
   };
 
   return (
@@ -399,10 +413,14 @@ export default function UsageDashboard() {
                   gradient="from-violet-500/20 to-purple-500/20"
                   delay={0.2}
                 />
+                {/* FIX 2 (component): Use server-supplied totalGenerations which
+                     counts ALL action_type rows, not just the top-5 slice that
+                     topActions exposes. Summing topActions undercounted when
+                     there were more than 5 distinct action types. */}
                 <StatCard
                   icon={Zap}
                   label="AI Generations"
-                  value={data.topActions.reduce((s, a) => s + a.count, 0).toLocaleString()}
+                  value={data.totalGenerations.toLocaleString()}
                   sub={`Last ${range}`}
                   gradient="from-amber-500/20 to-orange-500/20"
                   delay={0.3}

--- a/components/dashboard/usage-dashboard.tsx
+++ b/components/dashboard/usage-dashboard.tsx
@@ -1,0 +1,721 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { SiteHeader } from "@/components/site-header";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import {
+  Loader2,
+  Zap,
+  FileText,
+  TrendingUp,
+  Download,
+  Sparkles,
+  Activity,
+  BarChart3,
+  PieChart as PieChartIcon,
+  Clock,
+  RefreshCw,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface CreditInfo {
+  tier: string;
+  total: number;
+  used: number;
+  remaining: number;
+  resetAt: string | null;
+  subscriptionStatus: string;
+}
+
+interface UsageData {
+  credits: CreditInfo;
+  totalDocuments: number;
+  documentTypeBreakdown: { type: string; count: number }[];
+  creditUsageOverTime: { date: string; credits: number }[];
+  topModels: { model: string; count: number }[];
+  topActions: { action: string; count: number }[];
+  generationHistory: {
+    id: string;
+    title: string;
+    type: string;
+    created_at: string;
+    template_id: string | null;
+  }[];
+  topTemplates: { templateId: string; count: number }[];
+  range: string;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TYPE_COLORS: Record<string, string> = {
+  resume: "#6366f1",
+  presentation: "#8b5cf6",
+  letter: "#10b981",
+  diagram: "#f59e0b",
+  cv: "#3b82f6",
+  unknown: "#6b7280",
+};
+
+const CHART_COLORS = ["#6366f1", "#8b5cf6", "#10b981", "#f59e0b", "#3b82f6", "#ef4444"];
+
+const RANGE_OPTIONS = [
+  { label: "7 Days", value: "7d" },
+  { label: "30 Days", value: "30d" },
+  { label: "90 Days", value: "90d" },
+];
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  gradient,
+  delay = 0,
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: string | number;
+  sub?: string;
+  gradient: string;
+  delay?: number;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay, duration: 0.4, ease: "easeOut" }}
+      className="relative group overflow-hidden rounded-2xl border border-white/10 bg-white/5 backdrop-blur-sm p-6 hover:border-white/20 hover:bg-white/8 transition-all duration-300"
+    >
+      <div
+        className={`absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 ${gradient}`}
+      />
+      <div className="relative z-10 flex items-start justify-between">
+        <div>
+          <p className="text-sm text-muted-foreground font-medium mb-1">{label}</p>
+          <p className="text-3xl font-extrabold tracking-tight">{value}</p>
+          {sub && <p className="text-xs text-muted-foreground mt-1">{sub}</p>}
+        </div>
+        <div className={`p-3 rounded-xl bg-gradient-to-br ${gradient} opacity-80`}>
+          <Icon className="h-6 w-6 text-white" />
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function CreditMeter({ credits }: { credits: CreditInfo }) {
+  const pct = credits.total > 0 ? Math.min(100, (credits.used / credits.total) * 100) : 0;
+  const color =
+    pct > 85 ? "#ef4444" : pct > 60 ? "#f59e0b" : "#10b981";
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.15, duration: 0.4 }}
+      className="rounded-2xl border border-white/10 bg-white/5 backdrop-blur-sm p-6 col-span-full lg:col-span-2"
+    >
+      <div className="flex items-center gap-3 mb-4">
+        <div className="p-2 rounded-xl bg-primary/10">
+          <Zap className="h-5 w-5 text-primary" />
+        </div>
+        <div>
+          <h3 className="font-bold text-lg">AI Credit Usage</h3>
+          <p className="text-xs text-muted-foreground capitalize">
+            {credits.tier} plan · {credits.subscriptionStatus}
+          </p>
+        </div>
+        <div className="ml-auto text-right">
+          <p className="text-2xl font-extrabold" style={{ color }}>
+            {credits.remaining.toLocaleString()}
+          </p>
+          <p className="text-xs text-muted-foreground">remaining</p>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-4 rounded-full bg-white/10 overflow-hidden mb-3">
+        <motion.div
+          initial={{ width: 0 }}
+          animate={{ width: `${pct}%` }}
+          transition={{ duration: 1, ease: "easeOut", delay: 0.4 }}
+          className="h-full rounded-full transition-colors"
+          style={{ background: `linear-gradient(90deg, ${color}99, ${color})` }}
+        />
+      </div>
+
+      <div className="flex justify-between text-xs text-muted-foreground">
+        <span>{credits.used.toLocaleString()} used</span>
+        <span>{credits.total.toLocaleString()} total</span>
+      </div>
+
+      {credits.resetAt && (
+        <p className="text-xs text-muted-foreground mt-3 flex items-center gap-1">
+          <Clock className="h-3 w-3" />
+          Resets on {new Date(credits.resetAt).toLocaleDateString()}
+        </p>
+      )}
+    </motion.div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export default function UsageDashboard() {
+  const [data, setData] = useState<UsageData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [range, setRange] = useState("30d");
+  const [isExporting, setIsExporting] = useState(false);
+  const router = useRouter();
+  const supabase = createClient();
+
+  const fetchData = useCallback(
+    async (selectedRange: string) => {
+      setIsLoading(true);
+      try {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+        if (!session) {
+          router.push("/auth/signin");
+          return;
+        }
+
+        const res = await fetch(`/api/usage-dashboard?range=${selectedRange}`, {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+
+        if (!res.ok) throw new Error("Failed to fetch usage data");
+        const json = await res.json();
+        setData(json);
+      } catch (err) {
+        console.error("Usage dashboard error:", err);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [router, supabase]
+  );
+
+  useEffect(() => {
+    fetchData(range);
+  }, [range, fetchData]);
+
+  // ── CSV Export ──────────────────────────────────────────────────────────────
+  const exportCSV = () => {
+    if (!data) return;
+    setIsExporting(true);
+
+    const rows: string[][] = [
+      ["Date", "Credits Used"],
+      ...data.creditUsageOverTime.map((r) => [r.date, String(r.credits)]),
+      [],
+      ["Document Type", "Count"],
+      ...data.documentTypeBreakdown.map((r) => [r.type, String(r.count)]),
+      [],
+      ["AI Model", "Uses"],
+      ...data.topModels.map((r) => [r.model, String(r.count)]),
+      [],
+      ["Action Type", "Count"],
+      ...data.topActions.map((r) => [r.action, String(r.count)]),
+    ];
+
+    const csv = rows.map((r) => r.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `draftdeckai-usage-${range}-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+    setIsExporting(false);
+  };
+
+  // ── Loading State ───────────────────────────────────────────────────────────
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex flex-col bg-background relative overflow-hidden">
+        <div className="absolute inset-0 mesh-gradient opacity-20" />
+        <SiteHeader />
+        <div className="flex-1 flex items-center justify-center relative z-10">
+          <div className="text-center glass-effect p-12 rounded-3xl border border-white/10">
+            <div className="relative mx-auto mb-6 w-20 h-20">
+              <div className="absolute inset-0 rounded-full bg-primary/20 animate-ping" />
+              <div className="relative flex items-center justify-center w-20 h-20 rounded-full bg-primary/10">
+                <BarChart3 className="h-10 w-10 text-primary" />
+              </div>
+            </div>
+            <h2 className="text-xl font-bold mb-2">Loading Usage Dashboard</h2>
+            <p className="text-muted-foreground flex items-center gap-2 justify-center">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Aggregating your data…
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const creditPct =
+    data && data.credits.total > 0
+      ? Math.round((data.credits.used / data.credits.total) * 100)
+      : 0;
+
+  // Format date labels for chart
+  const formatDate = (dateStr: string) => {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background relative overflow-hidden">
+      {/* Background */}
+      <div className="absolute inset-0 mesh-gradient opacity-20" />
+      <div className="floating-orb w-[500px] h-[500px] bolt-gradient opacity-[0.07] top-[-100px] left-[-100px] blur-[120px]" />
+      <div className="floating-orb w-[400px] h-[400px] bolt-gradient opacity-[0.05] bottom-[-50px] right-[-50px] blur-[100px]" />
+
+      <SiteHeader />
+
+      <main className="flex-1 p-4 md:p-10 relative z-10 max-w-7xl mx-auto w-full">
+        {/* ── Header ── */}
+        <div className="mb-10">
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-full glass-effect border border-white/10 mb-6 shimmer"
+          >
+            <Sparkles className="h-4 w-4 text-yellow-500" />
+            <span className="text-sm font-bold tracking-tight">Usage Intelligence</span>
+            <Activity className="h-4 w-4 text-primary" />
+          </motion.div>
+
+          <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-6">
+            <div>
+              <h1 className="text-5xl font-extrabold bolt-gradient-text mb-3 tracking-tighter">
+                Usage Dashboard
+              </h1>
+              <p className="text-lg text-muted-foreground max-w-2xl leading-relaxed">
+                Track your AI credit consumption, document generation activity, template usage, and
+                export detailed reports.
+              </p>
+            </div>
+
+            <div className="flex items-center gap-3 flex-wrap">
+              {/* Range selector */}
+              <div className="flex items-center gap-1 glass-effect border border-white/10 rounded-xl p-1">
+                {RANGE_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    id={`range-${opt.value}`}
+                    onClick={() => setRange(opt.value)}
+                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
+                      range === opt.value
+                        ? "bg-primary text-primary-foreground shadow-md"
+                        : "text-muted-foreground hover:text-foreground hover:bg-white/5"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Refresh */}
+              <Button
+                id="refresh-usage"
+                variant="outline"
+                size="sm"
+                onClick={() => fetchData(range)}
+                className="glass-effect border-white/10 h-10"
+              >
+                <RefreshCw className="h-4 w-4" />
+              </Button>
+
+              {/* Export CSV */}
+              <Button
+                id="export-usage-csv"
+                onClick={exportCSV}
+                disabled={!data || isExporting}
+                className="bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white font-semibold h-10 px-5"
+              >
+                {isExporting ? (
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                ) : (
+                  <Download className="h-4 w-4 mr-2" />
+                )}
+                Export CSV
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <AnimatePresence mode="wait">
+          {data && (
+            <motion.div
+              key={range}
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -16 }}
+              transition={{ duration: 0.35 }}
+              className="space-y-8"
+            >
+              {/* ── Stat Cards ── */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <CreditMeter credits={data.credits} />
+
+                <StatCard
+                  icon={FileText}
+                  label="Total Documents"
+                  value={data.totalDocuments.toLocaleString()}
+                  sub="All-time generated"
+                  gradient="from-blue-500/20 to-cyan-500/20"
+                  delay={0.1}
+                />
+                <StatCard
+                  icon={TrendingUp}
+                  label="Credits Used"
+                  value={data.credits.used.toLocaleString()}
+                  sub={`${creditPct}% of quota`}
+                  gradient="from-violet-500/20 to-purple-500/20"
+                  delay={0.2}
+                />
+                <StatCard
+                  icon={Zap}
+                  label="AI Generations"
+                  value={data.topActions.reduce((s, a) => s + a.count, 0).toLocaleString()}
+                  sub={`Last ${range}`}
+                  gradient="from-amber-500/20 to-orange-500/20"
+                  delay={0.3}
+                />
+              </div>
+
+              {/* ── Credit Usage Over Time ── */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.2 }}
+                className="rounded-2xl border border-white/10 bg-white/5 backdrop-blur-sm p-6"
+              >
+                <div className="flex items-center gap-3 mb-6">
+                  <div className="p-2 rounded-xl bg-primary/10">
+                    <TrendingUp className="h-5 w-5 text-primary" />
+                  </div>
+                  <h2 className="text-xl font-bold">Credit Usage Over Time</h2>
+                  <span className="ml-auto text-xs text-muted-foreground uppercase tracking-wider">
+                    Daily · {range}
+                  </span>
+                </div>
+                <ResponsiveContainer width="100%" height={280}>
+                  <AreaChart data={data.creditUsageOverTime}>
+                    <defs>
+                      <linearGradient id="creditGradient" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#6366f1" stopOpacity={0.4} />
+                        <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+                    <XAxis
+                      dataKey="date"
+                      tickFormatter={formatDate}
+                      tick={{ fill: "rgba(255,255,255,0.4)", fontSize: 11 }}
+                      axisLine={false}
+                      tickLine={false}
+                      interval={Math.floor(data.creditUsageOverTime.length / 6)}
+                    />
+                    <YAxis
+                      tick={{ fill: "rgba(255,255,255,0.4)", fontSize: 11 }}
+                      axisLine={false}
+                      tickLine={false}
+                      width={40}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        background: "rgba(10,10,20,0.9)",
+                        border: "1px solid rgba(255,255,255,0.1)",
+                        borderRadius: "12px",
+                        color: "#fff",
+                      }}
+                      labelFormatter={(l) => formatDate(l as string)}
+                      formatter={(v: number) => [`${v} credits`, "Used"]}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="credits"
+                      stroke="#6366f1"
+                      strokeWidth={2.5}
+                      fill="url(#creditGradient)"
+                      dot={false}
+                      activeDot={{ r: 5, fill: "#6366f1" }}
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </motion.div>
+
+              {/* ── Two-column: Doc Type + AI Models ── */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                {/* Document Type Breakdown */}
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.3 }}
+                  className="rounded-2xl border border-white/10 bg-white/5 backdrop-blur-sm p-6"
+                >
+                  <div className="flex items-center gap-3 mb-6">
+                    <div className="p-2 rounded-xl bg-emerald-500/10">
+                      <PieChartIcon className="h-5 w-5 text-emerald-400" />
+                    </div>
+                    <h2 className="text-xl font-bold">Document Type Breakdown</h2>
+                  </div>
+                  {data.documentTypeBreakdown.length > 0 ? (
+                    <div className="flex flex-col sm:flex-row items-center gap-6">
+                      <ResponsiveContainer width={200} height={200}>
+                        <PieChart>
+                          <Pie
+                            data={data.documentTypeBreakdown}
+                            cx="50%"
+                            cy="50%"
+                            innerRadius={55}
+                            outerRadius={85}
+                            dataKey="count"
+                            nameKey="type"
+                            paddingAngle={3}
+                          >
+                            {data.documentTypeBreakdown.map((entry, index) => (
+                              <Cell
+                                key={entry.type}
+                                fill={TYPE_COLORS[entry.type] || CHART_COLORS[index % CHART_COLORS.length]}
+                              />
+                            ))}
+                          </Pie>
+                          <Tooltip
+                            contentStyle={{
+                              background: "rgba(10,10,20,0.9)",
+                              border: "1px solid rgba(255,255,255,0.1)",
+                              borderRadius: "12px",
+                              color: "#fff",
+                            }}
+                          />
+                        </PieChart>
+                      </ResponsiveContainer>
+                      <div className="flex-1 space-y-2">
+                        {data.documentTypeBreakdown.map((entry, i) => (
+                          <div key={entry.type} className="flex items-center justify-between gap-3">
+                            <div className="flex items-center gap-2">
+                              <div
+                                className="w-3 h-3 rounded-full"
+                                style={{
+                                  background:
+                                    TYPE_COLORS[entry.type] || CHART_COLORS[i % CHART_COLORS.length],
+                                }}
+                              />
+                              <span className="text-sm capitalize font-medium">{entry.type}</span>
+                            </div>
+                            <span className="text-sm text-muted-foreground font-bold">
+                              {entry.count}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : (
+                    <EmptyState label="No documents yet" />
+                  )}
+                </motion.div>
+
+                {/* Most Used AI Models */}
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.35 }}
+                  className="rounded-2xl border border-white/10 bg-white/5 backdrop-blur-sm p-6"
+                >
+                  <div className="flex items-center gap-3 mb-6">
+                    <div className="p-2 rounded-xl bg-violet-500/10">
+                      <Sparkles className="h-5 w-5 text-violet-400" />
+                    </div>
+                    <h2 className="text-xl font-bold">Most Used AI Models</h2>
+                  </div>
+                  {data.topModels.length > 0 ? (
+                    <ResponsiveContainer width="100%" height={200}>
+                      <BarChart data={data.topModels} layout="vertical">
+                        <CartesianGrid
+                          strokeDasharray="3 3"
+                          stroke="rgba(255,255,255,0.05)"
+                          horizontal={false}
+                        />
+                        <XAxis
+                          type="number"
+                          tick={{ fill: "rgba(255,255,255,0.4)", fontSize: 11 }}
+                          axisLine={false}
+                          tickLine={false}
+                        />
+                        <YAxis
+                          type="category"
+                          dataKey="model"
+                          tick={{ fill: "rgba(255,255,255,0.6)", fontSize: 12 }}
+                          axisLine={false}
+                          tickLine={false}
+                          width={80}
+                        />
+                        <Tooltip
+                          contentStyle={{
+                            background: "rgba(10,10,20,0.9)",
+                            border: "1px solid rgba(255,255,255,0.1)",
+                            borderRadius: "12px",
+                            color: "#fff",
+                          }}
+                          formatter={(v: number) => [v, "Uses"]}
+                        />
+                        <Bar dataKey="count" radius={[0, 8, 8, 0]}>
+                          {data.topModels.map((_, index) => (
+                            <Cell key={index} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                          ))}
+                        </Bar>
+                      </BarChart>
+                    </ResponsiveContainer>
+                  ) : (
+                    <EmptyState label="No model data yet" />
+                  )}
+                </motion.div>
+              </div>
+
+              {/* ── Most Used Action Types ── */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.4 }}
+                className="rounded-2xl border border-white/10 bg-white/5 backdrop-blur-sm p-6"
+              >
+                <div className="flex items-center gap-3 mb-6">
+                  <div className="p-2 rounded-xl bg-amber-500/10">
+                    <BarChart3 className="h-5 w-5 text-amber-400" />
+                  </div>
+                  <h2 className="text-xl font-bold">Top Generation Actions</h2>
+                </div>
+                {data.topActions.length > 0 ? (
+                  <ResponsiveContainer width="100%" height={220}>
+                    <BarChart data={data.topActions}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+                      <XAxis
+                        dataKey="action"
+                        tick={{ fill: "rgba(255,255,255,0.5)", fontSize: 11 }}
+                        axisLine={false}
+                        tickLine={false}
+                      />
+                      <YAxis
+                        tick={{ fill: "rgba(255,255,255,0.4)", fontSize: 11 }}
+                        axisLine={false}
+                        tickLine={false}
+                        width={36}
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          background: "rgba(10,10,20,0.9)",
+                          border: "1px solid rgba(255,255,255,0.1)",
+                          borderRadius: "12px",
+                          color: "#fff",
+                        }}
+                        formatter={(v: number) => [v, "Times Used"]}
+                      />
+                      <Bar dataKey="count" radius={[8, 8, 0, 0]}>
+                        {data.topActions.map((_, index) => (
+                          <Cell key={index} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <EmptyState label="No generation activity in this period" />
+                )}
+              </motion.div>
+
+              {/* ── Recent Generation History ── */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.45 }}
+                className="rounded-2xl border border-white/10 bg-white/5 backdrop-blur-sm p-6"
+              >
+                <div className="flex items-center gap-3 mb-6">
+                  <div className="p-2 rounded-xl bg-blue-500/10">
+                    <Clock className="h-5 w-5 text-blue-400" />
+                  </div>
+                  <h2 className="text-xl font-bold">Recent Generation History</h2>
+                  <span className="ml-auto text-xs text-muted-foreground">Last 20 documents</span>
+                </div>
+
+                {data.generationHistory.length > 0 ? (
+                  <div className="space-y-2">
+                    {data.generationHistory.map((doc, i) => (
+                      <motion.div
+                        key={doc.id}
+                        initial={{ opacity: 0, x: -12 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        transition={{ delay: 0.05 * i }}
+                        className="flex items-center gap-4 p-4 rounded-xl border border-white/5 bg-white/3 hover:border-white/10 hover:bg-white/5 transition-all group"
+                      >
+                        <div
+                          className="w-2 h-8 rounded-full flex-shrink-0"
+                          style={{
+                            background:
+                              TYPE_COLORS[doc.type] || CHART_COLORS[i % CHART_COLORS.length],
+                          }}
+                        />
+                        <div className="flex-1 min-w-0">
+                          <p className="font-semibold truncate text-sm">{doc.title || "Untitled"}</p>
+                          <p className="text-xs text-muted-foreground capitalize">{doc.type}</p>
+                        </div>
+                        <p className="text-xs text-muted-foreground flex-shrink-0">
+                          {new Date(doc.created_at).toLocaleDateString("en-US", {
+                            month: "short",
+                            day: "numeric",
+                            year: "numeric",
+                          })}
+                        </p>
+                      </motion.div>
+                    ))}
+                  </div>
+                ) : (
+                  <EmptyState label="No documents generated yet" />
+                )}
+              </motion.div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </main>
+    </div>
+  );
+}
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function EmptyState({ label }: { label: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <div className="p-4 rounded-2xl bg-white/5 mb-4">
+        <BarChart3 className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <p className="text-muted-foreground text-sm">{label}</p>
+    </div>
+  );
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -28,6 +28,7 @@ import {
   MoreHorizontal,
   Trophy,
   Download,
+  BarChart3,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -583,6 +584,12 @@ const navItems = [
     label: "History",
     icon: <History className="h-4 w-4" />,
     tooltip: "View all your created documents with previews",
+  },
+  {
+    href: "/dashboard/usage",
+    label: "Usage",
+    icon: <BarChart3 className="h-4 w-4" />,
+    tooltip: "View AI credit usage, document analytics and generation history",
   },
   {
     href: "/dashboard/export",


### PR DESCRIPTION
Closes #847

## Summary
Implements the full usage analytics dashboard at /dashboard/usage.

## Features
- Credit usage over time chart (7d / 30d / 90d)
- Document type breakdown (Pie chart)
- Most used AI models (Bar chart)
- Top generation actions (Bar chart)
- Credit meter with progress bar
- Recent generation history
- Export usage report as CSV

##progrm-GSSoC 2026


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Usage Dashboard with visual analytics: daily credit trends, document-type breakdown, top models/actions, recent generation history, and top templates.
  * Export dashboard data to CSV; selectable date ranges shown in the UI.
  * New "Usage" link in the site header.

* **Bug Fixes**
  * Charts and timelines now use UTC-aligned dates to prevent timezone shifts; loading and empty states handled gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->