### PR TITLE
feat: add Go backend env validation at startup (#901)

### DIFF
--- a/backend/go/cmd/server/main.go
+++ b/backend/go/cmd/server/main.go
@@ -1,0 +1,41 @@
+// Package main is the entry point for the DraftDeckAI Go backend server.
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/Muneerali199/Draftdeckai/backend/go/pkg/config"
+)
+
+func main() {
+	log.Println("[server] Starting DraftDeckAI Go backend...")
+
+	// Validate all required environment variables before doing anything else.
+	// This will log ALL missing vars and exit with code 1 if any are absent.
+	if err := config.ValidateEnv(); err != nil {
+		log.Fatalf("[server] FATAL: %v", err)
+	}
+
+	// Print startup summary with secrets masked
+	config.PrintStartupSummary()
+
+	port := os.Getenv("PORT")
+
+	mux := http.NewServeMux()
+
+	// Health check endpoint
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
+			log.Printf("[server] health write error: %v", err)
+		}
+	})
+
+	log.Printf("[server] Listening on :%s", port)
+	if err := http.ListenAndServe(":"+port, mux); err != nil {
+		log.Fatalf("[server] FATAL: %v", err)
+	}
+}

--- a/backend/go/go.mod
+++ b/backend/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/Muneerali199/Draftdeckai/backend/go
+
+go 1.22
+
+require github.com/golang-jwt/jwt/v5 v5.2.1

--- a/backend/go/pkg/auth/middleware.go
+++ b/backend/go/pkg/auth/middleware.go
@@ -1,0 +1,49 @@
+// Package auth provides JWT authentication middleware for the Go backend.
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// AuthMiddleware validates the Supabase JWT token in the Authorization header.
+// Instead of panicking on missing config, it returns 500 with a clear message.
+func AuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secret := os.Getenv("SUPABASE_JWT_SECRET")
+		if secret == "" {
+			// Configuration error — do not panic, return 500
+			http.Error(w,
+				"server configuration error: SUPABASE_JWT_SECRET is not set",
+				http.StatusInternalServerError,
+			)
+			return
+		}
+
+		authHeader := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			http.Error(w, "missing or invalid Authorization header", http.StatusUnauthorized)
+			return
+		}
+
+		tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+
+		token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
+			return []byte(secret), nil
+		})
+
+		if err != nil || !token.Valid {
+			http.Error(w, "invalid or expired token", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/go/pkg/config/env.go
+++ b/backend/go/pkg/config/env.go
@@ -1,0 +1,117 @@
+// Package config provides environment variable validation and configuration
+// loading for the DraftDeckAI Go backend.
+package config
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+// EnvVar describes a single environment variable — whether it is required,
+// its default value (for optional vars), and a short description shown at
+// startup.
+type EnvVar struct {
+	Name        string
+	Required    bool
+	Default     string
+	Description string
+	Secret      bool // if true, mask value in startup log
+}
+
+// requiredVars lists every variable the server needs to operate correctly.
+var envVars = []EnvVar{
+	{
+		Name:        "SUPABASE_JWT_SECRET",
+		Required:    true,
+		Description: "JWT secret used to verify Supabase auth tokens",
+		Secret:      true,
+	},
+	{
+		Name:        "SUPABASE_URL",
+		Required:    true,
+		Description: "Base URL of your Supabase project",
+		Secret:      false,
+	},
+	{
+		Name:        "PORT",
+		Required:    false,
+		Default:     "8080",
+		Description: "HTTP port the server listens on",
+		Secret:      false,
+	},
+	{
+		Name:        "DATABASE_URL",
+		Required:    false,
+		Default:     "",
+		Description: "Postgres connection string (future use)",
+		Secret:      true,
+	},
+}
+
+// maskSecret returns a partially masked string for secret values.
+// e.g. "abcdefghij" -> "abc...hij"
+func maskSecret(value string) string {
+	if len(value) <= 6 {
+		return "***"
+	}
+	return value[:3] + "..." + value[len(value)-3:]
+}
+
+// ValidateEnv checks that all required environment variables are set.
+// It logs every missing variable before returning an error so operators
+// see all problems at once instead of fixing one at a time.
+// Optional variables are set to their default when absent.
+func ValidateEnv() error {
+	var missing []string
+
+	for _, v := range envVars {
+		val := os.Getenv(v.Name)
+
+		if val == "" {
+			if v.Required {
+				missing = append(missing, v.Name)
+			} else if v.Default != "" {
+				// Apply default for optional vars
+				if err := os.Setenv(v.Name, v.Default); err != nil {
+					log.Printf("[config] warning: could not set default for %s: %v", v.Name, err)
+				}
+			}
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"server startup aborted — missing required environment variables: %s\n"+
+				"Set them in your .env file or shell environment before starting.",
+			strings.Join(missing, ", "),
+		)
+	}
+
+	return nil
+}
+
+// PrintStartupSummary logs a human-readable summary of all env vars,
+// masking secrets so they never appear in plain text in logs.
+func PrintStartupSummary() {
+	log.Println("[config] Environment variable summary:")
+	for _, v := range envVars {
+		val := os.Getenv(v.Name)
+
+		display := val
+		if display == "" {
+			display = "(not set)"
+		} else if v.Secret {
+			display = maskSecret(val)
+		}
+
+		status := "optional"
+		if v.Required {
+			status = "required"
+		}
+
+		log.Printf("[config]   %-30s = %-20s  [%s] %s",
+			v.Name, display, status, v.Description)
+	}
+}


### PR DESCRIPTION
Closes #901

Added environment variable validation at Go backend startup.

Changes:
- Created backend/go/pkg/config/env.go:
  - validateEnv() checks all required vars and logs ALL missing ones
  - PrintStartupSummary() shows all vars at startup with secrets masked
  - Optional vars get defaults applied automatically
  - No panic() — exits cleanly with log.Fatalf and code 1
- Created backend/go/pkg/auth/middleware.go:
  - Removed panic for missing SUPABASE_JWT_SECRET
  - Returns HTTP 500 with clear message instead
- Created backend/go/cmd/server/main.go:
  - Calls ValidateEnv() before starting HTTP server
  - Prints startup summary after validation passes
  - Health check endpoint at /health

Required vars: SUPABASE_JWT_SECRET, SUPABASE_URL
Optional vars: PORT (default: 8080), DATABASE_URL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend HTTP server now available with a health check endpoint.
  * JWT-based authentication middleware protects API endpoints with secure token validation.
  * Environment variable validation system provides startup diagnostics with masked secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->