### PR TITLE
Add logger redaction and level filtering

### DIFF
--- a/__tests__/lib/logger-redaction-levels.test.ts
+++ b/__tests__/lib/logger-redaction-levels.test.ts
@@ -1,0 +1,93 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const originalEnv = { ...process.env };
+
+async function importLoggerWithEnv(env: Record<string, string | undefined>) {
+  jest.resetModules();
+  process.env = { ...originalEnv, ...env };
+  return import("@/lib/logger");
+}
+
+describe("structured logger redaction and levels", () => {
+  let infoSpy: jest.SpiedFunction<typeof console.info>;
+  let warnSpy: jest.SpiedFunction<typeof console.warn>;
+  let errorSpy: jest.SpiedFunction<typeof console.error>;
+  let debugSpy: jest.SpiedFunction<typeof console.debug>;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(console, "info").mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    debugSpy = jest.spyOn(console, "debug").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  it("redacts sensitive keys in context and payload objects", async () => {
+    const { logger } = await importLoggerWithEnv({
+      NODE_ENV: "production",
+      LOG_LEVEL: "debug",
+    });
+
+    logger.info(
+      {
+        requestId: "req-1",
+        authorization: "Bearer secret-token",
+        route: "/api/test",
+      },
+      "login attempt",
+      {
+        email: "user@example.com",
+        password: "plain-text",
+        nested: { apiKey: "sk-test" },
+      },
+    );
+
+    const line = String(infoSpy.mock.calls[0]?.[0] ?? "");
+    expect(line).toContain('"authorization":"[REDACTED]"');
+    expect(line).toContain("[REDACTED]");
+    expect(line).not.toContain("plain-text");
+    expect(line).not.toContain("sk-test");
+    expect(line).not.toContain("secret-token");
+  });
+
+  it("honors LOG_LEVEL by suppressing lower-priority entries", async () => {
+    const { logger } = await importLoggerWithEnv({
+      NODE_ENV: "production",
+      LOG_LEVEL: "warn",
+    });
+
+    logger.debug(null, "debug hidden");
+    logger.info(null, "info hidden");
+    logger.warn(null, "warn shown");
+    logger.error(null, "error shown");
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to info level when LOG_LEVEL is invalid", async () => {
+    const { logger } = await importLoggerWithEnv({
+      NODE_ENV: "production",
+      LOG_LEVEL: "verbose",
+    });
+
+    logger.debug(null, "debug hidden");
+    logger.info(null, "info shown");
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/logger-redaction-levels.test.ts
+++ b/__tests__/lib/logger-redaction-levels.test.ts
@@ -90,4 +90,28 @@ describe("structured logger redaction and levels", () => {
     expect(debugSpy).not.toHaveBeenCalled();
     expect(infoSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps valid incoming request IDs for request context", async () => {
+    const { requestContextFromHeaders } = await importLoggerWithEnv({
+      NODE_ENV: "production",
+    });
+    const headers = new Headers({ "x-request-id": "req-valid-12345" });
+
+    expect(requestContextFromHeaders(headers, "/api/test")).toEqual({
+      requestId: "req-valid-12345",
+      route: "/api/test",
+    });
+  });
+
+  it("generates a safe request ID when the incoming header is invalid", async () => {
+    const { requestContextFromHeaders } = await importLoggerWithEnv({
+      NODE_ENV: "production",
+    });
+    const headers = new Headers({ "x-request-id": "../bad id" });
+    const context = requestContextFromHeaders(headers, "/api/test");
+
+    expect(context.route).toBe("/api/test");
+    expect(context.requestId).toEqual(expect.any(String));
+    expect(context.requestId).not.toBe("../bad id");
+  });
 });

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,46 +1,128 @@
 /**
  * lib/logger.ts  —  Fix #9 (structured logging)
  */
-type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+type LogLevel = "debug" | "info" | "warn" | "error";
 export interface LogContext {
-  requestId?: string; userId?: string; route?: string;
-  durationMs?: number; statusCode?: number; [key: string]: unknown;
+  requestId?: string;
+  userId?: string;
+  route?: string;
+  durationMs?: number;
+  statusCode?: number;
+  [key: string]: unknown;
 }
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+const SENSITIVE_KEY_PATTERN =
+  /(password|passwd|token|secret|api[_-]?key|authorization|cookie|session)/i;
 const getEnv = () => {
-  const key = 'NODE_ENV';
+  const key = "NODE_ENV";
   return process.env[key];
 };
-const IS_PROD = getEnv() === 'production';
-const IS_TEST = getEnv() === 'test';
-const COLOURS: Record<LogLevel,string> = { debug:'\x1b[90m', info:'\x1b[36m', warn:'\x1b[33m', error:'\x1b[31m' };
-const RESET = '\x1b[0m';
+const IS_PROD = getEnv() === "production";
+const IS_TEST = getEnv() === "test";
+const COLOURS: Record<LogLevel, string> = {
+  debug: "\x1b[90m",
+  info: "\x1b[36m",
+  warn: "\x1b[33m",
+  error: "\x1b[31m",
+};
+const RESET = "\x1b[0m";
+
+function getConfiguredLevel(): LogLevel {
+  const configured = process.env.LOG_LEVEL?.toLowerCase() as
+    | LogLevel
+    | undefined;
+  if (configured && configured in LOG_LEVEL_PRIORITY) return configured;
+  return getEnv() === "production" ? "info" : "debug";
+}
+
+function shouldLog(level: LogLevel): boolean {
+  return LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[getConfiguredLevel()];
+}
+
+function redactSensitive(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (!value || typeof value !== "object") return value;
+  if (value instanceof Error)
+    return { message: value.message, stack: value.stack };
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitive(item, seen));
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+      key,
+      SENSITIVE_KEY_PATTERN.test(key)
+        ? "[REDACTED]"
+        : redactSensitive(entry, seen),
+    ]),
+  );
+}
+
 function serialize(v: unknown): string {
   if (v === null || v === undefined) return String(v);
-  if (typeof v === 'string') return v;
-  if (v instanceof Error) return JSON.stringify({ message: v.message, stack: v.stack });
-  try { return JSON.stringify(v); } catch { return String(v); }
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(redactSensitive(v));
+  } catch {
+    return String(v);
+  }
 }
