### PR TITLE
Add image optimization helpers

### DIFF
--- a/components/optimized-image.tsx
+++ b/components/optimized-image.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image, { type ImageProps } from "next/image";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type SyntheticEvent } from "react";
 
 export interface OptimizedImageSource {
   url?: string;
@@ -39,6 +39,11 @@ export function OptimizedImage({
   fallbackSrc,
   sizes = "(max-width: 768px) 100vw, 50vw",
   loading = "lazy",
+  onError,
+  className,
+  style,
+  width,
+  height,
   ...props
 }: OptimizedImageProps) {
   const [currentSrc, setCurrentSrc] = useState(src);
@@ -49,6 +54,31 @@ export function OptimizedImage({
     setCurrentSrc(src);
   }, [src]);
 
+  const handleError = (event: SyntheticEvent<HTMLImageElement, Event>) => {
+    onError?.(event);
+    if (fallbackSrc && currentSrc !== fallbackSrc) {
+      setCurrentSrc(fallbackSrc);
+    }
+  };
+
+  if (shouldUseVariants) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element -- custom storage srcSet variants are pre-generated and must be forwarded directly.
+      <img
+        src={currentSrc}
+        srcSet={srcSet}
+        sizes={typeof sizes === "string" ? sizes : undefined}
+        alt={alt}
+        loading={loading}
+        className={className}
+        style={style}
+        width={typeof width === "number" ? width : undefined}
+        height={typeof height === "number" ? height : undefined}
+        onError={handleError}
+      />
+    );
+  }
+
   return (
     <Image
       {...props}
@@ -56,12 +86,11 @@ export function OptimizedImage({
       alt={alt}
       sizes={sizes}
       loading={loading}
-      onError={() => {
-        if (fallbackSrc && currentSrc !== fallbackSrc) {
-          setCurrentSrc(fallbackSrc);
-        }
-      }}
-      {...(shouldUseVariants ? { srcSet } : {})}
+      className={className}
+      style={style}
+      width={width}
+      height={height}
+      onError={handleError}
     />
   );
 }

--- a/components/optimized-image.tsx
+++ b/components/optimized-image.tsx
@@ -4,21 +4,31 @@ import Image, { type ImageProps } from "next/image";
 import { useEffect, useMemo, useState } from "react";
 
 export interface OptimizedImageSource {
-  url: string;
+  url?: string;
+  path?: string;
   width: number;
   format?: "webp" | "avif" | "jpeg";
 }
 
-interface OptimizedImageProps extends Omit<ImageProps, "src"> {
+interface OptimizedImageProps extends Omit<ImageProps, "src" | "alt"> {
   src: string;
+  alt: string;
   variants?: OptimizedImageSource[];
   fallbackSrc?: string;
+}
+
+function getVariantUrl(variant: OptimizedImageSource) {
+  return variant.url || variant.path;
 }
 
 function buildSrcSet(variants: OptimizedImageSource[] = []) {
   return [...variants]
     .sort((a, b) => a.width - b.width)
-    .map((variant) => `${variant.url} ${variant.width}w`)
+    .map((variant) => {
+      const url = getVariantUrl(variant);
+      return url ? `${url} ${variant.width}w` : "";
+    })
+    .filter(Boolean)
     .join(", ");
 }
 
@@ -33,6 +43,7 @@ export function OptimizedImage({
 }: OptimizedImageProps) {
   const [currentSrc, setCurrentSrc] = useState(src);
   const srcSet = useMemo(() => buildSrcSet(variants), [variants]);
+  const shouldUseVariants = Boolean(srcSet) && currentSrc !== fallbackSrc;
 
   useEffect(() => {
     setCurrentSrc(src);
@@ -50,7 +61,7 @@ export function OptimizedImage({
           setCurrentSrc(fallbackSrc);
         }
       }}
-      {...(srcSet ? { srcSet } : {})}
+      {...(shouldUseVariants ? { srcSet } : {})}
     />
   );
 }

--- a/components/optimized-image.tsx
+++ b/components/optimized-image.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Image, { type ImageProps } from "next/image";
+import { useEffect, useMemo, useState } from "react";
+
+export interface OptimizedImageSource {
+  url: string;
+  width: number;
+  format?: "webp" | "avif" | "jpeg";
+}
+
+interface OptimizedImageProps extends Omit<ImageProps, "src"> {
+  src: string;
+  variants?: OptimizedImageSource[];
+  fallbackSrc?: string;
+}
+
+function buildSrcSet(variants: OptimizedImageSource[] = []) {
+  return [...variants]
+    .sort((a, b) => a.width - b.width)
+    .map((variant) => `${variant.url} ${variant.width}w`)
+    .join(", ");
+}
+
+export function OptimizedImage({
+  src,
+  alt,
+  variants = [],
+  fallbackSrc,
+  sizes = "(max-width: 768px) 100vw, 50vw",
+  loading = "lazy",
+  ...props
+}: OptimizedImageProps) {
+  const [currentSrc, setCurrentSrc] = useState(src);
+  const srcSet = useMemo(() => buildSrcSet(variants), [variants]);
+
+  useEffect(() => {
+    setCurrentSrc(src);
+  }, [src]);
+
+  return (
+    <Image
+      {...props}
+      src={currentSrc}
+      alt={alt}
+      sizes={sizes}
+      loading={loading}
+      onError={() => {
+        if (fallbackSrc && currentSrc !== fallbackSrc) {
+          setCurrentSrc(fallbackSrc);
+        }
+      }}
+      {...(srcSet ? { srcSet } : {})}
+    />
+  );
+}

--- a/lib/__tests__/image-optimizer.test.ts
+++ b/lib/__tests__/image-optimizer.test.ts
@@ -1,7 +1,14 @@
+/**
+ * @jest-environment node
+ */
+
 import {
   buildOptimizedImagePath,
+  createResponsiveImageVariants,
   getImageCacheControl,
+  IMAGE_VARIANTS,
 } from "../image-optimizer";
+import sharp from "sharp";
 
 describe("image optimizer helpers", () => {
   it("builds predictable variant paths", () => {
@@ -13,5 +20,76 @@ describe("image optimizer helpers", () => {
   it("returns immutable cache headers for optimized variants", () => {
     expect(getImageCacheControl()).toContain("max-age=31536000");
     expect(getImageCacheControl()).toContain("immutable");
+  });
+
+  it("creates one variant for every size and requested format", async () => {
+    const input = await sharp({
+      create: {
+        width: 1600,
+        height: 900,
+        channels: 3,
+        background: "#1d4ed8",
+      },
+    })
+      .png()
+      .toBuffer();
+
+    const variants = await createResponsiveImageVariants(input, {
+      basePath: "uploads/hero.png",
+      formats: ["webp", "jpeg"],
+    });
+
+    expect(variants).toHaveLength(Object.keys(IMAGE_VARIANTS).length * 2);
+    expect(variants.map((variant) => variant.format)).toEqual([
+      "webp",
+      "jpeg",
+      "webp",
+      "jpeg",
+      "webp",
+      "jpeg",
+    ]);
+  });
+
+  it("does not upscale variants beyond the source width", async () => {
+    const input = await sharp({
+      create: {
+        width: 320,
+        height: 240,
+        channels: 3,
+        background: "#0f172a",
+      },
+    })
+      .png()
+      .toBuffer();
+
+    const variants = await createResponsiveImageVariants(input, {
+      basePath: "uploads/small.png",
+      formats: ["webp"],
+    });
+
+    expect(variants.every((variant) => variant.width <= 320)).toBe(true);
+  });
+
+  it("uses auto-oriented dimensions when capping variant widths", async () => {
+    const input = await sharp({
+      create: {
+        width: 80,
+        height: 160,
+        channels: 3,
+        background: "#2563eb",
+      },
+    })
+      .jpeg()
+      .withMetadata({ orientation: 6 })
+      .toBuffer();
+
+    const variants = await createResponsiveImageVariants(input, {
+      basePath: "uploads/rotated.jpg",
+      formats: ["jpeg"],
+    });
+
+    expect(variants[0].width).toBe(150);
+    const metadata = await sharp(variants[0].buffer).metadata();
+    expect(metadata.width).toBe(150);
   });
 });

--- a/lib/__tests__/image-optimizer.test.ts
+++ b/lib/__tests__/image-optimizer.test.ts
@@ -1,0 +1,17 @@
+import {
+  buildOptimizedImagePath,
+  getImageCacheControl,
+} from "../image-optimizer";
+
+describe("image optimizer helpers", () => {
+  it("builds predictable variant paths", () => {
+    expect(
+      buildOptimizedImagePath("uploads/user/avatar.png", "medium", "webp"),
+    ).toBe("uploads/user/avatar/medium.webp");
+  });
+
+  it("returns immutable cache headers for optimized variants", () => {
+    expect(getImageCacheControl()).toContain("max-age=31536000");
+    expect(getImageCacheControl()).toContain("immutable");
+  });
+});

--- a/lib/image-optimizer.ts
+++ b/lib/image-optimizer.ts
@@ -56,12 +56,13 @@ export async function createResponsiveImageVariants(
   const formats = options.formats || ["webp", "avif", "jpeg"];
   const source = sharp(input, { failOn: "none" }).rotate();
   const metadata = await source.metadata();
+  const sourceWidth = metadata.autoOrient?.width || metadata.width;
   const variants: OptimizedImageVariant[] = [];
 
   for (const [name, config] of Object.entries(IMAGE_VARIANTS) as Array<
     [ImageVariantName, (typeof IMAGE_VARIANTS)[ImageVariantName]]
   >) {
-    const targetWidth = Math.min(config.width, metadata.width || config.width);
+    const targetWidth = Math.min(config.width, sourceWidth || config.width);
 
     for (const format of formats) {
       const resized = source.clone().resize({

--- a/lib/image-optimizer.ts
+++ b/lib/image-optimizer.ts
@@ -1,0 +1,88 @@
+import sharp from "sharp";
+
+export const IMAGE_VARIANTS = {
+  thumbnail: { width: 150, quality: 72 },
+  medium: { width: 640, quality: 78 },
+  large: { width: 1200, quality: 82 },
+} as const;
+
+export type ImageVariantName = keyof typeof IMAGE_VARIANTS;
+export type ImageFormat = "webp" | "avif" | "jpeg";
+
+export interface OptimizedImageVariant {
+  name: ImageVariantName;
+  width: number;
+  format: ImageFormat;
+  path: string;
+  buffer: Buffer;
+  contentType: string;
+}
+
+export interface OptimizeImageOptions {
+  basePath: string;
+  formats?: ImageFormat[];
+}
+
+const CONTENT_TYPES: Record<ImageFormat, string> = {
+  webp: "image/webp",
+  avif: "image/avif",
+  jpeg: "image/jpeg",
+};
+
+export function buildOptimizedImagePath(
+  basePath: string,
+  variant: ImageVariantName,
+  format: ImageFormat,
+) {
+  const cleanPath = basePath.replace(/\.[a-z0-9]+$/i, "").replace(/^\/+/, "");
+  return `${cleanPath}/${variant}.${format}`;
+}
+
+async function encodeImage(
+  image: sharp.Sharp,
+  format: ImageFormat,
+  quality: number,
+) {
+  if (format === "avif") return image.avif({ quality }).toBuffer();
+  if (format === "jpeg")
+    return image.jpeg({ quality, mozjpeg: true }).toBuffer();
+  return image.webp({ quality }).toBuffer();
+}
+
+export async function createResponsiveImageVariants(
+  input: Buffer | ArrayBuffer | Uint8Array,
+  options: OptimizeImageOptions,
+): Promise<OptimizedImageVariant[]> {
+  const formats = options.formats || ["webp", "avif", "jpeg"];
+  const source = sharp(input, { failOn: "none" }).rotate();
+  const metadata = await source.metadata();
+  const variants: OptimizedImageVariant[] = [];
+
+  for (const [name, config] of Object.entries(IMAGE_VARIANTS) as Array<
+    [ImageVariantName, (typeof IMAGE_VARIANTS)[ImageVariantName]]
+  >) {
+    const targetWidth = Math.min(config.width, metadata.width || config.width);
+
+    for (const format of formats) {
+      const resized = source.clone().resize({
+        width: targetWidth,
+        withoutEnlargement: true,
+      });
+
+      variants.push({
+        name,
+        width: targetWidth,
+        format,
+        path: buildOptimizedImagePath(options.basePath, name, format),
+        buffer: await encodeImage(resized, format, config.quality),
+        contentType: CONTENT_TYPES[format],
+      });
+    }
+  }
+
+  return variants;
+}
+
+export function getImageCacheControl() {
+  return "public, max-age=31536000, immutable";
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -116,7 +116,7 @@ export function middleware(req: NextRequest) {
     });
   }
 
-  if (/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$/i.test(pathname)) {
+  if (/\.(js|css|png|jpg|jpeg|gif|svg|webp|avif|ico|woff2?)$/i.test(pathname)) {
     const r = NextResponse.next();
     r.headers.set("Cache-Control", "public,max-age=31536000,immutable");
     r.headers.set(REQUEST_ID_HEADER, requestId);


### PR DESCRIPTION
## Linked Issue
Closes #955

## GSSoC Labels / Level
- gssoc:approved
- level:intermediate

## Summary
- Adds a sharp-based image optimizer utility for thumbnail, medium, and large variants.
- Supports WebP, AVIF, and JPEG output with predictable storage paths.
- Adds a reusable `OptimizedImage` component with lazy loading, srcset support, and fallback handling.
- Adds WebP/AVIF to immutable static cache matching.

## Validation
- `npm test -- --runInBand lib/__tests__/image-optimizer.test.ts`
- Filtered TypeScript check for changed files returned no errors.
- Repo-wide `npx tsc --noEmit --pretty false --incremental false` still reports pre-existing unrelated errors, including middleware `NextResponse` typing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optimized image component with variant-aware srcSet and fallback handling.
  * Server-side generation of responsive image variants (AVIF/WebP/JPEG) with long-lived immutable cache headers.
  * Static asset caching broadened to include AVIF and WebP files.

* **Tests**
  * Added test coverage for image optimization utilities and responsive variant generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->