### PR TITLE
test: extend Stripe webhook coverage

### DIFF
--- a/__tests__/api/stripe-webhook.test.ts
+++ b/__tests__/api/stripe-webhook.test.ts
@@ -226,6 +226,69 @@ describe("Stripe webhook route", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("returns 500 when the webhook idempotency lookup fails", async () => {
+    const { route, supabase } = await loadRoute();
+    constructEvent.mockReturnValue(
+      eventFixture("checkout.session.completed", {
+        metadata: { userId: "user-1" },
+        customer: "cus_123",
+        subscription: "sub_123",
+      }),
+    );
+    supabase.tableBuilders
+      .get("stripe_webhook_events")!
+      .maybeSingle.mockResolvedValue({
+        data: null,
+        error: new Error("lookup failed"),
+      });
+
+    const response = await route.POST(makeRequest());
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Webhook processing failed",
+    });
+    expect(retrieveSubscription).not.toHaveBeenCalled();
+    expect(
+      supabase.tableBuilders.get("stripe_webhook_events")!.insert,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("upserts subscription details for customer.subscription.created", async () => {
+    const { route, supabase } = await loadRoute();
+    constructEvent.mockReturnValue(
+      eventFixture("customer.subscription.created", subscriptionFixture()),
+    );
+    supabase.tableBuilders
+      .get("subscription_plans")!
+      .single.mockResolvedValue({ data: { id: "plan_123" }, error: null });
+    supabase.tableBuilders
+      .get("user_subscriptions")!
+      .upsert.mockResolvedValue({ error: null });
+
+    const response = await route.POST(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(
+      supabase.tableBuilders.get("user_subscriptions")!.upsert,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "user-1",
+        plan_id: "plan_123",
+        stripe_subscription_id: "sub_123",
+        status: "active",
+      }),
+    );
+    expect(
+      supabase.tableBuilders.get("stripe_webhook_events")!.insert,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripe_event_id: "evt_customer.subscription.created",
+        event_type: "customer.subscription.created",
+      }),
+    );
+  });
+
   it("upserts current subscription details for customer.subscription.updated", async () => {
     const { route, supabase } = await loadRoute();
     constructEvent.mockReturnValue(


### PR DESCRIPTION
## Summary
- add explicit coverage for customer.subscription.created webhook processing
- verify Stripe webhook idempotency lookup failures return a safe 500 response
- keep the Stripe webhook suite focused on existing mocks and route behavior

Closes #948

## GSSoC
- Label: gssoc:approved
- Level: level:intermediate
- Type: type:testing

## Validation
- npm test -- __tests__/api/stripe-webhook.test.ts --runInBand
- pre-commit hook: npm run typecheck:changed, eslint/prettier on staged file, jest --findRelatedTests, full jest suite (26 suites / 394 tests passed)

Note: npm ci is blocked on current main because package.json and package-lock.json are out of sync for @emnapi packages, so dependencies were installed with npm install and package-lock.json was not committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Stripe webhook event handling, including error scenarios and subscription creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->