-function buildEntry(level: LogLevel, ctx: LogContext|null, args: unknown[]): string {
+function buildEntry(
+  level: LogLevel,
+  ctx: LogContext | null,
+  args: unknown[],
+): string {
   const ts = new Date().toISOString();
-  const msg = args.map(serialize).join(' ');
-  if (IS_PROD) return JSON.stringify({ timestamp: ts, level: level.toUpperCase(), message: msg, ...(ctx ?? {}) });
-  const c = COLOURS[level]; const ctxStr = ctx ? ` ${JSON.stringify(ctx)}` : '';
+  const safeCtx = ctx ? redactSensitive(ctx) : null;
+  const msg = args.map(serialize).join(" ");
+  if (IS_PROD)
+    return JSON.stringify({
+      timestamp: ts,
+      level: level.toUpperCase(),
+      message: msg,
+      ...(safeCtx ?? {}),
+    });
+  const c = COLOURS[level];
+  const ctxStr = safeCtx ? ` ${JSON.stringify(safeCtx)}` : "";
   return `[${ts}] ${c}${level.toUpperCase()}${RESET}${ctxStr} ${msg}`;
 }
 function out(level: LogLevel, entry: string) {
+  if (!shouldLog(level)) return;
   if (IS_TEST) return;
-  if (level === 'error') console.error(entry);
-  else if (level === 'warn') console.warn(entry);
-  else if (level === 'debug') console.debug(entry);
+  if (level === "error") console.error(entry);
+  else if (level === "warn") console.warn(entry);
+  else if (level === "debug") console.debug(entry);
   else console.info(entry);
 }
 export const logger = {
-  debug(ctx: LogContext|null, ...a: unknown[]) { if (!IS_PROD) out('debug', buildEntry('debug',ctx,a)); },
-  info (ctx: LogContext|null, ...a: unknown[]) { out('info',  buildEntry('info', ctx,a)); },
-  warn (ctx: LogContext|null, ...a: unknown[]) { out('warn',  buildEntry('warn', ctx,a)); },
-  error(ctx: LogContext|null, ...a: unknown[]) { out('error', buildEntry('error',ctx,a)); },
+  debug(ctx: LogContext | null, ...a: unknown[]) {
+    if (!IS_PROD) out("debug", buildEntry("debug", ctx, a));
+  },
+  info(ctx: LogContext | null, ...a: unknown[]) {
+    out("info", buildEntry("info", ctx, a));
+  },
+  warn(ctx: LogContext | null, ...a: unknown[]) {
+    out("warn", buildEntry("warn", ctx, a));
+  },
+  error(ctx: LogContext | null, ...a: unknown[]) {
+    out("error", buildEntry("error", ctx, a));
+  },
   withContext(ctx: LogContext) {
-    return { debug:(...a:unknown[])=>logger.debug(ctx,...a), info:(...a:unknown[])=>logger.info(ctx,...a),
-             warn:(...a:unknown[])=>logger.warn(ctx,...a),  error:(...a:unknown[])=>logger.error(ctx,...a) };
+    return {
+      debug: (...a: unknown[]) => logger.debug(ctx, ...a),
+      info: (...a: unknown[]) => logger.info(ctx, ...a),
+      warn: (...a: unknown[]) => logger.warn(ctx, ...a),
+      error: (...a: unknown[]) => logger.error(ctx, ...a),
+    };
   },
 };

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -2,6 +2,8 @@
  * lib/logger.ts  —  Fix #9 (structured logging)
  */
 type LogLevel = "debug" | "info" | "warn" | "error";
+export const REQUEST_ID_HEADER = "x-request-id";
+
 export interface LogContext {
   requestId?: string;
   userId?: string;
@@ -31,6 +33,29 @@ const COLOURS: Record<LogLevel, string> = {
   error: "\x1b[31m",
 };
 const RESET = "\x1b[0m";
+
+export function createRequestId(candidate?: string | null): string {
+  const trimmed = candidate?.trim();
+  if (trimmed && /^[a-zA-Z0-9._:-]{8,128}$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `req_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+}
+
+export function requestContextFromHeaders(
+  headers: Pick<Headers, "get">,
+  route: string,
+): LogContext {
+  return {
+    requestId: createRequestId(headers.get(REQUEST_ID_HEADER)),
+    route,
+  };
+}
 
 function getConfiguredLevel(): LogLevel {
   const configured = process.env.LOG_LEVEL?.toLowerCase() as

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,8 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
-import { CSP_HEADER, buildCspWithNonce } from '@/lib/csp';
-import { applySecurityHeaders, buildCorsHeaders } from '@/lib/security-headers';
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { CSP_HEADER, buildCspWithNonce } from "@/lib/csp";
+import { REQUEST_ID_HEADER, createRequestId, logger } from "@/lib/logger";
+import { applySecurityHeaders, buildCorsHeaders } from "@/lib/security-headers";
 
 const DEPLOYMENT_ERROR_PATTERNS = [
   /DEPLOYMENT_NOT_FOUND/i,
@@ -18,26 +19,28 @@ function isDeploymentError(response: Response): boolean {
   return false;
 }
 
-async function logError(
+function logError(
   pathname: string,
   error: string,
   status: number,
-  timestamp: number
+  timestamp: number,
+  requestId: string,
 ) {
-  if (process.env.NODE_ENV === 'development') {
-    console.error(`[ERROR] ${pathname}: ${error} (${status}) at ${new Date(timestamp).toISOString()}`);
-  }
+  logger.error(
+    { requestId, route: pathname, statusCode: status, timestamp },
+    error,
+  );
 }
 
 const RL = {
-  AUTH:     { windowMs: 15 * 60 * 1000, max: 10  },
-  GENERATE: { windowMs:  5 * 60 * 1000, max: 20  },
-  API:      { windowMs:       60 * 1000, max: 100 },
+  AUTH: { windowMs: 15 * 60 * 1000, max: 10 },
+  GENERATE: { windowMs: 5 * 60 * 1000, max: 20 },
+  API: { windowMs: 60 * 1000, max: 100 },
 } as const;
 
 type RLKey = keyof typeof RL;
 
-// NOTE: In-memory Maps only rate-limit per individual Edge node in production. 
+// NOTE: In-memory Maps only rate-limit per individual Edge node in production.
 // For global production rate limiting, swap this Map for Vercel KV or Redis.
 const store = new Map<string, { count: number; reset: number }>();
 function pruneStore() {
@@ -46,10 +49,10 @@ function pruneStore() {
 }
 
 function rlKey(p: string): RLKey {
-  const norm = p.replace(/^\/api\/v\d+(?:\/|$)/, '/api/');
-  if (norm.startsWith('/api/auth/'))     return 'AUTH';
-  if (norm.startsWith('/api/generate/')) return 'GENERATE';
-  return 'API';
+  const norm = p.replace(/^\/api\/v\d+(?:\/|$)/, "/api/");
+  if (norm.startsWith("/api/auth/")) return "AUTH";
+  if (norm.startsWith("/api/generate/")) return "GENERATE";
+  return "API";
 }
 
 function checkRL(ip: string, pathname: string) {
@@ -62,12 +65,22 @@ function checkRL(ip: string, pathname: string) {
   if (!e || now > e.reset) {
     e = { count: 1, reset: now + cfg.windowMs };
     store.set(sk, e);
-    return { allowed: true, remaining: cfg.max - 1, reset: e.reset, limit: cfg.max };
+    return {
+      allowed: true,
+      remaining: cfg.max - 1,
+      reset: e.reset,
+      limit: cfg.max,
+    };
   }
   if (e.count >= cfg.max)
     return { allowed: false, remaining: 0, reset: e.reset, limit: cfg.max };
   e.count++;
-  return { allowed: true, remaining: cfg.max - e.count, reset: e.reset, limit: cfg.max };
+  return {
+    allowed: true,
+    remaining: cfg.max - e.count,
+    reset: e.reset,
+    limit: cfg.max,
+  };
 }
 
 /**
@@ -77,88 +90,130 @@ function checkRL(ip: string, pathname: string) {
 function generateNonce(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return btoa(Array.from(bytes).map(b => String.fromCharCode(b)).join(''));
+  return btoa(
+    Array.from(bytes)
+      .map((b) => String.fromCharCode(b))
+      .join(""),
+  );
 }
 
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
-  const origin = req.headers.get('origin');
+  const origin = req.headers.get("origin");
   const cors = buildCorsHeaders(origin);
+  const requestId = createRequestId(req.headers.get(REQUEST_ID_HEADER));
 
-  if (req.method === 'OPTIONS') {
-    if (!Object.keys(cors).length) return new NextResponse(null, { status: 403 });
-    return new NextResponse(null, { status: 204, headers: cors });
+  if (req.method === "OPTIONS") {
+    if (!Object.keys(cors).length) {
+      return new NextResponse(null, {
+        status: 403,
+        headers: { [REQUEST_ID_HEADER]: requestId },
+      });
+    }
+    return new NextResponse(null, {
+      status: 204,
+      headers: { ...cors, [REQUEST_ID_HEADER]: requestId },
+    });
   }
 
   if (/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$/i.test(pathname)) {
     const r = NextResponse.next();
-    r.headers.set('Cache-Control', 'public,max-age=31536000,immutable');
+    r.headers.set("Cache-Control", "public,max-age=31536000,immutable");
+    r.headers.set(REQUEST_ID_HEADER, requestId);
     return r;
   }
 
-  if (pathname.startsWith('/api/')) {
+  if (pathname.startsWith("/api/")) {
     const ip = (
-      req.headers.get('x-forwarded-for')?.split(',')[0] ??
-      req.headers.get('x-real-ip') ??
-      'unknown'
+      req.headers.get("x-forwarded-for")?.split(",")[0] ??
+      req.headers.get("x-real-ip") ??
+      "unknown"
     ).trim();
-    
+
     const rl = checkRL(ip, pathname);
     if (!rl.allowed) {
       const ra = Math.ceil((rl.reset - Date.now()) / 1000);
-      logError(pathname, 'Rate limit exceeded', 429, Date.now());
+      logError(pathname, "Rate limit exceeded", 429, Date.now(), requestId);
       return NextResponse.json(
-        { error: 'Rate limit exceeded', retryAfter: ra },
+        { error: "Rate limit exceeded", retryAfter: ra },
         {
           status: 429,
           headers: {
             ...cors,
-            'Retry-After': String(ra),
-            'X-RateLimit-Limit': String(rl.limit),
-            'X-RateLimit-Remaining': '0',
-            'X-RateLimit-Reset': String(Math.ceil(rl.reset / 1000)),
+            "Retry-After": String(ra),
+            "X-RateLimit-Limit": String(rl.limit),
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": String(Math.ceil(rl.reset / 1000)),
+            [REQUEST_ID_HEADER]: requestId,
           },
-        }
+        },
       );
     }
 
-    const r = NextResponse.next();
+    const requestHeaders = new Headers(req.headers);
+    requestHeaders.set(REQUEST_ID_HEADER, requestId);
+
+    const r = NextResponse.next({ request: { headers: requestHeaders } });
     for (const [k, v] of Object.entries(cors)) r.headers.set(k, v);
-    r.headers.set('X-RateLimit-Limit', String(rl.limit));
-    r.headers.set('X-RateLimit-Remaining', String(rl.remaining));
-    r.headers.set('X-RateLimit-Reset', String(Math.ceil(rl.reset / 1000)));
+    r.headers.set(REQUEST_ID_HEADER, requestId);
+    r.headers.set("X-RateLimit-Limit", String(rl.limit));
+    r.headers.set("X-RateLimit-Remaining", String(rl.remaining));
+    r.headers.set("X-RateLimit-Reset", String(Math.ceil(rl.reset / 1000)));
 
     const versionMatch = pathname.match(/^\/api\/(v\d+)(?:\/|$)/);
-    r.headers.set('X-API-Version', versionMatch ? versionMatch[1] : 'v2');
+    r.headers.set("X-API-Version", versionMatch ? versionMatch[1] : "v2");
 
-    if (pathname.startsWith('/api/generate/') || pathname.startsWith('/api/analyze-ats')) {
-      r.headers.set('X-Endpoint-Type', 'ai-generation');
+    if (
+      pathname.startsWith("/api/generate/") ||
+      pathname.startsWith("/api/analyze-ats")
+    ) {
+      r.headers.set("X-Endpoint-Type", "ai-generation");
     }
 
     if (isDeploymentError(r)) {
-      logError(pathname, 'Deployment error detected', r.status, Date.now());
-      r.headers.set('X-Deployment-Error', 'true');
+      logError(
+        pathname,
+        "Deployment error detected",
+        r.status,
+        Date.now(),
+        requestId,
+      );
+      r.headers.set("X-Deployment-Error", "true");
     }
 
     return r;
   }
 
-  if (!pathname.includes('.')) {
+  if (!pathname.includes(".")) {
     const nonce = generateNonce();
     const requestHeaders = new Headers(req.headers);
-    requestHeaders.set('x-nonce', nonce);
+    requestHeaders.set("x-nonce", nonce);
+    requestHeaders.set(REQUEST_ID_HEADER, requestId);
 
     const r = NextResponse.next({ request: { headers: requestHeaders } });
     applySecurityHeaders(r.headers);
-    
-    r.headers.set('Content-Security-Policy', buildCspWithNonce(nonce));
-    r.headers.set('X-DNS-Prefetch-Control', 'on');
-    r.headers.set('Cache-Control', 'public,max-age=300,stale-while-revalidate=3600');
-    r.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+    r.headers.set("Content-Security-Policy", buildCspWithNonce(nonce));
+    r.headers.set(REQUEST_ID_HEADER, requestId);
+    r.headers.set("X-DNS-Prefetch-Control", "on");
+    r.headers.set(
+      "Cache-Control",
+      "public,max-age=300,stale-while-revalidate=3600",
+    );
+    r.headers.set(
+      "Permissions-Policy",
+      "camera=(), microphone=(), geolocation=()",
+    );
 
     if (isDeploymentError(r)) {
-      logError(pathname, 'Deployment error on page load', r.status, Date.now());
-      r.headers.set('X-Deployment-Error', 'true');
+      logError(
+        pathname,
+        "Deployment error on page load",
+        r.status,
+        Date.now(),
+        requestId,
+      );
+      r.headers.set("X-Deployment-Error", "true");
     }
 
     return r;
@@ -166,11 +221,15 @@ export function middleware(req: NextRequest) {
 
   const r = NextResponse.next();
   applySecurityHeaders(r.headers);
-  r.headers.set('Content-Security-Policy', CSP_HEADER);
-  r.headers.set('Cache-Control', 'public,max-age=300,stale-while-revalidate=3600');
+  r.headers.set("Content-Security-Policy", CSP_HEADER);
+  r.headers.set(
+    "Cache-Control",
+    "public,max-age=300,stale-while-revalidate=3600",
+  );
+  r.headers.set(REQUEST_ID_HEADER, requestId);
   return r;
 }
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico|public/).*)'],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|public/).*)"],
 };


### PR DESCRIPTION
## Linked Issue
Closes #953

## GSSoC
- gssoc:approved
- level:intermediate

## Summary
- Added LOG_LEVEL filtering to the structured logger.
- Redacts sensitive context and payload keys before serialization.
- Adds request correlation ID helpers and middleware propagation through `x-request-id`.
- Logs middleware errors with request context instead of raw console output.
- Added focused tests for redaction, level behavior, and request ID context handling.

## Validation
- npx jest __tests__/lib/logger.test.ts __tests__/lib/logger-redaction-levels.test.ts --runInBand
- npx eslint lib/logger.ts middleware.ts __tests__/lib/logger-redaction-levels.test.ts --max-warnings=0
- lint-staged on commit: eslint, prettier, jest --findRelatedTests --passWithNoTests
- Pre-push hook: node scripts/typecheck-changed.mjs; jest --runInBand --passWithNoTests (24 suites / 378 tests passed)