### PR TITLE
Test Stripe webhook idempotency

### DIFF
--- a/__tests__/api/stripe-webhook.test.ts
+++ b/__tests__/api/stripe-webhook.test.ts
@@ -43,6 +43,7 @@ function makeBuilder(): Builder {
     "select",
     "eq",
     "single",
+    "maybeSingle",
     "upsert",
     "update",
     "insert",
@@ -58,6 +59,7 @@ function makeSupabase() {
     "subscription_plans",
     "user_subscriptions",
     "payment_history",
+    "stripe_webhook_events",
   ]) {
     tableBuilders.set(table, makeBuilder());
   }
@@ -182,6 +184,46 @@ describe("Stripe webhook route", () => {
         status: "active",
       }),
     );
+    expect(
+      supabase.tableBuilders.get("stripe_webhook_events")!.insert,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripe_event_id: "evt_checkout.session.completed",
+        event_type: "checkout.session.completed",
+      }),
+    );
+  });
+
+  it("acknowledges duplicate events without applying database writes again", async () => {
+    const { route, supabase } = await loadRoute();
+    constructEvent.mockReturnValue(
+      eventFixture("checkout.session.completed", {
+        metadata: { userId: "user-1" },
+        customer: "cus_123",
+        subscription: "sub_123",
+      }),
+    );
+    supabase.tableBuilders
+      .get("stripe_webhook_events")!
+      .maybeSingle.mockResolvedValue({
+        data: { stripe_event_id: "evt_checkout.session.completed" },
+        error: null,
+      });
+
+    const response = await route.POST(makeRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      received: true,
+      duplicate: true,
+    });
+    expect(retrieveSubscription).not.toHaveBeenCalled();
+    expect(
+      supabase.tableBuilders.get("user_subscriptions")!.upsert,
+    ).not.toHaveBeenCalled();
+    expect(
+      supabase.tableBuilders.get("stripe_webhook_events")!.insert,
+    ).not.toHaveBeenCalled();
   });
 
   it("upserts current subscription details for customer.subscription.updated", async () => {
@@ -241,12 +283,10 @@ describe("Stripe webhook route", () => {
         description: "Monthly plan",
       }),
     );
-    supabase.tableBuilders
-      .get("user_subscriptions")!
-      .single.mockResolvedValue({
-        data: { user_id: "user-1", id: "usub_1" },
-        error: null,
-      });
+    supabase.tableBuilders.get("user_subscriptions")!.single.mockResolvedValue({
+      data: { user_id: "user-1", id: "usub_1" },
+      error: null,
+    });
     supabase.tableBuilders
       .get("payment_history")!
       .insert.mockResolvedValue({ error: null });
@@ -279,12 +319,10 @@ describe("Stripe webhook route", () => {
         payment_settings: { payment_method_types: ["card"] },
       }),
     );
-    supabase.tableBuilders
-      .get("user_subscriptions")!
-      .single.mockResolvedValue({
-        data: { user_id: "user-1", id: "usub_1" },
-        error: null,
-      });
+    supabase.tableBuilders.get("user_subscriptions")!.single.mockResolvedValue({
+      data: { user_id: "user-1", id: "usub_1" },
+      error: null,
+    });
     supabase.tableBuilders
       .get("payment_history")!
       .insert.mockResolvedValue({ error: null });
@@ -316,6 +354,8 @@ describe("Stripe webhook route", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ received: true });
-    expect(supabase.from).not.toHaveBeenCalled();
+    expect(supabase.from).not.toHaveBeenCalledWith("subscription_plans");
+    expect(supabase.from).not.toHaveBeenCalledWith("user_subscriptions");
+    expect(supabase.from).not.toHaveBeenCalledWith("payment_history");
   });
 });

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,21 +1,21 @@
-import { logger } from '@/lib/logger';
-import { headers } from 'next/headers';
-import { NextRequest, NextResponse } from 'next/server';
-import { stripe } from '@/lib/stripe';
-import { createClient } from '@supabase/supabase-js';
-import Stripe from 'stripe';
+import { logger } from "@/lib/logger";
+import { headers } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { stripe } from "@/lib/stripe";
+import { createClient } from "@supabase/supabase-js";
+import Stripe from "stripe";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
 
 export async function POST(req: Request) {
   const body = await req.text();
-  const signature = headers().get('stripe-signature');
+  const signature = headers().get("stripe-signature");
 
   if (!signature) {
-    return NextResponse.json({ error: 'No signature' }, { status: 400 });
+    return NextResponse.json({ error: "No signature" }, { status: 400 });
   }
 
   let event: Stripe.Event;
@@ -24,70 +24,141 @@ export async function POST(req: Request) {
     event = stripe.webhooks.constructEvent(
       body,
       signature,
-      process.env.STRIPE_WEBHOOK_SECRET!
+      process.env.STRIPE_WEBHOOK_SECRET!,
     );
   } catch (err: any) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, '⚠️ Webhook signature verification failed:', err.message);
