### PR TITLE
refactor: replace ts-ignore directives with types

### DIFF
--- a/app/api/generate/slide-image/route.ts
+++ b/app/api/generate/slide-image/route.ts
@@ -10,6 +10,7 @@ import {
   safeParseBody,
   slideImageGenerationSchema,
 } from "@/lib/validation";
+import type { NebiusImageGenerationRequest } from "@/types/nebius";
 
 const NEBIUS_API_KEY = process.env.NEBIUS_API_KEY;
 const NEBIUS_BASE_URL = "https://api.tokenfactory.nebius.com/v1/";
@@ -205,17 +206,17 @@ export async function POST(request: NextRequest) {
     const imageResults = await Promise.all(
       prompts.map(async (prompt, index) => {
         try {
-          const response = await client.images.generate({
+          const imageRequest: NebiusImageGenerationRequest = {
             model: "black-forest-labs/flux-dev",
             prompt: prompt,
             response_format: "url",
-
-            // @ts-ignore - Nebius-specific parameters
             width: width,
             height: height,
             num_inference_steps: 28,
             n: 1,
-          });
+          };
+
+          const response = await client.images.generate(imageRequest);
 
           if (!response.data?.[0]?.url) {
             throw new Error("Invalid response from FLUX API");

--- a/components/presentation/ai-image-generator.tsx
+++ b/components/presentation/ai-image-generator.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, type CSSProperties } from 'react';
 import { 
   X, 
   Loader2, 
@@ -86,6 +86,10 @@ interface GeneratedImage {
   prompt: string;
   success?: boolean;
 }
+
+type TailwindRingStyle = CSSProperties & {
+  '--tw-ring-color'?: string;
+};
 
 export function AIImageGeneratorModal({
   isOpen,
@@ -282,12 +286,11 @@ export function AIImageGeneratorModal({
                   placeholder={`e.g., "${slideTitle || presentationTopic || 'modern business concept'}"`}
                   rows={3}
                   className="w-full px-4 py-3 rounded-xl border bg-transparent resize-none text-sm focus:outline-none focus:ring-2"
-                  style={{ 
+                  style={{
                     borderColor: `${theme?.colors?.foreground || '#fff'}20`,
                     color: theme?.colors?.foreground || '#fff',
-                    // @ts-ignore
                     '--tw-ring-color': accentColor
-                  }}
+                  } as TailwindRingStyle}
                 />
                 
                 {/* Quick Prompts */}

--- a/lib/flux-image-generator.ts
+++ b/lib/flux-image-generator.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib/logger";
+import type { NebiusImageGenerationRequest } from "@/types/nebius";
 /**
  * FLUX.1-schnell Image Generator using Nebius API
  * High-quality image generation for presentations
@@ -60,16 +61,17 @@ export async function generateFluxImage({
       apiKey: NEBIUS_API_KEY,
     });
 
-    const response = await client.images.generate({
+    const imageRequest: NebiusImageGenerationRequest = {
       model: model,
       prompt: enhancedPrompt,
       response_format: "url",
-      // @ts-ignore - Nebius-specific parameters
       width: width,
       height: height,
       num_inference_steps: 28,
       n: 1,
-    });
+    };
+
+    const response = await client.images.generate(imageRequest);
 
     if (!response.data || !response.data[0] || !response.data[0].url) {
       throw new Error('Invalid response from FLUX API');

--- a/pages/api/send-newsletter.ts
+++ b/pages/api/send-newsletter.ts
@@ -1,5 +1,4 @@
-// @ts-ignore
-import type { NextApiRequest, NextApiResponse } from 'next/types';
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { sendTestMail } from '../../lib/testmail';
 
 // Example: POST /api/send-newsletter

--- a/types/nebius.ts
+++ b/types/nebius.ts
@@ -1,0 +1,9 @@
+export interface NebiusImageGenerationRequest {
+  model: string;
+  prompt: string;
+  response_format: "url";
+  width: number;
+  height: number;
+  num_inference_steps: number;
+  n?: number;
+}


### PR DESCRIPTION
## Summary
- add a shared `NebiusImageGenerationRequest` type for Nebius-specific image generation parameters
- remove `@ts-ignore` from the slide image API and FLUX generator by passing typed request objects
- replace the textarea Tailwind CSS custom property ignore with a typed style object
- import Next API request/response types from `next` instead of suppressing the newsletter API import

## Verification
- `rg -n "@ts-ignore|@ts-expect-error" app/api/generate/slide-image/route.ts lib/flux-image-generator.ts components/presentation/ai-image-generator.tsx pages/api/send-newsletter.ts types/nebius.ts` returned no matches
- `git diff --cached --check`
- `npm run typecheck:changed` completed, but the repo script reported `No changed TypeScript source files to type-check`
- `npx --no-install tsc --noEmit --pretty false` could not run because dependencies are not installed in this low-disk workspace

Closes #875
