### PR TITLE
feat: replace keyword search with PostgreSQL full-text search (#854)

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,38 +1,7 @@
 import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server'
-import { searchDocuments, suggestCorrection } from '@/lib/search-engine'
-import type { SearchableDocument } from '@/lib/search-engine'
+import { suggestCorrection } from '@/lib/search-engine'
 import { createRoute } from '@/lib/supabase/server'
-
-// Recursive helper to extract all nested string contents from JSON fields
-function extractTextFromContent(content: any): string {
-  if (!content) return ''
-  if (typeof content === 'string') return content
-  if (typeof content === 'number' || typeof content === 'boolean') return String(content)
-
-  const texts: string[] = []
-
-  if (Array.isArray(content)) {
-    for (const item of content) {
-      texts.push(extractTextFromContent(item))
-    }
-    return texts.join(' ')
-  }
-
-  if (typeof content === 'object') {
-    for (const key in content) {
-      const val = content[key]
-      if (typeof val === 'string') {
-        texts.push(val)
-      } else if (Array.isArray(val) || typeof val === 'object') {
-        texts.push(extractTextFromContent(val))
-      }
-    }
-    return texts.join(' ')
-  }
-
-  return ''
-}
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -61,122 +30,56 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ results: [], suggestion: null, total: 0 })
     }
 
-    const allMappedDocs: SearchableDocument[] = []
+    // Call the PostgreSQL full-text search RPC function
+    const { data: rpcResults, error: rpcError } = await supabase.rpc('search_user_content', {
+      p_user_id: user.id,
+      p_query: query,
+      p_category: category,
+      p_limit: limit,
+      p_offset: offset
+    });
 