-    return NextResponse.json({ error: 'Webhook signature verification failed' }, { status: 400 });
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "⚠️ Webhook signature verification failed:",
+      err.message,
+    );
+    return NextResponse.json(
+      { error: "Webhook signature verification failed" },
+      { status: 400 },
+    );
   }
 
-  logger.info({ route: 'app/api/webhooks/stripe/route.ts' }, '✅ Webhook event received:', event.type);
+  logger.info(
+    { route: "app/api/webhooks/stripe/route.ts" },
+    "✅ Webhook event received:",
+    event.type,
+  );
 
   try {
+    const shouldProcessEvent = await shouldProcessWebhookEvent(event);
+    if (!shouldProcessEvent) {
+      return NextResponse.json({ received: true, duplicate: true });
+    }
+
     switch (event.type) {
-      case 'checkout.session.completed': {
+      case "checkout.session.completed": {
         const session = event.data.object as Stripe.Checkout.Session;
         await handleCheckoutSessionCompleted(session);
         break;
       }
 
-      case 'customer.subscription.created':
-      case 'customer.subscription.updated': {
+      case "customer.subscription.created":
+      case "customer.subscription.updated": {
         const subscription = event.data.object as Stripe.Subscription;
         await handleSubscriptionUpdate(subscription);
         break;
       }
 
-      case 'customer.subscription.deleted': {
+      case "customer.subscription.deleted": {
         const subscription = event.data.object as Stripe.Subscription;
         await handleSubscriptionDeleted(subscription);
         break;
       }
 
-      case 'invoice.payment_succeeded': {
+      case "invoice.payment_succeeded": {
         const invoice = event.data.object as Stripe.Invoice;
         await handleInvoicePaymentSucceeded(invoice);
         break;
       }
 
-      case 'invoice.payment_failed': {
+      case "invoice.payment_failed": {
         const invoice = event.data.object as Stripe.Invoice;
         await handleInvoicePaymentFailed(invoice);
         break;
       }
 
       default:
-        logger.info({ route: 'app/api/webhooks/stripe/route.ts' }, `Unhandled event type: ${event.type}`);
+        logger.info(
+          { route: "app/api/webhooks/stripe/route.ts" },
+          `Unhandled event type: ${event.type}`,
+        );
     }
+
+    await recordProcessedWebhookEvent(event);
 
     return NextResponse.json({ received: true });
   } catch (error) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'Error processing webhook:', error);
-    return NextResponse.json({ error: 'Webhook processing failed' }, { status: 500 });
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "Error processing webhook:",
+      error,
+    );
+    return NextResponse.json(
+      { error: "Webhook processing failed" },
+      { status: 500 },
+    );
   }
 }
 
-async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) {
+async function shouldProcessWebhookEvent(event: Stripe.Event) {
+  const { data, error } = await supabase
+    .from("stripe_webhook_events")
+    .select("stripe_event_id")
+    .eq("stripe_event_id", event.id)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  if (data) {
+    logger.info(
+      { route: "app/api/webhooks/stripe/route.ts", stripeEventId: event.id },
+      "Duplicate Stripe webhook event skipped",
+    );
+    return false;
+  }
+
+  return true;
+}
+
+async function recordProcessedWebhookEvent(event: Stripe.Event) {
+  const { error } = await supabase.from("stripe_webhook_events").insert({
+    stripe_event_id: event.id,
+    event_type: event.type,
+    processed_at: new Date().toISOString(),
+  });
+
+  if (error) {
+    throw error;
+  }
+}
+
+async function handleCheckoutSessionCompleted(
+  session: Stripe.Checkout.Session,
+) {
   const userId = session.metadata?.userId;
   const customerId = session.customer as string;
   const subscriptionId = session.subscription as string;
 
   if (!userId) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'No userId in session metadata');
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "No userId in session metadata",
+    );
     return;
   }
 
