### PR TITLE
Test/admin dashboard unit tests

### DIFF
--- a/app/admin/__tests__/config-page.test.tsx
+++ b/app/admin/__tests__/config-page.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import AdminConfigPage from "@/app/admin/config/page";
+
+describe("AdminConfigPage", () => {
+  it("renders all configuration settings and values", () => {
+    render(<AdminConfigPage />);
+
+    expect(screen.getByText("System Configuration")).toBeInTheDocument();
+
+    expect(screen.getByText("Default Credits (New User)")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+
+    expect(screen.getByText("Max Documents Per User")).toBeInTheDocument();
+    expect(screen.getByText("50")).toBeInTheDocument();
+
+    expect(screen.getByText("AI Generation Rate Limit")).toBeInTheDocument();
+    expect(screen.getByText("20 / 5 min")).toBeInTheDocument();
+
+    expect(screen.getByText("Maintenance Mode")).toBeInTheDocument();
+    expect(screen.getByText("Off")).toBeInTheDocument();
+  });
+
+  it("renders the correct number of rows", () => {
+    render(<AdminConfigPage />);
+    expect(screen.getAllByRole("row")).toHaveLength(5); // 1 header + 4 data rows
+  });
+
+  it("shows the coming-soon notice", () => {
+    render(<AdminConfigPage />);
+    expect(
+      screen.getByText("Live config editing coming soon."),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/admin/__tests__/overview-page.test.tsx
+++ b/app/admin/__tests__/overview-page.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import AdminOverviewPage from "@/app/admin/page";
+
+const mockFrom = jest.fn();
+
+jest.mock("@/lib/supabase/server", () => ({
+  createServer: jest.fn(() => ({ from: mockFrom })),
+}));
+
+function mockCounts(userCount: number | null, docCount: number | null) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "profiles") {
+      return { select: jest.fn().mockResolvedValue({ count: userCount }) };
+    }
+    if (table === "documents") {
+      return { select: jest.fn().mockResolvedValue({ count: docCount }) };
+    }
+    return { select: jest.fn().mockResolvedValue({ count: 0 }) };
+  });
+}
+
+describe("AdminOverviewPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("aggregates and displays user and document counts", async () => {
+    mockCounts(42, 7);
+    const ui = await AdminOverviewPage();
+    render(ui);
+
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("Total Users")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("Total Documents")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("falls back to 0 when counts are null", async () => {
+    mockCounts(null, null);
+    const ui = await AdminOverviewPage();
+    render(ui);
+
+    expect(screen.getAllByText("0")).toHaveLength(2);
+  });
+
+  it("queries profiles and documents tables", async () => {
+    mockCounts(1, 2);
+    await AdminOverviewPage();
+
+    expect(mockFrom).toHaveBeenCalledWith("profiles");
+    expect(mockFrom).toHaveBeenCalledWith("documents");
+  });
+});

--- a/app/admin/__tests__/users-page.test.tsx
+++ b/app/admin/__tests__/users-page.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import AdminUsersPage from "@/app/admin/users/page";
+
+const mockLimit = jest.fn();
+const mockOrder = jest.fn(() => ({ limit: mockLimit }));
+const mockSelect = jest.fn(() => ({ order: mockOrder }));
+const mockFrom = jest.fn(() => ({ select: mockSelect }));
+
+jest.mock("@/lib/supabase/server", () => ({
+  createServer: jest.fn(() => ({ from: mockFrom })),
+}));
+
+describe("AdminUsersPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders user rows with correct data", async () => {
+    mockLimit.mockResolvedValue({
+      data: [
+        {
+          id: "1",
+          email: "alice@example.com",
+          full_name: "Alice",
+          role: "admin",
+          credits: 50,
+          created_at: "2026-01-15T00:00:00Z",
+          is_suspended: false,
+        },
+        {
+          id: "2",
+          email: "bob@example.com",
+          full_name: null,
+          role: "user",
+          credits: 0,
+          created_at: "2026-02-01T00:00:00Z",
+          is_suspended: true,
+        },
+      ],
+    });
+
+    const ui = await AdminUsersPage();
+    render(ui);
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    expect(screen.getByText("admin")).toBeInTheDocument();
+    expect(screen.getByText("50")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("bob@example.com")).toBeInTheDocument();
+    expect(screen.getByText("user")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("Suspended")).toBeInTheDocument();
+  });
+
+  it("renders no data rows when there are no users", async () => {
+    mockLimit.mockResolvedValue({ data: [] });
+    const ui = await AdminUsersPage();
+    render(ui);
+    expect(screen.getAllByRole("row")).toHaveLength(1); // header row only
+  });
+
+  it("queries profiles ordered by newest first, limited to 100", async () => {
+    mockLimit.mockResolvedValue({ data: [] });
+    await AdminUsersPage();
+    expect(mockFrom).toHaveBeenCalledWith("profiles");
+    expect(mockOrder).toHaveBeenCalledWith("created_at", { ascending: false });
+    expect(mockLimit).toHaveBeenCalledWith(100);
+  });
+});

