### PR TITLE
fix: correct Content-Type header for gzip export and remove internal …

### DIFF
--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -3,20 +3,28 @@
  * Protected endpoint that generates and returns user data export as JSON
  */
 
-import { NextRequest, NextResponse } from 'next/server';
-import { fetchAllUserData, generateExportFile, generateExportFilename, compressData } from '@/lib/data-export';
-import { createRoute } from '@/lib/supabase/server';
+import { NextRequest, NextResponse } from "next/server";
+import {
+  fetchAllUserData,
+  generateExportFile,
+  generateExportFilename,
+  compressData,
+} from "@/lib/data-export";
+import { createRoute } from "@/lib/supabase/server";
 
 export async function GET(request: NextRequest) {
   try {
     // Verify authentication using Supabase
     const supabase = await createRoute();
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
 
     if (authError || !user) {
       return NextResponse.json(
         { error: "Unauthorized. Please sign in to export your data." },
-        { status: 401 }
+        { status: 401 },
       );
     }
 
@@ -25,17 +33,16 @@ export async function GET(request: NextRequest) {
     const userData = await fetchAllUserData(user.id);
 
     // Check if client supports compression via Accept-Encoding header
-    const acceptEncoding = request.headers.get('accept-encoding') || '';
-    const supportsGzip = acceptEncoding.includes('gzip');
+    const acceptEncoding = request.headers.get("accept-encoding") || "";
+    const supportsGzip = acceptEncoding.includes("gzip");
 
     if (supportsGzip) {
-      // Use compression for large datasets
       const compressedBlob = await compressData(userData);
 
       return new NextResponse(compressedBlob, {
         status: 200,
         headers: {
-          "Content-Type": "application/json",
+          "Content-Type": "application/octet-stream", // ✅ FIXED: binary body
           "Content-Encoding": "gzip",
           "Content-Disposition": `attachment; filename="${filename}"`,
           "Cache-Control": "no-cache, no-store, must-revalidate",
@@ -56,13 +63,13 @@ export async function GET(request: NextRequest) {
     }
   } catch (error) {
     console.error("Error exporting user data:", error);
-    
+
     return NextResponse.json(
-      { 
-        error: "Failed to export data", 
-        details: error instanceof Error ? error.message : "Unknown error" 
+      {
+        error: "Failed to export data",
+        // details field removed — never expose internal error messages to clients
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
# Description
 
`app/api/export/route.ts` had two problems:
 
**Problem 1 — Wrong Content-Type:** When a client sends `Accept-Encoding: gzip`, the route compresses the response body using `compressData()` making it binary gzip, but then sets `Content-Type: application/json`. This is contradictory — the body is no longer JSON at that point. Strict clients and some browsers fail to decompress it correctly, resulting in corrupted download files.
 
**Problem 2 — Internal error leak:** The catch block sent `error.message` directly to the client as `details`, which can expose internal implementation details, stack traces, or database error messages to end users — a security concern.
 
This PR fixes both: sets the correct `Content-Type: application/octet-stream` for the compressed branch and removes the `details` field from the error response.
 
Fixes #1039 
 
## Type of change
 
- [x] Bug fix (non-breaking change which fixes an issue)
## Changes Made
 
- Changed `"Content-Type": "application/json"` to `"Content-Type": "application/octet-stream"` in the gzip response branch of `app/api/export/route.ts`
- Removed `details: error instanceof Error ? error.message : "Unknown error"` from the catch block error response — clients now only receive the generic `"Failed to export data"` message
- The non-compressed fallback branch was already correct (`application/json` on raw JSON blob) and is left unchanged
## Dependencies
 
- None. No new packages or config changes required.
# How Has This Been Tested?
 
- [x] Test A — Ran `npm run dev`, triggered a data export from Account Settings with a browser that sends `Accept-Encoding: gzip`. Downloaded the file and ran `file exported-data.json` in terminal — confirmed output reads `gzip compressed data` and decompresses cleanly.
- [x] Test B — Checked DevTools → Network → export → Response Headers. Confirmed `Content-Type: application/octet-stream` and `Content-Encoding: gzip` are both present.
- [x] Test C — Tested the non-compressed path by temporarily removing `gzip` from the request's `Accept-Encoding`. Confirmed `Content-Type: application/json` is still returned for that path and the file downloads correctly.
- [x] Test D — Triggered a forced error (by temporarily breaking the `fetchAllUserData` call) and confirmed the error response no longer includes a `details` field.
## Add Screenshots
 
_No UI changes. Network tab confirms correct headers before and after fix._
 
## Checklist
 
- [x] My code follows the style guidelines of this project
- [x] I have tested my changes across major browsers/devices
- [x] I have tested my changes in development mode (`npm run dev`)
- [x] I have successfully run `npm run lint` and resolved all warnings/errors
- [x] I have successfully run `npm run typecheck` and resolved all TypeScript errors
- [x] New and existing unit tests pass locally with my changes (`npx jest`)
- [x] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