-  logger.info({ route: 'app/api/webhooks/stripe/route.ts' }, '💰 Checkout completed for user:', userId);
+  logger.info(
+    { route: "app/api/webhooks/stripe/route.ts" },
+    "💰 Checkout completed for user:",
+    userId,
+  );
 
   // Get subscription details
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
@@ -95,34 +166,48 @@ async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) 
 
   // Get plan from database
   const { data: plan } = await supabase
-    .from('subscription_plans')
-    .select('id')
-    .eq('stripe_price_id', priceId)
+    .from("subscription_plans")
+    .select("id")
+    .eq("stripe_price_id", priceId)
     .single();
 
   if (!plan) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'No plan found for price:', priceId);
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "No plan found for price:",
+      priceId,
+    );
     return;
   }
 
   // Create or update user subscription
-  const { error } = await supabase
-    .from('user_subscriptions')
-    .upsert({
-      user_id: userId,
-      plan_id: plan.id,
-      stripe_customer_id: customerId,
-      stripe_subscription_id: subscriptionId,
-      status: subscription.status,
-      current_period_start: new Date(subscription.current_period_start * 1000).toISOString(),
-      current_period_end: new Date(subscription.current_period_end * 1000).toISOString(),
-      cancel_at_period_end: subscription.cancel_at_period_end,
-      trial_start: subscription.trial_start ? new Date(subscription.trial_start * 1000).toISOString() : null,
-      trial_end: subscription.trial_end ? new Date(subscription.trial_end * 1000).toISOString() : null,
-    });
+  const { error } = await supabase.from("user_subscriptions").upsert({
+    user_id: userId,
+    plan_id: plan.id,
+    stripe_customer_id: customerId,
+    stripe_subscription_id: subscriptionId,
+    status: subscription.status,
+    current_period_start: new Date(
+      subscription.current_period_start * 1000,
+    ).toISOString(),
+    current_period_end: new Date(
+      subscription.current_period_end * 1000,
+    ).toISOString(),
+    cancel_at_period_end: subscription.cancel_at_period_end,
+    trial_start: subscription.trial_start
+      ? new Date(subscription.trial_start * 1000).toISOString()
+      : null,
+    trial_end: subscription.trial_end
+      ? new Date(subscription.trial_end * 1000).toISOString()
+      : null,
+  });
 
   if (error) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'Error updating subscription:', error);
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "Error updating subscription:",
+      error,
+    );
   }
 }
 
@@ -130,42 +215,61 @@ async function handleSubscriptionUpdate(subscription: Stripe.Subscription) {
   const userId = subscription.metadata?.userId;
 
   if (!userId) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'No userId in subscription metadata');
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "No userId in subscription metadata",
+    );
     return;
   }
 
-  logger.info({ route: 'app/api/webhooks/stripe/route.ts' }, '🔄 Subscription updated for user:', userId);
+  logger.info(
+    { route: "app/api/webhooks/stripe/route.ts" },
+    "🔄 Subscription updated for user:",
+    userId,
+  );
 
   const priceId = subscription.items.data[0].price.id;
 
   // Get plan from database
   const { data: plan } = await supabase
-    .from('subscription_plans')
-    .select('id')
-    .eq('stripe_price_id', priceId)
+    .from("subscription_plans")
+    .select("id")
+    .eq("stripe_price_id", priceId)
     .single();
 
   if (!plan) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'No plan found for price:', priceId);
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "No plan found for price:",
+      priceId,
+    );
     return;
   }
 
   // Update user subscription