--- a/lib/__tests__/admin-auth.test.ts
+++ b/lib/__tests__/admin-auth.test.ts
@@ -1,0 +1,77 @@
+import { requireAdmin, isAdmin } from "@/lib/admin-auth";
+import { redirect } from "next/navigation";
+
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+}));
+
+const mockSingle = jest.fn();
+const mockEq = jest.fn(() => ({ single: mockSingle }));
+const mockSelect = jest.fn(() => ({ eq: mockEq }));
+const mockFrom = jest.fn(() => ({ select: mockSelect }));
+const mockGetUser = jest.fn();
+
+jest.mock("@/lib/supabase/server", () => ({
+  createServer: jest.fn(() => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+describe("admin-auth", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("requireAdmin", () => {
+    it("redirects to signin when no user", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      await expect(requireAdmin()).rejects.toThrow("NEXT_REDIRECT");
+      expect(redirect).toHaveBeenCalledWith("/auth/signin");
+    });
+
+    it("redirects to dashboard when role is not admin", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+      mockSingle.mockResolvedValue({ data: { role: "user" } });
+      await expect(requireAdmin()).rejects.toThrow("NEXT_REDIRECT");
+      expect(redirect).toHaveBeenCalledWith("/dashboard");
+    });
+
+    it("redirects to dashboard when profile is missing", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+      mockSingle.mockResolvedValue({ data: null });
+      await expect(requireAdmin()).rejects.toThrow("NEXT_REDIRECT");
+      expect(redirect).toHaveBeenCalledWith("/dashboard");
+    });
+
+    it("returns the user when role is admin", async () => {
+      const adminUser = { id: "u1" };
+      mockGetUser.mockResolvedValue({ data: { user: adminUser } });
+      mockSingle.mockResolvedValue({ data: { role: "admin" } });
+      const result = await requireAdmin();
+      expect(result).toEqual(adminUser);
+      expect(redirect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isAdmin", () => {
+    it("returns false when no user", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null } });
+      expect(await isAdmin()).toBe(false);
+    });
+
+    it("returns false when role is not admin", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+      mockSingle.mockResolvedValue({ data: { role: "user" } });
+      expect(await isAdmin()).toBe(false);
+    });
+
+    it("returns true when role is admin", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+      mockSingle.mockResolvedValue({ data: { role: "admin" } });
+      expect(await isAdmin()).toBe(true);
+    });
+  });
+});

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
+import { createServer as createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 
 export async function requireAdmin() {


### PR DESCRIPTION
# Description
Adds unit tests for the admin dashboard components and data flows introduced in #990, as requested in #998. Also fixes a bug in `lib/admin-auth.ts` discovered while writing the auth tests: it imported `createClient` from `@/lib/supabase/server`, but that file only exports `createServer`/`createRoute`/`createSupabaseAdmin`. This meant `requireAdmin()` — called in `app/admin/layout.tsx` on every admin page — crashed immediately with "createClient is not a function", breaking the entire admin dashboard at runtime.

Fixes #998

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

(Test additions don't fit the listed categories cleanly — this PR is primarily test coverage, plus one small bug fix needed to make the auth logic testable.)

## Changes Made
- Fixed broken `createClient` import in `lib/admin-auth.ts` (aliased to the correct `createServer` export)
- Added `lib/__tests__/admin-auth.test.ts` — tests `requireAdmin` and `isAdmin` (redirect on no user, redirect on non-admin role, redirect on missing profile, returns user when admin)
- Added `app/admin/__tests__/users-page.test.tsx` — tests user table rendering and the Supabase query (table, ordering, limit)
- Added `app/admin/__tests__/overview-page.test.tsx` — tests the user/document count aggregation and null-count fallback
- Added `app/admin/__tests__/config-page.test.tsx` — tests static config table rendering

## Dependencies
None added. (`npm install` was needed locally to pick up `@next/bundle-analyzer`, which was already in `package.json` but missing from `node_modules`.)

# How Has This Been Tested?
Ran the new suites directly and the full project test suite.
- [x] Test A — `npx jest lib/__tests__/admin-auth.test.ts app/admin/__tests__/` → 4 suites, 16 tests, all passing
- [x] Test B — `npx jest` (full suite) → 30 suites, 410 tests, all passing

## Add Screenshots
N/A — no UI changes, test-only PR (plus the one-line import fix).

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have tested my changes across major browsers/devices
- [x] I have tested my changes in development mode (`npm run dev`)
- [ ] I have successfully run `npm run lint` and resolved all warnings/errors
- [ ] I have successfully run `npm run typecheck` and resolved all TypeScript errors
- [x] New and existing unit tests pass locally with my changes (`npx jest`)
- [x] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for admin pages including configuration, overview, and user management sections.
  * Added test coverage for admin authentication and authorization helpers to ensure proper access control.

* **Chores**
  * Updated admin authentication module configuration for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->