### PR TITLE
fix: pass user phone and location to Mistral fallback instead of hard…

### DIFF
--- a/app/api/generate/resume/route.ts
+++ b/app/api/generate/resume/route.ts
@@ -1,29 +1,64 @@
-export const dynamic = 'force-dynamic';
-export const runtime = 'nodejs';
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
-import { NextResponse } from 'next/server';
-import { resumeGenerationSchema, detectSqlInjection, sanitizeObject, safeParseBody, RequestValidationError } from '@/lib/validation';
-import { createClient } from '@supabase/supabase-js';
-import { ACTION_COSTS, calculateRemainingCredits } from '@/lib/credits-service';
-import { hasUnlimitedDeveloperCredits, logDeveloperCreditBypass } from '@/lib/developer-credit-bypass';
-import { reserveCredits, refundCredits, creditReservationConflictResponse } from '@/lib/credit-operations';
-import { logSecurityEvent, checkRateLimit, SECURITY_CONFIG } from '@/lib/security';
-import { getCachedUserCredits, invalidateUserCredits } from '@/lib/cached-queries';
+import { NextResponse } from "next/server";
+import {
+  resumeGenerationSchema,
+  detectSqlInjection,
+  sanitizeObject,
+  safeParseBody,
+  RequestValidationError,
+} from "@/lib/validation";
+import { createClient } from "@supabase/supabase-js";
+import { ACTION_COSTS, calculateRemainingCredits } from "@/lib/credits-service";
+import {
+  hasUnlimitedDeveloperCredits,
+  logDeveloperCreditBypass,
+} from "@/lib/developer-credit-bypass";
+import {
+  reserveCredits,
+  refundCredits,
+  creditReservationConflictResponse,
+} from "@/lib/credit-operations";
+import {
+  logSecurityEvent,
+  checkRateLimit,
+  SECURITY_CONFIG,
+} from "@/lib/security";
+import {
+  getCachedUserCredits,
+  invalidateUserCredits,
+} from "@/lib/cached-queries";
 
-import { logger } from '@/lib/logger';
-import { getRequestId } from '@/lib/request-id';
-import { incrementRequestCount, incrementErrorCount } from '@/app/api/metrics/route';
-import { generateResume } from '@/lib/gemini';
-import { withErrorHandling } from '@/lib/error-handler';
+import { logger } from "@/lib/logger";
+import { getRequestId } from "@/lib/request-id";
+import {
+  incrementRequestCount,
+  incrementErrorCount,
+} from "@/app/api/metrics/route";
+import { generateResume } from "@/lib/gemini";
+import { withErrorHandling } from "@/lib/error-handler";
 
 // Service role client for credit operations
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
 
 // Mistral-based resume generation as fallback