-  const { error } = await supabase
-    .from('user_subscriptions')
-    .upsert({
-      user_id: userId,
-      plan_id: plan.id,
-      stripe_subscription_id: subscription.id,
-      status: subscription.status,
-      current_period_start: new Date(subscription.current_period_start * 1000).toISOString(),
-      current_period_end: new Date(subscription.current_period_end * 1000).toISOString(),
-      cancel_at_period_end: subscription.cancel_at_period_end,
-      canceled_at: subscription.canceled_at ? new Date(subscription.canceled_at * 1000).toISOString() : null,
-    });
+  const { error } = await supabase.from("user_subscriptions").upsert({
+    user_id: userId,
+    plan_id: plan.id,
+    stripe_subscription_id: subscription.id,
+    status: subscription.status,
+    current_period_start: new Date(
+      subscription.current_period_start * 1000,
+    ).toISOString(),
+    current_period_end: new Date(
+      subscription.current_period_end * 1000,
+    ).toISOString(),
+    cancel_at_period_end: subscription.cancel_at_period_end,
+    canceled_at: subscription.canceled_at
+      ? new Date(subscription.canceled_at * 1000).toISOString()
+      : null,
+  });
 
   if (error) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'Error updating subscription:', error);
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "Error updating subscription:",
+      error,
+    );
   }
 }
 
@@ -173,23 +277,34 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
   const userId = subscription.metadata?.userId;
 
   if (!userId) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'No userId in subscription metadata');
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "No userId in subscription metadata",
+    );
     return;
   }
 
-  logger.info({ route: 'app/api/webhooks/stripe/route.ts' }, '❌ Subscription deleted for user:', userId);
+  logger.info(
+    { route: "app/api/webhooks/stripe/route.ts" },
+    "❌ Subscription deleted for user:",
+    userId,
+  );
 
   // Update subscription status to canceled
   const { error } = await supabase
-    .from('user_subscriptions')
+    .from("user_subscriptions")
     .update({
-      status: 'canceled',
+      status: "canceled",
       canceled_at: new Date().toISOString(),
     })
-    .eq('user_id', userId);
+    .eq("user_id", userId);
 
   if (error) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'Error canceling subscription:', error);
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "Error canceling subscription:",
+      error,
+    );
   }
 }
 
@@ -199,36 +314,47 @@ async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
 
   // Get user from customer ID
   const { data: subscription } = await supabase
-    .from('user_subscriptions')
-    .select('user_id, id')
-    .eq('stripe_customer_id', customerId)
+    .from("user_subscriptions")
+    .select("user_id, id")
+    .eq("stripe_customer_id", customerId)
     .single();
 
   if (!subscription) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'No subscription found for customer:', customerId);
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "No subscription found for customer:",
+      customerId,
+    );
     return;
   }
 
-  logger.info({ route: 'app/api/webhooks/stripe/route.ts' }, '✅ Payment succeeded for user:', subscription.user_id);
+  logger.info(
+    { route: "app/api/webhooks/stripe/route.ts" },
+    "✅ Payment succeeded for user:",
+    subscription.user_id,
+  );
 
   // Record payment in history
-  const { error } = await supabase
-    .from('payment_history')
-    .insert({
-      user_id: subscription.user_id,
-      subscription_id: subscription.id,
-      stripe_payment_intent_id: invoice.payment_intent as string,
-      stripe_invoice_id: invoice.id,
-      amount: invoice.amount_paid / 100, // Convert from cents
-      currency: invoice.currency,
-      status: 'succeeded',
-      payment_method: invoice.payment_settings?.payment_method_types?.[0] || 'card',
-      description: invoice.description || 'Subscription payment',
-      receipt_url: invoice.hosted_invoice_url,
-    });
+  const { error } = await supabase.from("payment_history").insert({
+    user_id: subscription.user_id,
+    subscription_id: subscription.id,
+    stripe_payment_intent_id: invoice.payment_intent as string,
+    stripe_invoice_id: invoice.id,
+    amount: invoice.amount_paid / 100, // Convert from cents
+    currency: invoice.currency,
+    status: "succeeded",
+    payment_method:
+      invoice.payment_settings?.payment_method_types?.[0] || "card",
+    description: invoice.description || "Subscription payment",
+    receipt_url: invoice.hosted_invoice_url,
+  });
 
   if (error) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'Error recording payment:', error);
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "Error recording payment:",
+      error,
+    );
   }
 }
 
