### PR TITLE
fix: implement actual OpenAI streaming in generate-presentation-strea…

### DIFF
--- a/app/api/generate-presentation-stream/route.ts
+++ b/app/api/generate-presentation-stream/route.ts
@@ -1,23 +1,27 @@
-import { logger } from '@/lib/logger';
-import { NextRequest, NextResponse } from 'next/server';
-import OpenAI from 'openai';
-import { createEnhancedPresentationPrompt } from '@/lib/prompts/enhanced-presentation-prompt';
-import { createClient } from '@supabase/supabase-js';
+import { logger } from "@/lib/logger";
+import { NextRequest, NextResponse } from "next/server";
+import { createEnhancedPresentationPrompt } from "@/lib/prompts/enhanced-presentation-prompt";
+import { createClient } from "@supabase/supabase-js";
+import OpenAI from "openai";
 
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY!,
+});
 
 export async function POST(req: NextRequest) {
   try {
-    const authHeader = req.headers.get('Authorization');
-    const token = authHeader?.replace('Bearer ', '');
+    const authHeader = req.headers.get("Authorization");
+    const token = authHeader?.replace("Bearer ", "");
 
     if (!token) {
       return NextResponse.json(
-        { error: 'Authentication required. Please sign in.' },
-        { status: 401 }
+        { error: "Authentication required. Please sign in." },
+        { status: 401 },
       );
     }
 
@@ -28,30 +32,82 @@ export async function POST(req: NextRequest) {
 
     if (authError || !user) {
       return NextResponse.json(
-        { error: 'Authentication required. Please sign in.' },
-        { status: 401 }
+        { error: "Authentication required. Please sign in." },
+        { status: 401 },
       );
     }
 
     const { topic, audience, outline, settings } = await req.json();
 
     if (!topic) {
-      return NextResponse.json(
-        { error: 'Topic is required' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Topic is required" }, { status: 400 });
     }
 
-    return NextResponse.json({
-      success: true,
+    const prompt = createEnhancedPresentationPrompt(
+      topic,
+      audience,
+      outline,
+      settings,
+    );
+
+    // Create a ReadableStream that streams SSE chunks to the client
+    const stream = new ReadableStream({
+      async start(controller) {
+        const encoder = new TextEncoder();
+
+        try {
+          const completion = await openai.chat.completions.create({
+            model: "gpt-4o-mini",
+            messages: [{ role: "user", content: prompt }],
+            stream: true,
+            max_tokens: 4000,
+          });
+
+          for await (const chunk of completion) {
+            const content = chunk.choices[0]?.delta?.content ?? "";
+            if (content) {
+              // SSE format: "data: {json}\n\n"
+              const sseData = JSON.stringify({ content });
+              controller.enqueue(encoder.encode(`data: ${sseData}\n\n`));
+            }
+          }
+
+          // Signal completion to the client
+          const doneData = JSON.stringify({ done: true });
+          controller.enqueue(encoder.encode(`data: ${doneData}\n\n`));
+        } catch (streamError) {
+          logger.error(
+            { route: "generate-presentation-stream" },
+            "❌ Stream error:",
+            streamError,
+          );
+          const errorData = JSON.stringify({
+            error: "Stream generation failed",
+          });
+          controller.enqueue(encoder.encode(`data: ${errorData}\n\n`));
+        } finally {
+          controller.close();
+        }
+      },
     });
 
+    return new NextResponse(stream, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
   } catch (error) {
-    logger.error({ route: 'app/api/generate-presentation-stream/route.ts' }, '❌ API error:', error);
-
+    logger.error(
+      { route: "app/api/generate-presentation-stream/route.ts" },
+      "❌ API error:",
+      error,
+    );
     return NextResponse.json(
-      { error: 'Failed to generate presentation' },
-      { status: 500 }
+      { error: "Failed to generate presentation" },
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
# Description
 
The `/api/generate-presentation-stream` route was a stub — it imported `OpenAI` but never called any AI model. After auth validation it simply returned `{ success: true }` with no stream body, causing the entire real-time streaming presentation feature to silently produce empty results.
 
This PR replaces the stub with a working `ReadableStream` implementation using OpenAI's streaming API, returning proper SSE-formatted chunks that `hooks/useStreamingPresentation.ts` already expects via `response.body?.getReader()`.
 
Fixes #1037 
 
## Type of change
 
- [x] Bug fix (non-breaking change which fixes an issue)
## Changes Made
 
- Replaced the stub `return NextResponse.json({ success: true })` with a `ReadableStream` that calls `openai.chat.completions.create({ stream: true })`
- Used `createEnhancedPresentationPrompt` (already imported) to build the prompt from `topic`, `audience`, `outline`, and `settings`
- Each streamed chunk is encoded in SSE format (`data: {"content":"..."}\n\n`) matching what the client hook parses
- Sends a final `data: {"done":true}\n\n` signal on completion
- Returns response with `Content-Type: text/event-stream` headers so the browser keeps the connection open
- Error during streaming is caught and sent as an SSE error event before closing the stream
## Dependencies
 
- `openai` — already listed in `package.json`, no new dependency needed
- `OPENAI_API_KEY` — must be set in `.env.local` (already required by the project)
# How Has This Been Tested?
 
- [x] Test A — Started `npm run dev`, navigated to Presentation Generator, entered a topic and clicked Generate. Verified in DevTools → Network → `generate-presentation-stream` that response is `text/event-stream` and chunks arrive progressively over time instead of a single JSON blob.
- [x] Test B — Verified `useStreamingPresentation` hook correctly accumulates streamed content and updates UI state (`isStreaming`, `content`, `progress`) in real time.
- [x] Test C — Verified that when `topic` is missing, the route still returns `400` as expected.
- [x] Test D — Verified auth guard still returns `401` when no token is provided.
## Add Screenshots
 
_No UI component changed. The fix is backend-only; the presentation generator UI now shows streamed content instead of a blank result._
 
## Checklist
 
- [x] My code follows the style guidelines of this project
- [x] I have tested my changes across major browsers/devices
- [x] I have tested my changes in development mode (`npm run dev`)
- [x] I have successfully run `npm run lint` and resolved all warnings/errors
- [x] I have successfully run `npm run typecheck` and resolved all TypeScript errors
- [x] New and existing unit tests pass locally with my changes (`npx jest`)
- [x] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Presentation generation now streams results to the client in real time for a faster, more interactive experience.
  * Requests are now validated before generation begins, helping ensure a topic is provided.

* **Bug Fixes**
  * Improved handling of streaming errors so failures are surfaced cleanly to the client.
  * Added request authentication for better access control before generating content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->