-async function generateResumeWithMistral({ prompt, name, email }: { prompt: string; name: string; email: string }) {
+async function generateResumeWithMistral({
+  prompt,
+  name,
+  email,
+  phone,
+  location,
+}: {
+  prompt: string;
+  name: string;
+  email: string;
+  phone?: string;
+  location?: string;
+}) {
   const systemPrompt = `You are an expert ATS-optimized resume writer. Create a professional resume based on this requirement: "${prompt}".
 
 The candidate's name is: ${name}
@@ -33,8 +68,8 @@ Return ONLY valid JSON with this exact structure:
 {
   "name": "${name}",
   "email": "${email}",
-  "phone": "+1 (555) 123-4567",
-  "location": "City, State",
+  "phone": "${phone || ""}",
+  "location": "${location || ""}",
   "summary": "Professional summary with 3-4 sentences highlighting key expertise and achievements",
   "experience": [
     {
@@ -63,17 +98,15 @@ Return ONLY valid JSON with this exact structure:
 
 Create realistic, relevant content based on the job description. Use action verbs and quantifiable achievements.`;
 
-  const response = await fetch('https://api.mistral.ai/v1/chat/completions', {
-    method: 'POST',
+  const response = await fetch("https://api.mistral.ai/v1/chat/completions", {
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${process.env.MISTRAL_API_KEY}`,
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.MISTRAL_API_KEY}`,
     },
     body: JSON.stringify({
-      model: 'mistral-small-latest',
-      messages: [
-        { role: 'user', content: systemPrompt }
-      ],
+      model: "mistral-small-latest",
+      messages: [{ role: "user", content: systemPrompt }],
       temperature: 0.3,
       max_tokens: 3000,
     }),
@@ -86,14 +119,17 @@ Create realistic, relevant content based on the job description. Use action verb
   }
 
   const data = await response.json();
-  const content = data.choices?.[0]?.message?.content || '';
+  const content = data.choices?.[0]?.message?.content || "";
 
   // Parse JSON from response
-  const cleanedContent = content.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+  const cleanedContent = content
+    .replace(/```json\n?/g, "")
+    .replace(/```\n?/g, "")
+    .trim();
   const jsonMatch = cleanedContent.match(/\{[\s\S]*\}/);
 
   if (!jsonMatch) {
-    throw new Error('No JSON found in Mistral response');
+    throw new Error("No JSON found in Mistral response");
   }
 
   return JSON.parse(jsonMatch[0]);
@@ -106,18 +142,21 @@ async function postHandler(request: Request) {
 
   try {
     // Get authorization header
-    const authHeader = request.headers.get('authorization');
-    const token = authHeader?.replace('Bearer ', '');
+    const authHeader = request.headers.get("authorization");
+    const token = authHeader?.replace("Bearer ", "");
 
     if (!token) {
       return NextResponse.json(
-        { error: 'Unauthorized - No token provided' },
-        { status: 401 }
+        { error: "Unauthorized - No token provided" },
+        { status: 401 },
       );
     }
 
     // Custom fetch with timeout
-    const customFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const customFetch = async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 30000); // 30 second timeout
 
@@ -141,40 +180,50 @@ async function postHandler(request: Request) {
       {
         global: {
           headers: {
-            Authorization: `Bearer ${token}`
+            Authorization: `Bearer ${token}`,
           },
-          fetch: customFetch
-        }
-      }
+          fetch: customFetch,
+        },
+      },
     );
 
     // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
 
     if (authError || !user) {
-      log.error('Authentication error:', authError);
+      log.error("Authentication error:", authError);
       return NextResponse.json(
-        { error: 'Unauthorized - Please sign in' },
-        { status: 401 }
+        { error: "Unauthorized - Please sign in" },
+        { status: 401 },
       );
     }
 
     // Apply Rate Limiting
-    const ip = request.headers.get('x-forwarded-for') || 'unknown';
-    const rateLimit = checkRateLimit(user.id, SECURITY_CONFIG.RATE_LIMITS.GENERATE);
-    
+    const ip = request.headers.get("x-forwarded-for") || "unknown";
+    const rateLimit = checkRateLimit(
+      user.id,
+      SECURITY_CONFIG.RATE_LIMITS.GENERATE,
+    );
+
     if (!rateLimit.allowed) {
-      logSecurityEvent('RATE_LIMIT_EXCEEDED_RESUME', { userId: user.id, ip }, ip);
+      logSecurityEvent(
+        "RATE_LIMIT_EXCEEDED_RESUME",
+        { userId: user.id, ip },
+        ip,
+      );
       return NextResponse.json(
-        { 
-          error: 'Rate limit exceeded', 
+        {
+          error: "Rate limit exceeded",
           message: `Please wait ${rateLimit.retryAfter} seconds before trying again.`,
-          retryAfter: rateLimit.retryAfter 
+          retryAfter: rateLimit.retryAfter,
         },
-        { 
+        {
           status: 429,
-          headers: { 'Retry-After': rateLimit.retryAfter.toString() }
-        }
+          headers: { "Retry-After": rateLimit.retryAfter.toString() },
+        },
       );
     }
     const hasUnlimitedCredits = hasUnlimitedDeveloperCredits(user.email);
@@ -185,70 +234,87 @@ async function postHandler(request: Request) {
     // Get or create user credits (cached, 15 s TTL)
     const userCredits = await getCachedUserCredits(supabaseAdmin, user.id);
     if (!userCredits) {
-      log.error('Failed to load or initialize credits record');
+      log.error("Failed to load or initialize credits record");
       return NextResponse.json(
-        { error: 'Failed to initialize credits' },
-        { status: 500 }
+        { error: "Failed to initialize credits" },
+        { status: 500 },
       );
     }
 
     // Check if user has enough credits
     const creditsRemaining = hasUnlimitedCredits
       ? Number.MAX_SAFE_INTEGER
-      : calculateRemainingCredits(userCredits.credits_total, userCredits.credits_used);
+      : calculateRemainingCredits(
+          userCredits.credits_total,
+          userCredits.credits_used,
+        );
 
     if (!hasUnlimitedCredits && creditsRemaining < creditCost) {
       return NextResponse.json(
         {
-          error: 'Not enough credits',
+          error: "Not enough credits",
           message: `You need ${creditCost} credits to generate a resume. You have ${creditsRemaining} credits remaining.`,
           needsUpgrade: true,
           currentTier: userCredits.tier,
-          creditsRemaining
+          creditsRemaining,
         },
-        { status: 402 }
+        { status: 402 },
       );
     }
 
-    let prompt, name, email;
+    let prompt, name, email, phone, location;
     try {
-      const validatedData = await safeParseBody(request, resumeGenerationSchema);
+      const validatedData = await safeParseBody(
+        request,
+        resumeGenerationSchema,
+      );
       prompt = validatedData.prompt;
       name = validatedData.name;
       email = validatedData.email;
+      phone = validatedData.phone;
+      location = validatedData.location;
     } catch (validationError) {
       if (!(validationError instanceof RequestValidationError)) {
         throw validationError;
       }
       return NextResponse.json(
         { error: validationError.message, details: validationError.details },
-        { status: 400 }
+        { status: 400 },
       );
     }
-
 
     // Additional security checks - only check name and email for SQL injection
     // Note: We don't check prompt because it contains user-generated content like LinkedIn exports
     // that naturally contain words like "SELECT candidates" which trigger false positives.
     // The prompt is only passed to the AI model, not used in SQL queries.
     if (detectSqlInjection(name) || detectSqlInjection(email)) {
-      log.warn('Potential SQL injection attempt detected in name/email');
+      log.warn("Potential SQL injection attempt detected in name/email");
       return NextResponse.json(
-        { error: 'Invalid input detected' },
-        { status: 400 }
+        { error: "Invalid input detected" },
+        { status: 400 },
       );
     }
 
     // Sanitize all inputs consistently
-    const sanitizedInput = sanitizeObject({ prompt, name, email });
-    const { 
-      prompt: sanitizedPrompt, 
-      name: sanitizedName, 
-      email: sanitizedEmail 
+    const sanitizedInput = sanitizeObject({
+      prompt,
+      name,
+      email,
+      phone,
+      location,
+    });
+    const {
+      prompt: sanitizedPrompt,
+      name: sanitizedName,
+      email: sanitizedEmail,
     } = sanitizedInput;
 
     if (hasUnlimitedCredits) {
-      logDeveloperCreditBypass({ userId: user.id, email: user.email, action: 'resume' });
+      logDeveloperCreditBypass({
+        userId: user.id,
+        email: user.email,
+        action: "resume",
+      });
     }
 
     // Atomically reserve credits BEFORE generation to prevent the
@@ -260,13 +326,13 @@ async function postHandler(request: Request) {
         supabaseAdmin,
         user.id,
         userCredits!.credits_used,
-        creditCost
+        creditCost,
       );
       invalidateUserCredits(user.id);
       if (!reserved) {
         return NextResponse.json(
           creditReservationConflictResponse(creditCost, userCredits.tier),
-          { status: 402 }
+          { status: 402 },
         );
       }
     }
@@ -274,60 +340,74 @@ async function postHandler(request: Request) {
     // Generate resume - Try Gemini 2.0 Flash first (Enhanced ATS), fallback to Mistral
     let resume;
     try {
-      log.info('🚀 Generating resume with Gemini 2.0 Flash (Enhanced ATS)...');
-      
+      log.info("🚀 Generating resume with Gemini 2.0 Flash (Enhanced ATS)...");
+
       // Use a race to ensure Gemini doesn't hang the request
       const geminiPromise = generateResume({
         prompt: sanitizedPrompt,
         name: sanitizedName,
-        email: sanitizedEmail
+        email: sanitizedEmail,
       });
 
       // 25-second timeout for Gemini specifically (within the 30s overall limit)
       const timeoutPromise = new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('Gemini request timed out')), 25000)
+        setTimeout(() => reject(new Error("Gemini request timed out")), 25000),
       );
 
-      resume = await Promise.race([geminiPromise, timeoutPromise]) as any;
-      log.info('✅ Resume generated with Gemini');
+      resume = (await Promise.race([geminiPromise, timeoutPromise])) as any;
+      log.info("✅ Resume generated with Gemini");
     } catch (geminiError: any) {
-      log.warn('⚠️ Gemini failed or timed out, falling back to Mistral:', geminiError.message);
+      log.warn(
+        "⚠️ Gemini failed or timed out, falling back to Mistral:",
+        geminiError.message,
+      );
       try {
-        log.info('🚀 Generating resume with Mistral fallback...');
+        log.info("🚀 Generating resume with Mistral fallback...");
         resume = await generateResumeWithMistral({
           prompt: sanitizedPrompt,
           name: sanitizedName,
-          email: sanitizedEmail
+          email: sanitizedEmail,
+          phone: sanitizedInput.phone,
+          location: sanitizedInput.location,
         });
-        log.info('✅ Resume generated with Mistral');
+        log.info("✅ Resume generated with Mistral");
       } catch (mistralError: any) {
-        log.error('❌ Both Gemini and Mistral failed');
+        log.error("❌ Both Gemini and Mistral failed");
         if (!hasUnlimitedCredits) {
           await refundCredits(supabaseAdmin, user.id, creditCost);
           invalidateUserCredits(user.id);
         }
-        throw new Error('Unable to generate resume. Please try again later.');
+        throw new Error("Unable to generate resume. Please try again later.");
       }
     }
 
     // Fire-and-forget: log write does not block the response
     if (!hasUnlimitedCredits) {
       supabaseAdmin
-        .from('credit_usage_log')
-        .insert({ user_id: user.id, action_type: 'resume', credits_used: creditCost, metadata: { prompt_length: sanitizedPrompt.length } })
-        .then(({ error }) => { if (error) log.error('Failed to log credit usage:', error); });
+        .from("credit_usage_log")
+        .insert({
+          user_id: user.id,
+          action_type: "resume",
+          credits_used: creditCost,
+          metadata: { prompt_length: sanitizedPrompt.length },
+        })
+        .then(({ error }) => {
+          if (error) log.error("Failed to log credit usage:", error);
+        });
     }
 
     // Save resume to documents table for history
-    const resumeTitle = resume.name ? `${resume.name}'s Resume` : 'Untitled Resume';
+    const resumeTitle = resume.name
+      ? `${resume.name}'s Resume`
+      : "Untitled Resume";
 
     try {
       // First try to save to documents table
       const { data: savedDoc, error: docError } = await supabaseAdmin
-        .from('documents')
+        .from("documents")
         .insert({
           user_id: user.id,
-          type: 'resume',
+          type: "resume",
           title: resumeTitle,
           content: { resumeData: resume, prompt: sanitizedPrompt },
         })
@@ -335,11 +415,11 @@ async function postHandler(request: Request) {
         .single();
 
       if (docError) {
-        log.error('Failed to save to documents table:', docError);
+        log.error("Failed to save to documents table:", docError);
 
         // Fallback: Try saving to resumes table
         const { error: resumeError } = await supabaseAdmin
-          .from('resumes')
+          .from("resumes")
           .insert({
             user_id: user.id,
             title: resumeTitle,
@@ -350,45 +430,47 @@ async function postHandler(request: Request) {
               location: resume.location,
             },
             content: resume,
-            template: 'deedy-resume',
+            template: "deedy-resume",
           });
 
         if (resumeError) {
-          log.error('Failed to save to resumes table:', resumeError);
+          log.error("Failed to save to resumes table:", resumeError);
         } else {
-          log.info('📄 Resume saved to resumes table');
+          log.info("📄 Resume saved to resumes table");
         }
       } else {
-        log.info('📄 Resume saved to documents table:', savedDoc?.id);
+        log.info("📄 Resume saved to documents table:", savedDoc?.id);
       }
     } catch (saveError) {
-      log.error('Error saving resume:', saveError);
+      log.error("Error saving resume:", saveError);
       // Don't fail the request if saving fails
     }
 
     return NextResponse.json(resume, { status: 200 });
-
   } catch (error: any) {
     incrementErrorCount();
-    log.error('❌ Resume generation error:', {
+    log.error("❌ Resume generation error:", {
       message: error.message,
       name: error.name,
-      stack: error.stack?.split('\n').slice(0, 3)
+      stack: error.stack?.split("\n").slice(0, 3),
     });
 
     // Provide detailed, user-friendly error messages
-    let errorMessage = 'Failed to generate resume';
-    let errorDetails = error.message || 'Unknown error occurred';
+    let errorMessage = "Failed to generate resume";
+    let errorDetails = error.message || "Unknown error occurred";
 
-    if (error.message?.includes('API key')) {
-      errorMessage = 'AI service configuration error';
-      errorDetails = 'The AI service is not properly configured. Please contact support.';
-    } else if (error.message?.includes('quota')) {
-      errorMessage = 'Service temporarily unavailable';
-      errorDetails = 'The AI service has reached its limit. Please try again in a few minutes.';
-    } else if (error.message?.includes('timeout')) {
-      errorMessage = 'Request timeout';
-      errorDetails = 'The request took too long. Please try again with a shorter prompt.';
+    if (error.message?.includes("API key")) {
+      errorMessage = "AI service configuration error";
+      errorDetails =
+        "The AI service is not properly configured. Please contact support.";
+    } else if (error.message?.includes("quota")) {
+      errorMessage = "Service temporarily unavailable";
+      errorDetails =
+        "The AI service has reached its limit. Please try again in a few minutes.";
+    } else if (error.message?.includes("timeout")) {
+      errorMessage = "Request timeout";
+      errorDetails =
+        "The request took too long. Please try again with a shorter prompt.";
     }
     // Re-throw so the global error handler captures request context and stack trace
     throw error;


### PR DESCRIPTION
# Description
 
`app/api/generate/resume/route.ts` uses Mistral as a fallback when Gemini is unavailable. The `generateResumeWithMistral` function had `+1 (555) 123-4567` and `City, State` hardcoded directly into the AI system prompt. Mistral faithfully followed these instructions and returned fake contact info in every resume it generated — even when the user had provided their real phone number and location. There was no post-processing step to replace these values.
 
This PR updates `generateResumeWithMistral` to accept optional `phone` and `location` parameters and injects the real values into the prompt when available. If the values are not provided, the prompt now instructs Mistral to leave those fields as empty strings rather than inventing data.
 
Fixes #1040 
 
## Type of change
 
- [x] Bug fix (non-breaking change which fixes an issue)
## Changes Made
 
- Extended `generateResumeWithMistral` function signature to accept optional `phone?: string` and `location?: string` parameters
- Replaced hardcoded `"+1 (555) 123-4567"` and `"City, State"` in the system prompt with conditional template strings that use real values when provided, or instruct the model to leave those fields empty when not provided
- Updated the call site (line ~297) to pass `sanitizedInput.phone` and `sanitizedInput.location` through to the function — these values are already available in scope from the existing `sanitizeObject` call
- No changes to Gemini path, credit logic, auth, or any other part of the route
## Dependencies
 
- None. No new packages or config changes required.
# How Has This Been Tested?
 
- [x] Test A — Forced Mistral fallback by temporarily setting an invalid `GEMINI_API_KEY` in `.env.local`. Submitted a resume generation request with real phone `+91-9876543210` and location `Mumbai, India`. Confirmed the generated resume JSON contains the real values, not `+1 (555) 123-4567` or `City, State`.
- [x] Test B — Submitted a resume generation request with phone and location fields left blank. Confirmed the generated resume has empty strings for those fields instead of fabricated placeholders.
- [x] Test C — Restored a valid `GEMINI_API_KEY` and confirmed the Gemini path is completely unaffected — resumes still generate correctly via Gemini.
- [x] Test D — Ran `npx jest` to confirm all existing tests pass with no regressions.
## Add Screenshots
 
_No UI changes. The fix is in the API layer — the resume output now contains correct user-provided contact info instead of fake placeholders._
 
## Checklist
 
- [x] My code follows the style guidelines of this project
- [x] I have tested my changes across major browsers/devices
- [x] I have tested my changes in development mode (`npm run dev`)
- [x] I have successfully run `npm run lint` and resolved all warnings/errors
- [x] I have successfully run `npm run typecheck` and resolved all TypeScript errors
- [x] New and existing unit tests pass locally with my changes (`npx jest`)
- [x] I have written or updated related tests, if necessary
- [x] This is already assigned Issue to me, not an unassigned issue.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume generation now includes phone number and location details when provided.

* **Bug Fixes**
  * Improved resume generation reliability with a fallback path if the primary AI service fails.
  * Added clearer responses for rate limits and insufficient credits.
  * Prevents requests from failing silently when credit data cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->