@@ -237,44 +363,59 @@ async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
 
   // Get user from customer ID
   const { data: subscription } = await supabase
-    .from('user_subscriptions')
-    .select('user_id, id')
-    .eq('stripe_customer_id', customerId)
+    .from("user_subscriptions")
+    .select("user_id, id")
+    .eq("stripe_customer_id", customerId)
     .single();
 
   if (!subscription) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'No subscription found for customer:', customerId);
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "No subscription found for customer:",
+      customerId,
+    );
     return;
   }
 
-  logger.info({ route: 'app/api/webhooks/stripe/route.ts' }, '❌ Payment failed for user:', subscription.user_id);
+  logger.info(
+    { route: "app/api/webhooks/stripe/route.ts" },
+    "❌ Payment failed for user:",
+    subscription.user_id,
+  );
 
   // Update subscription status
   const { error: subError } = await supabase
-    .from('user_subscriptions')
-    .update({ status: 'past_due' })
-    .eq('user_id', subscription.user_id);
+    .from("user_subscriptions")
+    .update({ status: "past_due" })
+    .eq("user_id", subscription.user_id);
 
   if (subError) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'Error updating subscription status:', subError);
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "Error updating subscription status:",
+      subError,
+    );
   }
 
   // Record failed payment
-  const { error } = await supabase
-    .from('payment_history')
-    .insert({
-      user_id: subscription.user_id,
-      subscription_id: subscription.id,
-      stripe_payment_intent_id: invoice.payment_intent as string,
-      stripe_invoice_id: invoice.id,
-      amount: invoice.amount_due / 100,
-      currency: invoice.currency,
-      status: 'failed',
-      payment_method: invoice.payment_settings?.payment_method_types?.[0] || 'card',
-      description: invoice.description || 'Subscription payment (failed)',
-    });
+  const { error } = await supabase.from("payment_history").insert({
+    user_id: subscription.user_id,
+    subscription_id: subscription.id,
+    stripe_payment_intent_id: invoice.payment_intent as string,
+    stripe_invoice_id: invoice.id,
+    amount: invoice.amount_due / 100,
+    currency: invoice.currency,
+    status: "failed",
+    payment_method:
+      invoice.payment_settings?.payment_method_types?.[0] || "card",
+    description: invoice.description || "Subscription payment (failed)",
+  });
 
   if (error) {
-    logger.error({ route: 'app/api/webhooks/stripe/route.ts' }, 'Error recording failed payment:', error);
+    logger.error(
+      { route: "app/api/webhooks/stripe/route.ts" },
+      "Error recording failed payment:",
+      error,
+    );
   }
 }

--- a/supabase/migrations/20260610000000_add_stripe_webhook_events.sql
+++ b/supabase/migrations/20260610000000_add_stripe_webhook_events.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS public.stripe_webhook_events (
+  stripe_event_id VARCHAR(255) PRIMARY KEY,
+  event_type VARCHAR(255) NOT NULL,
+  processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_webhook_events_processed_at
+  ON public.stripe_webhook_events(processed_at);
+
+ALTER TABLE public.stripe_webhook_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role can manage stripe webhook events"
+  ON public.stripe_webhook_events
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');


### PR DESCRIPTION
## Linked Issue\nCloses #948\n\n## Summary\n- Adds a Supabase-backed Stripe webhook event ledger for duplicate delivery detection.\n- Skips duplicate Stripe events before applying subscription or payment database writes.\n- Adds a migration for processed Stripe webhook events.\n- Extends the webhook integration test suite with duplicate-event/idempotency coverage.\n\n## Validation\n- npm test -- --runTestsByPath __tests__/api/stripe-webhook.test.ts --runInBand\n- npx eslint app/api/webhooks/stripe/route.ts __tests__/api/stripe-webhook.test.ts\n- Pre-push hook: typecheck:changed and full Jest suite passed, 25 suites / 387 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook events now include deduplication to prevent processing duplicate requests.
  * Added signature verification for incoming Stripe webhooks.
  * Payment transactions are now tracked with success and failure history.

* **Bug Fixes**
  * Subscription status is now updated to past_due when payment processing fails.
  * Enhanced logging for webhook event processing and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->