### PR TITLE
refactor: add structured logging with slog to Go backend (#899)

### DIFF
--- a/backend/go/cmd/server/main.go
+++ b/backend/go/cmd/server/main.go
@@ -1,0 +1,68 @@
+// Package main is the entry point for the DraftDeckAI Go backend server.
+package main
+
+import (
+	"log"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/Muneerali199/Draftdeckai/backend/go/middleware"
+	"github.com/Muneerali199/Draftdeckai/backend/go/pkg/config"
+)
+
+func initLogger() {
+	level := slog.LevelInfo
+
+	switch os.Getenv("LOG_LEVEL") {
+	case "DEBUG":
+		level = slog.LevelDebug
+	case "WARN":
+		level = slog.LevelWarn
+	case "ERROR":
+		level = slog.LevelError
+	}
+
+	// JSON output by default — structured and parseable by Datadog/Grafana/CloudWatch
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: level,
+	})
+	slog.SetDefault(slog.New(handler))
+}
+
+func main() {
+	// Init structured logger first so all startup logs are JSON
+	initLogger()
+
+	slog.Info("starting DraftDeckAI Go backend")
+
+	// Validate all required environment variables before doing anything else.
+	if err := config.ValidateEnv(); err != nil {
+		log.Fatalf("FATAL: %v", err)
+	}
+
+	// Print startup summary with secrets masked
+	config.PrintStartupSummary()
+
+	port := os.Getenv("PORT")
+
+	mux := http.NewServeMux()
+
+	// Health check endpoint
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
+			slog.Error("health write error", slog.Any("error", err))
+		}
+	})
+
+	// Apply middleware: Recoverer → RequestLogger → mux
+	handler := middleware.Recoverer(middleware.RequestLogger(mux))
+
+	slog.Info("server listening", slog.String("port", port))
+
+	if err := http.ListenAndServe(":"+port, handler); err != nil {
+		log.Fatalf("FATAL: %v", err)
+	}
+}

--- a/backend/go/cmd/server/main.go
+++ b/backend/go/cmd/server/main.go
@@ -45,6 +45,9 @@ func main() {
 	config.PrintStartupSummary()
 
 	port := os.Getenv("PORT")
+if port == "" {
+    port = "8080"
+}
 
 	mux := http.NewServeMux()
 
@@ -58,6 +61,7 @@ func main() {
 	})
 
 	// Apply middleware: Recoverer → RequestLogger → mux
+	RequestLogger(Recoverer(mux))
 	handler := middleware.Recoverer(middleware.RequestLogger(mux))
 
 	slog.Info("server listening", slog.String("port", port))

--- a/backend/go/go.mod
+++ b/backend/go/go.mod
@@ -1,0 +1,8 @@
+module github.com/Muneerali199/Draftdeckai/backend/go
+
+go 1.22
+
+require (
+	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/google/uuid v1.6.0
+)

--- a/backend/go/go.mod
+++ b/backend/go/go.mod
@@ -3,6 +3,6 @@ module github.com/Muneerali199/Draftdeckai/backend/go
 go 1.22
 
 require (
-	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 )

