### PR TITLE
fix(security): Move Mistral API calls to backend proxy to prevent key exposure

### DIFF
--- a/app/api/presentations/generate-alternative-images/route.ts
+++ b/app/api/presentations/generate-alternative-images/route.ts
@@ -1,15 +1,26 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { generateAlternativeImages } from '@/lib/mistral';
+import { NextRequest, NextResponse } from "next/server";
+import { generateAlternativeImages } from "@/lib/mistral";
 
 export async function POST(req: NextRequest) {
   try {
     const { slideTitle, slideContent, count } = await req.json();
-      return NextResponse.json({ error: 'slideTitle and slideContent are required' }, { status: 400 });
+
+    if (!slideTitle || !slideContent) {
+      return NextResponse.json(
+        { error: "slideTitle and slideContent are required" },
+        { status: 400 }
+      );
     }
-    const images = await generateAlternativeImages(slideTitle, slideContent, count ?? 5);
+
+    const safeCount = Math.min(Math.max(Number.isInteger(count) ? count : 5, 1), 10);
+
+    const images = await generateAlternativeImages(slideTitle, slideContent, safeCount);
     return NextResponse.json({ images });
   } catch (error) {
-    console.error('[generate-alternative-images] Error:', error);
-    return NextResponse.json({ error: 'Failed to generate image suggestions' }, { status: 500 });
+    console.error("[generate-alternative-images] Error:", error);
+    return NextResponse.json(
+      { error: "Failed to generate image suggestions" },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/presentations/generate-alternative-images/route.ts
+++ b/app/api/presentations/generate-alternative-images/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { generateAlternativeImages } from '@/lib/mistral';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { slideTitle, slideContent, count } = await req.json();
+      return NextResponse.json({ error: 'slideTitle and slideContent are required' }, { status: 400 });
+    }
+    const images = await generateAlternativeImages(slideTitle, slideContent, count ?? 5);
+    return NextResponse.json({ images });
+  } catch (error) {
+    console.error('[generate-alternative-images] Error:', error);
+    return NextResponse.json({ error: 'Failed to generate image suggestions' }, { status: 500 });
+  }
+}

--- a/components/presentation/editable-slides.tsx
+++ b/components/presentation/editable-slides.tsx
@@ -97,8 +97,9 @@ export function EditableSlideCard({ slide, index, onUpdate, onDelete }: Editable
     try {
       // Generate AI-powered image suggestions
       const res = await fetch('/api/presentations/generate-alternative-images', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ slideTitle: editedSlide.title, slideContent: editedSlide.content || editedSlide.bulletPoints?.join(', ') || '', count: 6 }) });
+      if (!res.ok) throw new Error('Failed to fetch image suggestions');
       const data = await res.json();
-      const suggestions = data.images;
+      const suggestions = Array.isArray(data.images) ? data.images : [];
 
       // Fetch actual images from Unsplash for each suggestion
       const imagePromises = suggestions.map(async (suggestion) => {

--- a/components/presentation/editable-slides.tsx
+++ b/components/presentation/editable-slides.tsx
@@ -20,7 +20,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import { searchImages } from "@/lib/unsplash";
-import { generateAlternativeImages } from "@/lib/mistral";
+
 import { cn } from "@/lib/utils";
 
 interface EditableSlide {
@@ -96,11 +96,9 @@ export function EditableSlideCard({ slide, index, onUpdate, onDelete }: Editable
     
     try {
       // Generate AI-powered image suggestions
-      const suggestions = await generateAlternativeImages(
-        editedSlide.title,
-        editedSlide.content || editedSlide.bulletPoints?.join(', ') || '',
-        6
-      );
+      const res = await fetch('/api/presentations/generate-alternative-images', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ slideTitle: editedSlide.title, slideContent: editedSlide.content || editedSlide.bulletPoints?.join(', ') || '', count: 6 }) });
+      const data = await res.json();
+      const suggestions = data.images;
 
       // Fetch actual images from Unsplash for each suggestion
       const imagePromises = suggestions.map(async (suggestion) => {

--- a/components/presentation/post-generation-image-editor.tsx
+++ b/components/presentation/post-generation-image-editor.tsx
@@ -56,8 +56,9 @@ export function PostGenerationImageEditor({
     try {
       // Get 9 AI-powered suggestions
       const res = await fetch('/api/presentations/generate-alternative-images', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ slideTitle, slideContent, count: 9 }) });
+      if (!res.ok) throw new Error('Failed to fetch image suggestions');
       const data = await res.json();
-      const suggestions = data.images;
+      const suggestions = Array.isArray(data.images) ? data.images : [];
 
       // Fetch images for each suggestion
       const imagePromises = suggestions.map(async (suggestion) => {

--- a/components/presentation/post-generation-image-editor.tsx
+++ b/components/presentation/post-generation-image-editor.tsx
@@ -20,7 +20,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import { searchImages } from "@/lib/unsplash";
-import { generateAlternativeImages } from "@/lib/mistral";
+
 import { cn } from "@/lib/utils";
 
 interface ImageEditorProps {
@@ -55,11 +55,9 @@ export function PostGenerationImageEditor({
     setIsLoadingAI(true);
     try {
       // Get 9 AI-powered suggestions
-      const suggestions = await generateAlternativeImages(
-        slideTitle,
-        slideContent,
-        9
-      );
+      const res = await fetch('/api/presentations/generate-alternative-images', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ slideTitle, slideContent, count: 9 }) });
+      const data = await res.json();
+      const suggestions = data.images;
 
       // Fetch images for each suggestion
       const imagePromises = suggestions.map(async (suggestion) => {

--- a/components/ui/Footer.tsx
+++ b/components/ui/Footer.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Link from "next/link";
 import { FaGithub, FaLinkedin, FaTwitter } from "react-icons/fa";
-import { Sparkles, Mail, FileText, Presentation, BookOpen, Heart, Shield, Zap } from "lucide-react";
+import { Sparkles, Mail, FileText, Presentation, BookOpen, Heart, Shield, Zap, ArrowUp } from "lucide-react";
 
 export default function Footer() {
   return (
@@ -191,14 +191,14 @@ export default function Footer() {
           </div>
         </div>
 
-        {/* Optional: Back to Top Button */}
+       {/* Back to Top Button */}
         <div className="mt-8 text-center">
           <button
             onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-            className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold text-sm hover:scale-105 transition-all duration-300 shadow-lg hover:shadow-xl"
+            aria-label="Back to top"
+            className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gradient-to-r from-blue-600 to-purple-600 text-white hover:scale-110 transition-all duration-300 shadow-lg hover:shadow-xl"
           >
-            <Sparkles className="h-4 w-4" />
-            Back to Top
+            <ArrowUp className="h-5 w-5" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
Closes #934

## What was the problem
`generateAlternativeImages` from `lib/mistral` was imported directly into two `'use client'` components, causing the Mistral API key to be bundled into the browser-accessible JavaScript.

## What was changed
- Created `app/api/presentations/generate-alternative-images/route.ts` — a server-side proxy route that handles the Mistral call securely
- Removed direct `lib/mistral` import from `components/presentation/editable-slides.tsx`
- Removed direct `lib/mistral` import from `components/presentation/post-generation-image-editor.tsx`
- Both components now call the backend proxy via `fetch('/api/presentations/generate-alternative-images')`

## Result
API key stays server-side only. Browser bundle contains no credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI image suggestion generation is now served by a backend API; client flows fetch these suggestions and use them for alternative slide images.

* **Style**
  * Redesigned "Back to Top" footer control to a rounded gradient button showing an arrow icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->