-    // 1. Fetch user documents from 'documents' table if category is not 'template'
-    if (category !== 'template') {
-      let docQuery = supabase
+    if (rpcError) {
+      logger.error({ route: 'app/api/search/route.ts' }, 'RPC search_user_content error:', rpcError)
+      return NextResponse.json(
+        { error: 'Failed to search documents' },
+        { status: 500 }
+      )
+    }
+
+    // Map RPC results to expected format
+    const results = (rpcResults || [])
+      .filter((row: any) => row.quality_score >= minQuality)
+      .map((row: any) => ({
+        id: row.id,
+        title: row.title,
+        content: row.content,
+        category: row.category,
+        language: 'en', // Database level doesn't map language yet
+        qualityScore: row.quality_score,
+        createdAt: row.created_at
+      }));
+
+    const total = rpcResults && rpcResults.length > 0 ? Number(rpcResults[0].total_count) : 0;
+
+    let suggestion = null;
+    
+    if (total === 0 && query) {
+       // Since we no longer load all texts into memory, we check if pg_trgm can find a close title
+       const { data: similarTitles } = await supabase
         .from('documents')
-        .select('*')
+        .select('title')
         .eq('user_id', user.id)
-
-      // Filter by type if a specific category is requested
-      if (category === 'resume') {
-        docQuery = docQuery.or('type.eq.resume,type.eq.cv')
-      } else if (category) {
-        docQuery = docQuery.eq('type', category)
-      }
-
-      const { data: documents, error: docError } = await docQuery
-      if (docError) {
-        logger.error({ route: 'app/api/search/route.ts' }, 'Error fetching documents:', docError)
-        return NextResponse.json(
-          { error: 'Failed to fetch user documents' },
-          { status: 500 }
-        )
-      }
-
-      if (documents) {
-        for (const doc of documents) {
-          // Normalize type to category
-          let mappedCategory: 'resume' | 'presentation' | 'template' | 'letter' = 'resume'
-          if (doc.type === 'presentation') mappedCategory = 'presentation'
-          else if (doc.type === 'letter') mappedCategory = 'letter'
-          else if (doc.type !== 'resume' && doc.type !== 'cv') {
-            logger.warn({ route: 'app/api/search/route.ts', docType: doc.type }, 'Unknown document type, defaulting to resume')
-          }
-
-          const textContent = extractTextFromContent(doc.content)
-          
-          let score = 80
-          if (doc.content && typeof doc.content === 'object' && 'atsScore' in doc.content) {
-            score = Number(doc.content.atsScore) || 80
-          }
-
-          allMappedDocs.push({
-            id: doc.id,
-            title: doc.title,
-            content: textContent,
-            category: mappedCategory,
-            language: 'en',
-            qualityScore: score,
-            createdAt: doc.created_at || new Date().toISOString()
-          })
-        }
-      }
+        .ilike('title', `%${query.substring(0, 3)}%`)
+        .limit(5);
+        
+       if (similarTitles && similarTitles.length > 0) {
+         suggestion = suggestCorrection(query, similarTitles.flatMap(t => t.title.split(/\s+/)));
+       }
     }
-
-    // 2. Fetch user templates from 'templates' table if category is 'template' or undefined
-    if (!category || category === 'template') {
-      const { data: templates, error: templateError } = await supabase
-        .from('templates')
-        .select('*')
-        .eq('user_id', user.id)
-
-      if (templateError) {
-        logger.error({ route: 'app/api/search/route.ts' }, 'Error fetching templates:', templateError)
-        return NextResponse.json(
-          { error: 'Failed to fetch user templates' },
-          { status: 500 }
-        )
-      }
-
-      if (templates) {
-        for (const template of templates) {
-          const textContent = template.description || extractTextFromContent(template.content)
-          allMappedDocs.push({
-            id: template.id,
-            title: template.title,
-            content: textContent,
-            category: 'template',
-            language: 'en',
-            qualityScore: 85,
-            createdAt: template.created_at || new Date().toISOString()
-          })
-        }
-      }
-    }
-
-    // Retrieve all matches first so we can return the total count, then paginate manually.
-    // (searchDocuments returns only a slice, so we need the full result set for the total.)
-    const allResults = searchDocuments(allMappedDocs, {
-      query,
-      category,
-      language,
-      minQualityScore: minQuality,
-      limit: 999999,
-      offset: 0,
-    })
-
-    const total = allResults.length
-    const paginatedResults = allResults.slice(offset, offset + limit)
-
-    // Build vocabulary only when needed for spell correction (total === 0)
-    const suggestion =
-      total === 0
-        ? suggestCorrection(
-            query,
-            [...new Set(
-              allMappedDocs.flatMap((d) =>
-                [...d.title.split(/\s+/), ...d.content.split(/\s+/)]
-                  .map((w) => w.toLowerCase().replace(/[^a-z0-9]/g, ''))
-              ).filter(Boolean)
-            )]
-          )
-        : null
 
     return NextResponse.json({
-      results: paginatedResults,
+      results,
       suggestion,
       total,
       query,

--- a/supabase/migrations/20260611000000_add_full_text_search.sql
+++ b/supabase/migrations/20260611000000_add_full_text_search.sql
@@ -1,0 +1,105 @@
+-- Enable the pg_trgm extension for typo-tolerant matching and trigram indices
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- 1. Add fts columns to searchable tables
+ALTER TABLE documents 
+  ADD COLUMN IF NOT EXISTS fts TSVECTOR 
+  GENERATED ALWAYS AS (to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content::text, ''))) STORED;
+
+ALTER TABLE templates 
+  ADD COLUMN IF NOT EXISTS fts TSVECTOR 
+  GENERATED ALWAYS AS (to_tsvector('english', coalesce(title, '') || ' ' || coalesce(description, '') || ' ' || coalesce(content::text, ''))) STORED;
+
+ALTER TABLE resumes 
+  ADD COLUMN IF NOT EXISTS fts TSVECTOR 
+  GENERATED ALWAYS AS (to_tsvector('english', coalesce(title, '') || ' ' || coalesce(personal_info::text, '') || ' ' || coalesce(content::text, ''))) STORED;
+
+-- 2. Create GIN indices on the fts columns for full-text search
+CREATE INDEX IF NOT EXISTS documents_fts_idx ON documents USING GIN (fts);
+CREATE INDEX IF NOT EXISTS templates_fts_idx ON templates USING GIN (fts);
+CREATE INDEX IF NOT EXISTS resumes_fts_idx ON resumes USING GIN (fts);
+
+-- 3. Create trigram indices on titles for typo-tolerant LIKE/ILIKE searches
+CREATE INDEX IF NOT EXISTS documents_title_trgm_idx ON documents USING GIN (title gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS templates_title_trgm_idx ON templates USING GIN (title gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS resumes_title_trgm_idx ON resumes USING GIN (title gin_trgm_ops);
+
+-- 4. Create an RPC function to perform unified searching with pagination
+CREATE OR REPLACE FUNCTION search_user_content(
+  p_user_id UUID,
+  p_query TEXT,
+  p_category TEXT DEFAULT NULL,
+  p_limit INT DEFAULT 10,
+  p_offset INT DEFAULT 0
+) RETURNS TABLE (
+  id UUID,
+  title TEXT,
+  content TEXT,
+  category TEXT,
+  quality_score REAL,
+  rank REAL,
+  created_at TIMESTAMPTZ,
+  total_count BIGINT
+) LANGUAGE plpgsql STABLE AS $$
+BEGIN
+  RETURN QUERY
+  WITH combined AS (
+    SELECT 
+      d.id, 
+      d.title, 
+      d.content::text as content_text, 
+      CASE WHEN d.type IN ('resume', 'cv') THEN 'resume'
+           WHEN d.type = 'presentation' THEN 'presentation'
+           WHEN d.type = 'letter' THEN 'letter'
+           ELSE 'resume' END as category,
+      COALESCE((d.content->>'atsScore')::real, 80.0) as quality_score,
+      d.created_at,
+      ts_rank(d.fts, plainto_tsquery('english', p_query)) as rank
+    FROM documents d
+    WHERE d.user_id = p_user_id
+      AND (p_category IS NULL OR p_category != 'template')
+      AND (p_category IS NULL OR 
+           (p_category = 'resume' AND d.type IN ('resume', 'cv')) OR 
+           (p_category != 'resume' AND d.type = p_category))
+      AND (p_query = '' OR d.fts @@ plainto_tsquery('english', p_query) OR d.title ILIKE '%' || p_query || '%')
+    
+    UNION ALL
+    
+    SELECT 
+      t.id, 
+      t.title, 
+      coalesce(t.description, '') || ' ' || t.content::text as content_text, 
+      'template' as category,
+      85.0 as quality_score,
+      t.created_at,
+      ts_rank(t.fts, plainto_tsquery('english', p_query)) as rank
+    FROM templates t
+    WHERE t.user_id = p_user_id
+      AND (p_category IS NULL OR p_category = 'template')
+      AND (p_query = '' OR t.fts @@ plainto_tsquery('english', p_query) OR t.title ILIKE '%' || p_query || '%')
+
+    UNION ALL
+
+    SELECT
+      r.id, 
+      r.title, 
+      coalesce(r.personal_info::text, '') || ' ' || r.content::text as content_text,
+      'resume' as category,
+      80.0 as quality_score,
+      r.created_at,
+      ts_rank(r.fts, plainto_tsquery('english', p_query)) as rank
+    FROM resumes r
+    WHERE r.user_id = p_user_id
+      AND (p_category IS NULL OR p_category = 'resume' OR p_category != 'template')
+      AND (p_query = '' OR r.fts @@ plainto_tsquery('english', p_query) OR r.title ILIKE '%' || p_query || '%')
+  )
+  SELECT 
+    c.id, c.title, c.content_text, c.category, c.quality_score, c.rank, c.created_at,
+    count(*) OVER() as total_count
+  FROM combined c
+  ORDER BY 
+    CASE WHEN p_query = '' THEN 1 ELSE c.rank END DESC,
+    c.title ASC
+  LIMIT p_limit OFFSET p_offset;
+END;
+$$;


### PR DESCRIPTION
# Description

Replace basic keyword search with PostgreSQL full-text search.

Fixes #854

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `20260611000000_add_full_text_search.sql` Supabase migration which:
  - Adds `fts` TSVECTOR columns to `documents`, `templates`, and `resumes` tables.
  - Adds GIN indexes for rapid text searching.
  - Adds `pg_trgm` GIN indexes for typo-tolerant queries on document titles.
  - Creates the `search_user_content` RPC function to unify and paginate search across tables on the database side.
- Updated `app/api/search/route.ts` to replace the in-memory JavaScript search with a call to the new `search_user_content` RPC function.

## Dependencies

- Requires applying the new Supabase migration.
- Uses `pg_trgm` PostgreSQL extension.

# How Has This Been Tested?

- Run `supabase db push` or `supabase db reset` locally or remotely to apply the migration.
- Test the search endpoint by passing search queries (e.g., typos in titles) and observe paginated PostgreSQL results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added search suggestions when no results are found
  * Enhanced search result ranking and relevance

* **Performance**
  * Improved search efficiency and scalability
  * Better typo tolerance for search queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->