--- a/backend/go/middleware/middleware.go
+++ b/backend/go/middleware/middleware.go
@@ -1,0 +1,94 @@
+// Package middleware provides HTTP middleware for the DraftDeckAI Go backend.
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// contextKey is used to store values in request context safely.
+type contextKey string
+
+const RequestIDKey contextKey = "request_id"
+
+// GetRequestID retrieves the request ID from context.
+func GetRequestID(ctx context.Context) string {
+	if id, ok := ctx.Value(RequestIDKey).(string); ok {
+		return id
+	}
+	return "unknown"
+}
+
+// responseWriter wraps http.ResponseWriter to capture status code.
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func newResponseWriter(w http.ResponseWriter) *responseWriter {
+	return &responseWriter{w, http.StatusOK}
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// RequestLogger is a chi-compatible middleware that logs structured
+// request/response data using slog. Every log line includes:
+// method, path, status, duration_ms, request_id.
+// JWT tokens and Authorization headers are never logged.
+func RequestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		// Generate unique request ID
+		requestID := uuid.NewString()
+		ctx := context.WithValue(r.Context(), RequestIDKey, requestID)
+		r = r.WithContext(ctx)
+
+		// Set request ID in response header for client tracing
+		w.Header().Set("X-Request-ID", requestID)
+
+		// Wrap writer to capture status code
+		wrapped := newResponseWriter(w)
+
+		next.ServeHTTP(wrapped, r)
+
+		duration := time.Since(start)
+
+		slog.Info("request",
+			slog.String("request_id", requestID),
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", wrapped.statusCode),
+			slog.Int64("duration_ms", duration.Milliseconds()),
+			slog.String("remote_addr", r.RemoteAddr),
+			slog.String("user_agent", r.UserAgent()),
+		)
+	})
+}
+
+// Recoverer is a middleware that recovers from panics and logs them
+// as structured errors instead of crashing the server.
+func Recoverer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				requestID := GetRequestID(r.Context())
+				slog.Error("panic recovered",
+					slog.String("request_id", requestID),
+					slog.String("method", r.Method),
+					slog.String("path", r.URL.Path),
+					slog.Any("panic", rec),
+				)
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/go/pkg/auth/middleware.go
+++ b/backend/go/pkg/auth/middleware.go
@@ -1,0 +1,67 @@
+// Package auth provides JWT authentication middleware for the Go backend.
+package auth
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// AuthMiddleware validates the Supabase JWT token in the Authorization header.
+// Uses structured logging — JWT tokens are NEVER logged.
+func AuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secret := os.Getenv("SUPABASE_JWT_SECRET")
+		if secret == "" {
+			slog.Error("auth middleware misconfigured",
+				slog.String("reason", "SUPABASE_JWT_SECRET not set"),
+				slog.String("path", r.URL.Path),
+			)
+			http.Error(w,
+				"server configuration error: SUPABASE_JWT_SECRET is not set",
+				http.StatusInternalServerError,
+			)
+			return
+		}
+
+		authHeader := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			slog.Warn("auth failed: missing bearer token",
+				slog.String("path", r.URL.Path),
+				slog.String("remote_addr", r.RemoteAddr),
+			)
+			http.Error(w, "missing or invalid Authorization header", http.StatusUnauthorized)
+			return
+		}
+
+		// NOTE: tokenStr is intentionally NOT logged to avoid leaking secrets
+		tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+
+		token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
+			return []byte(secret), nil
+		})
+
+		if err != nil || !token.Valid {
+			slog.Warn("auth failed: invalid token",
+				slog.String("path", r.URL.Path),
+				slog.String("remote_addr", r.RemoteAddr),
+				slog.String("error", err.Error()),
+			)
+			http.Error(w, "invalid or expired token", http.StatusUnauthorized)
+			return
+		}
+
+		slog.Debug("auth successful",
+			slog.String("path", r.URL.Path),
+		)
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/go/pkg/auth/middleware.go
+++ b/backend/go/pkg/auth/middleware.go
@@ -21,8 +21,8 @@ func AuthMiddleware(next http.Handler) http.Handler {
 				slog.String("reason", "SUPABASE_JWT_SECRET not set"),
 				slog.String("path", r.URL.Path),
 			)
-			http.Error(w,
-				"server configuration error: SUPABASE_JWT_SECRET is not set",
+			http.Error(w,"internal server error",
+				
 				http.StatusInternalServerError,
 			)
 			return
@@ -52,7 +52,12 @@ func AuthMiddleware(next http.Handler) http.Handler {
 			slog.Warn("auth failed: invalid token",
 				slog.String("path", r.URL.Path),
 				slog.String("remote_addr", r.RemoteAddr),
-				slog.String("error", err.Error()),
+				slog.String("error", func() string {
+    if err != nil {
+        return err.Error()
+    }
+    return "token invalid"
+}()),
 			)
 			http.Error(w, "invalid or expired token", http.StatusUnauthorized)
 			return


### PR DESCRIPTION
Closes #899

Added structured JSON logging using Go 1.21's built-in log/slog package.

Changes:
- backend/go/middleware/middleware.go:
  - RequestLogger middleware logs method, path, status, duration_ms, request_id
  - Recoverer middleware catches panics and logs as structured errors
  - JWT tokens and Authorization headers never logged
- backend/go/cmd/server/main.go:
  - initLogger() sets up JSON handler with level from LOG_LEVEL env var
  - Supports DEBUG/INFO/WARN/ERROR levels
  - All startup logs now structured JSON
- backend/go/pkg/auth/middleware.go:
  - Replaced log.Printf with slog structured calls
  - Auth failures logged as WARN with path and remote_addr
  - Token strings never appear in logs

Log levels: LOG_LEVEL=DEBUG|INFO|WARN|ERROR (default: INFO)
Output: JSON by default, parseable by Datadog/Grafana/CloudWatch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /health endpoint for server status monitoring
  * Added JWT authentication validation for API requests

* **Improvements**
  * Structured JSON logging to stdout and masked startup summary
  * Automatic panic recovery returning 500 instead of crashing
  * Per-request tracking with request IDs (exposed via response header) and single-line request logs including method/path/status/duration

* **Chores**
  * Initialized Go backend module and dependencies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->