### PR TITLE
Added case:complexity case label in content.js switch

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1047,7 +1047,8 @@
                     ${data.spaceComplexity ? `<p><strong>💾 Space:</strong> ${data.spaceComplexity}</p>` : ''}
                 </div>`;
                 break;
-                
+
+            case 'complexity':
                 html = `<div class="draftdeckai-complexity">
                     <h4>⏱️ Complexity Analysis:</h4>
                     <p><strong>Time:</strong> ${data.timeComplexity || data.content || 'O(n)'}</p>


### PR DESCRIPTION
# Description

The `case "complexity":` label was missing in the `displayResult()` switch statement in `extension/content.js`. Without this label, the complexity analysis block was unreachable dead code ,the backend ran the analysis but results were never rendered in the UI.

Fixes #883 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `case "complexity":` label before the complexity rendering block in the `displayResult()` switch statement in `extension/content.js`

## Dependencies

- None

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A Opened a LeetCode problem, clicked "⏱️ Complexity Analysis" button

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have tested my changes across major browsers/devices
- [ ] I have tested my changes in development mode (`npm run dev`)
- [ ] I have successfully run `npm run lint` and resolved all warnings/errors
- [ ] I have successfully run `npm run typecheck` and resolved all TypeScript errors
- [ ] New and existing unit tests pass locally with my changes (`npx jest`)
- [ ] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved an issue where complexity analysis results failed to render properly. The fix ensures that complexity analysis responses now display as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->