### PR TITLE
fix(sw): add isReplaying lock to replayQueuedRequests

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -93,22 +93,30 @@ async function deleteQueuedRequest(id) {
   await runStoreTransaction("readwrite", (store) => store.delete(id));
 }
 
+let isReplaying = false;
+
 async function replayQueuedRequests() {
-  const requests = await getQueuedRequests();
+  if (isReplaying) return;
+  isReplaying = true;
+  try {
+    const requests = await getQueuedRequests();
 
-  for (const queuedRequest of requests) {
-    const response = await fetch(queuedRequest.url, {
-      method: queuedRequest.method,
-      headers: queuedRequest.headers,
-      body: queuedRequest.body,
-      credentials: "include",
-    });
+    for (const queuedRequest of requests) {
+      const response = await fetch(queuedRequest.url, {
+        method: queuedRequest.method,
+        headers: queuedRequest.headers,
+        body: queuedRequest.body,
+        credentials: "include",
+      });
 
-    if (!response.ok) {
-      throw new Error(`Queued request failed with ${response.status}`);
+      if (!response.ok) {
+        throw new Error(`Queued request failed with ${response.status}`);
+      }
+
+      await deleteQueuedRequest(queuedRequest.id);
     }
-
-    await deleteQueuedRequest(queuedRequest.id);
+  } finally {
+    isReplaying = false;
   }
 }
 


### PR DESCRIPTION
# Description

This PR implements concurrency control (an `isReplaying` lock/guard) in the offline queue service worker (`worker/index.js`). 

Without this control, multiple simultaneous network reconnect events or parallel synchronization triggers could attempt to execute `replayQueuedRequests()` concurrently. This would result in race conditions, duplicate database operations, and duplicate HTTP requests to the backend. This logic has been split from PR #980 into this dedicated pull request as requested by `@Muneerali199` to isolate review concerns.

Fixes # (Split from PR #980)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes Made

- **Service Worker Concurrency Guard**: Added a module-scoped `isReplaying` boolean state flag in [worker/index.js](file:///D:/MyProject/Contribution/Draftdeckai/worker/index.js).
- **Exception Safety**: Wrapped the database-fetching, request replaying loop, and item deletions in a `try-finally` block to ensure the `isReplaying` lock is reliably released under both successful and failed execution states.
- **Early Abort**: Return early if `replayQueuedRequests()` is invoked while a cycle is already active.

## Dependencies

- None (No new dependencies).

# How Has This Been Tested?

- [x] Test A: Ran the project workspace pre-push hooks verifying that all 25 Jest test suites (386 unit tests total) pass successfully locally.
- [x] Test B: Verified project builds correctly under development mode.

## Add Screenshots
N/A (This is a background service worker logic change, there are no UI updates).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have tested my changes across major browsers/devices
- [x] I have tested my changes in development mode (`npm run dev`)
- [x] I have successfully run `npm run lint` and resolved all warnings/errors
- [x] I have successfully run `npm run typecheck` and resolved all TypeScript errors
- [x] New and existing unit tests pass locally with my changes (`npx jest`)
- [x] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where offline request retries could be processed concurrently, preventing race conditions and ensuring reliable sequential processing of queued requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->