### PR TITLE
fix: remove production debug data logs

### DIFF
--- a/components/letter/letter-generator.tsx
+++ b/components/letter/letter-generator.tsx
@@ -19,7 +19,6 @@ import { useToast } from "@/hooks/use-toast";
 import { AlertCircle, CheckCircle2, Send, Copy, Download, Mail, Loader2, Sparkles, Wand2, FileText, User, MapPin, Check } from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { createClient } from "@/lib/supabase/client";
-import { logger } from "@/lib/logger";
 
 export function LetterGenerator() {
   const [prompt, setPrompt] = useState("");
@@ -67,10 +66,6 @@ export function LetterGenerator() {
 
     try {
       const { data: { session } } = await supabase.auth.getSession();
-      if (process.env.NODE_ENV !== "production") {
-        logger.info(null, 'DEBUG: Generating letter, Session User:', session?.user?.email);
-        logger.info(null, 'DEBUG: Access Token Present:', !!session?.access_token);
-      }
 
       if (!session?.access_token) {
         console.error("No valid session or access token found when generating letter.");

--- a/components/presentation/presentation-generator.tsx
+++ b/components/presentation/presentation-generator.tsx
@@ -761,13 +761,13 @@ export function PresentationGenerator({ templateId }: PresentationGeneratorProps
         const hasBullets = slide.bullets && Array.isArray(slide.bullets) && slide.bullets.length > 0;
         const isCover = index === 0;
 
-        // DEBUG: Log image status
-        logger.info(null, `📊 Slide ${index + 1}:`, {
-          hasImage,
-          imageUrl: slide.image?.substring(0, 60) + '...',
-          hasBullets,
-          hasChart
-        })
+        if (process.env.NODE_ENV !== 'production') {
+          logger.debug(null, `Slide ${index + 1} export assets`, {
+            hasImage,
+            hasBullets,
+            hasChart
+          })
+        }
 
         // --- COVER SLIDE LAYOUT ---
         if (isCover) {


### PR DESCRIPTION
## Summary
- remove letter generation debug logs that exposed user email and access-token presence
- keep PPTX slide export diagnostics development-only
- stop logging slide image URL fragments from the export path

Fixes #1038

## Validation
- git diff --check
- Not run: 
pm run typecheck because 
ode_modules is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary logging during letter and presentation generation.
  * Sensitive session details are no longer surfaced in logs.
  * Debug output is now limited to non-production environments, helping keep production logs cleaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->