### PR TITLE
refactor: move rate limit thresholds to config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,9 +102,9 @@ SUPABASE_POOLER_URL=
 # RATE LIMIT CONFIGURATION
 # Maximum requests per IP for each middleware bucket. Defaults are used when
 # these values are unset or invalid.
+RATE_LIMIT_API_MAX=100
 RATE_LIMIT_AUTH_MAX=10
 RATE_LIMIT_GENERATE_MAX=20
-RATE_LIMIT_API_MAX=100
 
 # Cron Authentication
 CRON_SECRET=your_secure_random_string_here

--- a/.env.example
+++ b/.env.example
@@ -99,5 +99,12 @@ DRAFTDECK_RUNTIME_ENV=development
 DEVELOPER_BYPASS_EMAILS=
 SUPABASE_POOLER_URL=
 
+# RATE LIMIT CONFIGURATION
+# Maximum requests per IP for each middleware bucket. Defaults are used when
+# these values are unset or invalid.
+RATE_LIMIT_AUTH_MAX=10
+RATE_LIMIT_GENERATE_MAX=20
+RATE_LIMIT_API_MAX=100
+
 # Cron Authentication
 CRON_SECRET=your_secure_random_string_here

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -8,6 +8,31 @@ const isProduction = process.env.NODE_ENV === "production";
 const isVercel = process.env.VERCEL === "1";
 const isNetlify = process.env.NETLIFY === "true";
 
+function getPositiveIntegerEnv(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+
+  if (Number.isSafeInteger(value) && value > 0) {
+    return value;
+  }
+
+  return fallback;
+}
+
+export const RATE_LIMIT_CONFIG = {
+  AUTH: {
+    windowMs: 15 * 60 * 1000,
+    max: getPositiveIntegerEnv("RATE_LIMIT_AUTH_MAX", 10),
+  },
+  GENERATE: {
+    windowMs: 5 * 60 * 1000,
+    max: getPositiveIntegerEnv("RATE_LIMIT_GENERATE_MAX", 20),
+  },
+  API: {
+    windowMs: 60 * 1000,
+    max: getPositiveIntegerEnv("RATE_LIMIT_API_MAX", 100),
+  },
+} as const;
+
 // Stripe Configuration
 export const STRIPE_CONFIG = {
   // Enable Stripe integration (set to true in production when ready)

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { RATE_LIMIT_CONFIG } from "@/lib/config";
 import { CSP_HEADER, buildCspWithNonce } from "@/lib/csp";
 import { REQUEST_ID_HEADER, createRequestId, logger } from "@/lib/logger";
 import { applySecurityHeaders, buildCorsHeaders } from "@/lib/security-headers";
@@ -32,11 +33,7 @@ function logError(
   );
 }
 
-const RL = {
-  AUTH: { windowMs: 15 * 60 * 1000, max: 10 },
-  GENERATE: { windowMs: 5 * 60 * 1000, max: 20 },
-  API: { windowMs: 60 * 1000, max: 100 },
-} as const;
+const RL = RATE_LIMIT_CONFIG;
 
 type RLKey = keyof typeof RL;
 


### PR DESCRIPTION
## Summary
- move middleware rate-limit max thresholds into `RATE_LIMIT_CONFIG`
- read `RATE_LIMIT_AUTH_MAX`, `RATE_LIMIT_GENERATE_MAX`, and `RATE_LIMIT_API_MAX` with safe defaults
- document the new variables in `.env.example`

Closes #867

## Verification
- `git diff --check`
- reviewed the scoped diff for `middleware.ts`, `lib/config.ts`, and `.env.example`

## Note
- This checkout does not have dependencies installed, and the machine is currently low on disk space from earlier validation attempts, so I did not run `npm run lint` or `npm run build` locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate limiting is now configurable via environment variables with separate limits for authentication, generation, and API requests; the runtime now reads a shared rate-limit configuration.
* **Documentation**
  * Example environment file updated to document the new rate-limit settings and default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->