### PR TITLE
Add new user onboarding wizard

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,9 @@
+import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard";
+
+export default function OnboardingPage() {
+  return (
+    <main className="min-h-screen bg-background px-4 py-10">
+      <OnboardingWizard />
+    </main>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/components/auth-provider";
 import { useTheme } from "@/hooks/use-theme";
 import { useUsageStats } from "@/hooks/use-usage-stats";
+import { useOnboarding } from "@/hooks/use-onboarding";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -19,6 +20,7 @@ import {
   Layout,
   TrendingUp,
   Upload,
+  Rocket,
 } from "lucide-react";
 import {
   Select,
@@ -49,6 +51,7 @@ export default function SettingsPage() {
     loading: statsLoading,
     error: statsError,
   } = useUsageStats();
+  const onboarding = useOnboarding();
 
   if (loading) {
     return (
@@ -244,6 +247,37 @@ export default function SettingsPage() {
                 >
                   <Upload className="h-4 w-4 mr-2" />
                   Import Data
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Onboarding */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Rocket className="h-5 w-5" />
+                Onboarding
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="font-medium">Restart product tour</p>
+                  <p className="text-sm text-muted-foreground">
+                    Revisit profile setup, templates, first document creation,
+                    and workspace tips.
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  onClick={async () => {
+                    await onboarding.reset();
+                    router.push("/onboarding");
+                  }}
+                >
+                  <Rocket className="h-4 w-4 mr-2" />
+                  Open Onboarding
                 </Button>
               </div>
             </CardContent>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -6,10 +6,12 @@ import { useAuth } from "@/components/auth-provider";
 import { useTheme } from "@/hooks/use-theme";
 import { useUsageStats } from "@/hooks/use-usage-stats";
 import { useOnboarding } from "@/hooks/use-onboarding";
+import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Settings,
+  Loader2,
   Sparkles,
   Zap,
   Sun,
@@ -52,6 +54,30 @@ export default function SettingsPage() {
     error: statsError,
   } = useUsageStats();
   const onboarding = useOnboarding();
+  const { toast } = useToast();
+  const [isRestartingOnboarding, setIsRestartingOnboarding] = useState(false);
+
+  const restartOnboarding = async () => {
+    setIsRestartingOnboarding(true);
+
+    try {
+      await onboarding.reset();
+      router.push("/onboarding");
+    } catch (error) {
+      logger.error(
+        { component: "SettingsPage" },
+        "Failed to restart onboarding",
+        error,
+      );
+      toast({
+        title: "Could not restart onboarding",
+        description: "Please try again in a moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsRestartingOnboarding(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -271,13 +297,18 @@ export default function SettingsPage() {
                 </div>
                 <Button
                   variant="outline"
-                  onClick={async () => {
-                    await onboarding.reset();
-                    router.push("/onboarding");
-                  }}
+                  onClick={restartOnboarding}
+                  disabled={isRestartingOnboarding}
+                  aria-busy={isRestartingOnboarding}
                 >
-                  <Rocket className="h-4 w-4 mr-2" />
-                  Open Onboarding
+                  {isRestartingOnboarding ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Rocket className="h-4 w-4 mr-2" />
+                  )}
+                  {isRestartingOnboarding
+                    ? "Opening Onboarding..."
+                    : "Open Onboarding"}
                 </Button>
               </div>
             </CardContent>

--- a/components/onboarding/onboarding-wizard.tsx
+++ b/components/onboarding/onboarding-wizard.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  CheckCircle2,
+  FileText,
+  LayoutTemplate,
+  Sparkles,
+  UserRound,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { useOnboarding } from "@/hooks/use-onboarding";
+
+const steps = [
+  {
+    title: "Set up your profile",
+    description:
+      "Add your name and role so generated documents start with better context.",
+    icon: UserRound,
+    action: "Open Profile",
+    href: "/profile",
+  },
+  {
+    title: "Choose a template",
+    description:
+      "Browse resume, presentation, and document templates before creating your first draft.",
+    icon: LayoutTemplate,
+    action: "Browse Templates",
+    href: "/templates",
+  },
+  {
+    title: "Create your first document",
+    description:
+      "Start with a resume, letter, presentation, or diagram and let DraftDeckAI guide the draft.",
+    icon: FileText,
+    action: "Create Document",
+    href: "/dashboard/history",
+  },
+  {
+    title: "Tour the workflow",
+    description:
+      "Use export, templates, analytics, and settings to manage your document workspace.",
+    icon: Sparkles,
+    action: "Go to Dashboard",
+    href: "/dashboard/history",
+  },
+];
+
+export function OnboardingWizard() {
+  const router = useRouter();
+  const onboarding = useOnboarding();
+  const [busy, setBusy] = useState(false);
+  const activeStep = steps[onboarding.currentStep] || steps[0];
+  const Icon = activeStep.icon;
+  const progress = ((onboarding.currentStep + 1) / steps.length) * 100;
+
+  const moveTo = async (step: number) => {
+    setBusy(true);
+    try {
+      await onboarding.setCurrentStep(
+        Math.max(0, Math.min(step, steps.length - 1)),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const finish = async () => {
+    setBusy(true);
+    try {
+      await onboarding.complete();
+      router.push("/dashboard/history");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const skip = async () => {
+    setBusy(true);
+    try {
+      await onboarding.skip();
+      router.push("/dashboard/history");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card className="mx-auto max-w-3xl">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Sparkles className="h-5 w-5 text-blue-500" />
+          Welcome to DraftDeckAI
+        </CardTitle>
+        <CardDescription>
+          Complete these steps to personalize your workspace and create your
+          first document.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">
+              Step {onboarding.currentStep + 1} of {steps.length}
+            </span>
+            <span>{Math.round(progress)}%</span>
+          </div>
+          <Progress value={progress} />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-[220px_1fr]">
+          <div className="space-y-2">
+            {steps.map((step, index) => (
+              <button
+                key={step.title}
+                type="button"
+                onClick={() => moveTo(index)}
+                className={`flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+                  index === onboarding.currentStep
+                    ? "border-blue-500 bg-blue-50 dark:bg-blue-950/30"
+                    : "hover:bg-muted/50"
+                }`}
+              >
+                {index < onboarding.currentStep ? (
+                  <CheckCircle2 className="h-4 w-4 text-green-500" />
+                ) : (
+                  <step.icon className="h-4 w-4 text-blue-500" />
+                )}
+                {step.title}
+              </button>
+            ))}
+          </div>
+
+          <div className="rounded-lg border p-6">
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-100 text-blue-600 dark:bg-blue-950/40">
+              <Icon className="h-6 w-6" />
+            </div>
+            <h2 className="mb-2 text-2xl font-semibold">{activeStep.title}</h2>
+            <p className="mb-6 text-muted-foreground">
+              {activeStep.description}
+            </p>
+            <Button
+              variant="outline"
+              onClick={() => router.push(activeStep.href)}
+            >
+              {activeStep.action}
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-between">
+          <Button variant="ghost" onClick={skip} disabled={busy}>
+            Skip for now
+          </Button>
+          <div className="flex gap-3">
+            <Button
+              variant="outline"
+              onClick={() => moveTo(onboarding.currentStep - 1)}
+              disabled={busy || onboarding.currentStep === 0}
+            >
+              Back
+            </Button>
+            {onboarding.currentStep === steps.length - 1 ? (
+              <Button onClick={finish} disabled={busy}>
+                Finish
+              </Button>
+            ) : (
+              <Button
+                onClick={() => moveTo(onboarding.currentStep + 1)}
+                disabled={busy}
+              >
+                Next
+              </Button>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/use-onboarding.ts
+++ b/hooks/use-onboarding.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useAuth } from "@/components/auth-provider";
+import { logger } from "@/lib/logger";
+
+const STORAGE_KEY = "draftdeckai:onboarding";
+const supabase = createClient();
+
+export interface OnboardingState {
+  completed: boolean;
+  skipped: boolean;
+  currentStep: number;
+}
+
+const defaultState: OnboardingState = {
+  completed: false,
+  skipped: false,
+  currentStep: 0,
+};
+
+function readLocalState(): OnboardingState {
+  if (typeof window === "undefined") return defaultState;
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored ? { ...defaultState, ...JSON.parse(stored) } : defaultState;
+  } catch {
+    return defaultState;
+  }
+}
+
+function writeLocalState(state: OnboardingState) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+export function useOnboarding() {
+  const { user } = useAuth();
+  const [state, setState] = useState<OnboardingState>(() => {
+    const metadata = user?.user_metadata?.onboarding as
+      | Partial<OnboardingState>
+      | undefined;
+    return { ...readLocalState(), ...metadata };
+  });
+  const stateRef = useRef(state);
+  const userRef = useRef(user);
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  useEffect(() => {
+    userRef.current = user;
+  }, [user]);
+
+  useEffect(() => {
+    const metadata = user?.user_metadata?.onboarding as
+      | Partial<OnboardingState>
+      | undefined;
+
+    if (!metadata) return;
+
+    setState((current) => {
+      const nextState = { ...current, ...metadata };
+      const isSameState =
+        current.completed === nextState.completed &&
+        current.skipped === nextState.skipped &&
+        current.currentStep === nextState.currentStep;
+
+      if (isSameState) return current;
+
+      stateRef.current = nextState;
+      writeLocalState(nextState);
+      return nextState;
+    });
+  }, [user]);
+
+  const persist = useCallback(async (nextState: OnboardingState) => {
+    const activeUser = userRef.current;
+
+    if (activeUser && supabase.auth.updateUser) {
+      const { error } = await supabase.auth.updateUser({
+        data: {
+          ...(activeUser.user_metadata || {}),
+          onboarding: nextState,
+        },
+      });
+
+      if (error) {
+        logger.error(
+          { component: "useOnboarding" },
+          "Failed to persist onboarding state",
+          error,
+        );
+        throw error;
+      }
+    }
+
+    setState(nextState);
+    stateRef.current = nextState;
+    writeLocalState(nextState);
+  }, []);
+
+  const setCurrentStep = useCallback(
+    async (currentStep: number) =>
+      persist({ ...stateRef.current, currentStep }),
+    [persist],
+  );
+
+  const complete = useCallback(
+    async () => persist({ completed: true, skipped: false, currentStep: 3 }),
+    [persist],
+  );
+
+  const skip = useCallback(
+    async () =>
+      persist({
+        completed: false,
+        skipped: true,
+        currentStep: stateRef.current.currentStep,
+      }),
+    [persist],
+  );
+
+  const reset = useCallback(async () => persist(defaultState), [persist]);
+
+  return {
+    ...state,
+    setCurrentStep,
+    complete,
+    skip,
+    reset,
+  };
+}


### PR DESCRIPTION
## Linked Issue
Closes #945

## GSSoC Labels / Level
- gssoc:approved
- level:intermediate
- type:feature

## Type of Change
- New feature
- UI/UX improvement
- State persistence enhancement

## Summary
Adds a complete new-user onboarding flow that guides users through the first key product steps and lets them restart the tour later from Settings.

## Changes Made
- Added a reusable `useOnboarding` hook for onboarding state, localStorage persistence, and Supabase user metadata sync.
- Added a four-step onboarding wizard covering profile setup, templates, first document creation, and workflow exploration.
- Added the `/onboarding` route to render the wizard as a standalone product flow.
- Added a Settings entry point that resets onboarding progress and routes users back into the tour.
- Included skip, next, previous, and finish actions with busy-state handling.

## Dependencies
- No new dependencies were added.
- Uses existing routing, Supabase auth, and UI patterns already present in the app.

## How Has This Been Tested?
- Filtered TypeScript check for changed files returned no errors.
- Repo-wide `npx tsc --noEmit --pretty false --incremental false` still reports pre-existing unrelated errors outside this PR.
- GitHub Actions `test-and-build` checks passed on Node 18.x and Node 20.x.
- Dependency audit/security checks passed on Node 18.x and Node 20.x.

## Checklist
- [x] Linked the related issue.
- [x] Followed the existing project structure and styling patterns.
- [x] Added no unrelated files or scope creep.
- [x] Documented local validation and known unrelated repo-wide typecheck noise.
- [x] Ready for maintainer review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step onboarding wizard for profile setup, template selection, first document creation, and a workflow tour.
  * New onboarding page and a Restart/Open Onboarding action in Settings with loading and error feedback.
  * Progress is persisted across sessions and tied to the user account.
  * Users can navigate steps, skip the tour, or finish to resume the product.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->