### PR TITLE
docs: Add Contributor Covenant Code of Conduct v2.1

### DIFF
--- a/docs/Code_of_Conduct.md
+++ b/docs/Code_of_Conduct.md
@@ -1,80 +1,86 @@
-✨ Documentation Code of Conduct — DraftDeckAI ✨
 
-🌟 Our Commitment: 
+# Contributor Covenant Code of Conduct
 
-DraftDeckAI is dedicated to creating a respectful, inclusive, and collaborative space where users of all backgrounds and expertise levels feel empowered to create, learn, and grow. Whether you’re generating documents or contributing to platform improvements, we aim to keep this space professional, safe, and inspiring.
+## Our Pledge
 
----
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
-🤝 Community Values
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
-We believe our platform thrives when we:
-- 📝 Respect every user’s input, query, and creation
-- 🤖 Use AI responsibly and ethically
-- 🌐 Embrace diversity in ideas, disciplines, and users
-- 💬 Ask for help freely and offer constructive, kind feedback
-- 🎉 Celebrate innovation, collaboration, and learning
-- 🤝 Interact with patience, clarity, and mutual respect
+## Our Standards
 
----
+Examples of behavior that contributes to a positive environment for our community include:
 
-🚫 Not Tolerated
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-To maintain a positive environment, we do not tolerate:
-- ❌ Disrespectful or aggressive communication
-- ❌ Misuse of AI to generate plagiarized or harmful content
-- ❌ Harassment, bullying, or unsolicited contact
-- ❌ Unauthorized sharing of private or sensitive data
-- ❌ Discrimination, hate speech, or unethical behavior
+Examples of unacceptable behavior include:
 
----
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
-🧭 Where This Applies
+## Enforcement Responsibilities
 
-This Code of Conduct applies across all DraftDeckAI spaces:
-- DraftDeckAI Platform and Documentation
-- GitHub repositories and issue discussions
-- Community channels (Discord)
-- Online workshops, webinars, and official events
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
----
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
-🛑 Reporting Misconduct:
+## Scope
 
-If you encounter or experience behavior that violates this Code of Conduct, please report it to the moderation team or platform administrators. All reports will be handled with care and confidentiality.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
----
+## Enforcement
 
-🧩 Possible Actions
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
 
-Violations may lead to the following actions:
-- 🟡 Friendly reminder or guidance
-- 🟠 Official warning
-- 🔴 Temporary restriction from platform access
-- ⚫ Permanent ban from the community
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
----
+## Enforcement Guidelines
 
-🎯 Contributor Expectations
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
-When using or contributing to DraftDeckAI, we expect you to:
-- ✔️ Be courteous, inclusive, and professional
-- ✔️ Avoid creating or sharing offensive or plagiarized documents
-- ✔️ Provide helpful and respectful feedback
-- ✔️ Attribute content sources properly
-- ✔️ Support a learning-focused and beginner-friendly environment
+### 1. Correction
 
----
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
-🌟 Our Vision:
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
-DraftDeckAI is more than an AI document tool—it's a community of creators, learners, and innovators. Let’s work together to build a platform where everyone feels safe, respected, and inspired to turn ideas into impactful documents. 🪄📄
+### 2. Warning
 
----
+**Community Impact**: A violation through a single incident or series of actions.
 
-📄 Attribution:
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
-This Code of Conduct is crafted for DraftDeckAI in alignment with principles from the 
-[Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) and adapted for our AI-powered documentation ecosystem.
+### 3. Temporary Ban
 
-Let’s empower creation with responsibility and respect! 💼✨
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+
+


### PR DESCRIPTION
Adds Contributor Covenant Code of Conduct v2.1. Standard practice for open source projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the Code of Conduct with the standardized Contributor Covenant version 2.1. The updated document features comprehensive sections covering community pledge, expected behavioral standards, enforcement responsibilities and guidelines, applicability scope, and proper attribution. Contact information placeholders have been added to facilitate community reporting, issue escalation, and contributor support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->