### PR TITLE
fix: remove debug console.log statements from production code

### DIFF
--- a/app/api/analyze-ats/route.ts
+++ b/app/api/analyze-ats/route.ts
@@ -1,47 +1,73 @@
-import { logger } from '@/lib/logger';
-export const dynamic = 'force-dynamic';
-import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
-import { ACTION_COSTS, TIER_LIMITS, getCreditsResetDate, shouldResetCredits, calculateRemainingCredits } from '@/lib/credits-service';
-import { hasUnlimitedDeveloperCredits, logDeveloperCreditBypass } from '@/lib/developer-credit-bypass';
-import { reserveCredits, refundCredits, creditReservationConflictResponse } from '@/lib/credit-operations';
+import { logger } from "@/lib/logger";
+export const dynamic = "force-dynamic";
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import {
+  ACTION_COSTS,
+  TIER_LIMITS,
+  getCreditsResetDate,
+  shouldResetCredits,
+  calculateRemainingCredits,
+} from "@/lib/credits-service";
+import {
+  hasUnlimitedDeveloperCredits,
+  logDeveloperCreditBypass,
+} from "@/lib/developer-credit-bypass";
+import {
+  reserveCredits,
+  refundCredits,
+  creditReservationConflictResponse,
+} from "@/lib/credit-operations";
 
 const MISTRAL_API_KEY = process.env.MISTRAL_API_KEY;
 
 // Service role client for credit operations
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
 
 export async function POST(request: Request) {
   try {
     // ✅ CHECK API KEY FIRST - fail fast if service is misconfigured
     if (!MISTRAL_API_KEY) {
-      logger.error({ route: 'app/api/analyze-ats/route.ts' }, 'MISTRAL_API_KEY is not configured');
+      logger.error(
+        { route: "app/api/analyze-ats/route.ts" },
+        "MISTRAL_API_KEY is not configured",
+      );
       return NextResponse.json(
-        { error: 'AI service is not properly configured. Please contact support.' },
-        { status: 503 }
+        {
+          error:
+            "AI service is not properly configured. Please contact support.",
+        },
+        { status: 503 },
       );
     }
 
     // ✅ AUTHENTICATION CHECK
-    const authHeader = request.headers.get('Authorization');
-    const token = authHeader?.replace('Bearer ', '');
-    
+    const authHeader = request.headers.get("Authorization");
+    const token = authHeader?.replace("Bearer ", "");
+
     if (!token) {
       return NextResponse.json(
-        { error: 'Authentication required. Please sign in to analyze resumes.' },
-        { status: 401 }
+        {
+          error: "Authentication required. Please sign in to analyze resumes.",
+        },
+        { status: 401 },
       );
     }
 
-    const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token);
-    
+    const {
+      data: { user },
+      error: authError,
+    } = await supabaseAdmin.auth.getUser(token);
+
     if (authError || !user) {
       return NextResponse.json(
-        { error: 'Authentication required. Please sign in to analyze resumes.' },
-        { status: 401 }
+        {
+          error: "Authentication required. Please sign in to analyze resumes.",
+        },
+        { status: 401 },
       );
     }
     const hasUnlimitedCredits = hasUnlimitedDeveloperCredits(user.email);
@@ -50,40 +76,44 @@ export async function POST(request: Request) {
 
     if (!resumeText || resumeText.trim().length < 20) {
       return NextResponse.json(
-        { error: 'Resume text is required and must be at least 20 characters' },
-        { status: 400 }
+        { error: "Resume text is required and must be at least 20 characters" },
+        { status: 400 },
       );
     }
 
     // Check user credits
     const creditCost = ACTION_COSTS.ats_check;
-    
+
     // Get or create user credits
     let { data: userCredits } = await supabaseAdmin
-      .from('user_credits')
-      .select('*')
-      .eq('user_id', user.id)
+      .from("user_credits")
+      .select("*")
+      .eq("user_id", user.id)
       .single();
 
     // If no credits record exists, create one
     if (!userCredits) {
       const { data: newCredits, error: insertError } = await supabaseAdmin
-        .from('user_credits')
+        .from("user_credits")
         .insert({
           user_id: user.id,
-          tier: 'free',
+          tier: "free",
           credits_total: TIER_LIMITS.free,
           credits_used: 0,
-          credits_reset_at: getCreditsResetDate()
+          credits_reset_at: getCreditsResetDate(),
         })
         .select()
         .single();
-      
+
       if (insertError) {
-        logger.error({ route: 'app/api/analyze-ats/route.ts' }, 'Failed to create credits record:', insertError);
+        logger.error(
+          { route: "app/api/analyze-ats/route.ts" },
+          "Failed to create credits record:",
+          insertError,
+        );
         return NextResponse.json(
-          { error: 'Failed to initialize credits' },
-          { status: 500 }
+          { error: "Failed to initialize credits" },
+          { status: 500 },
         );
       }
       userCredits = newCredits;
@@ -93,12 +123,12 @@ export async function POST(request: Request) {
     if (userCredits && shouldResetCredits(userCredits.credits_reset_at)) {
       const resetAt = getCreditsResetDate();
       const { data: updatedCredits } = await supabaseAdmin
-        .from('user_credits')
+        .from("user_credits")
         .update({
           credits_used: 0,
           credits_reset_at: resetAt,
         })
-        .eq('user_id', user.id)
+        .eq("user_id", user.id)
         .select()
         .single();
 
@@ -110,18 +140,21 @@ export async function POST(request: Request) {
     // Check if user has enough credits
     const creditsRemaining = hasUnlimitedCredits
       ? Number.MAX_SAFE_INTEGER
-      : calculateRemainingCredits(userCredits.credits_total, userCredits.credits_used);
-    
+      : calculateRemainingCredits(
+          userCredits.credits_total,
+          userCredits.credits_used,
+        );
+
     if (!hasUnlimitedCredits && creditsRemaining < creditCost) {
       return NextResponse.json(
         {
-          error: 'Not enough credits',
+          error: "Not enough credits",
           message: `You need ${creditCost} credits to analyze a resume. You have ${creditsRemaining} credits remaining.`,
           needsUpgrade: true,
           currentTier: userCredits.tier,
-          creditsRemaining
+          creditsRemaining,
         },
-        { status: 402 }
+        { status: 402 },
       );
     }
 
@@ -132,19 +165,23 @@ export async function POST(request: Request) {
         supabaseAdmin,
         user.id,
         userCredits.credits_used,
-        creditCost
+        creditCost,
       );
       if (!reserved) {
         return NextResponse.json(
           creditReservationConflictResponse(creditCost, userCredits.tier),
-          { status: 402 }
+          { status: 402 },
         );
       }
       userCredits = reserved;
     }
 
     if (hasUnlimitedCredits) {
-      logDeveloperCreditBypass({ userId: user.id, email: user.email, action: 'ats_check' });
+      logDeveloperCreditBypass({
+        userId: user.id,
+        email: user.email,
+        action: "ats_check",
+      });
     }
 
     // Single refund-on-exit guard for everything after the reservation:
@@ -152,8 +189,7 @@ export async function POST(request: Request) {
     // exception) refunds via finally; success flips the flag off.
     let refundOnExit = !hasUnlimitedCredits;
     try {
-
-    const systemPrompt = `You are an expert ATS (Applicant Tracking System) analyzer. Analyze the provided resume text and return a detailed ATS compatibility score with actionable suggestions.
+      const systemPrompt = `You are an expert ATS (Applicant Tracking System) analyzer. Analyze the provided resume text and return a detailed ATS compatibility score with actionable suggestions.
 
 You MUST respond with a valid JSON object in this exact format:
 {
@@ -196,133 +232,158 @@ Grade Scale:
 
 IMPORTANT: Return ONLY the JSON object, no additional text or markdown.`;
 
-    const userPrompt = jobDescription 
-      ? `Analyze this resume for ATS compatibility, considering the target job description.
+      const userPrompt = jobDescription
+        ? `Analyze this resume for ATS compatibility, considering the target job description.
 
 RESUME:
 ${resumeText}
 
 JOB DESCRIPTION:
 ${jobDescription}`
-      : `Analyze this resume for ATS compatibility:
+        : `Analyze this resume for ATS compatibility:
 
 RESUME:
 ${resumeText}`;
 
-    const response = await fetch('https://api.mistral.ai/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${MISTRAL_API_KEY}`,
-      },
-      body: JSON.stringify({
-        model: 'mistral-large-latest',
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userPrompt }
-        ],
-        temperature: 0.3,
-        max_tokens: 2000,
-      }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      logger.error({ route: 'app/api/analyze-ats/route.ts' }, 'Mistral API error:', errorText);
-      return NextResponse.json(
-        { error: 'Failed to analyze resume. Please try again.' },
-        { status: 500 }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content;
-
-    if (!content) {
-      return NextResponse.json(
-        { error: 'No analysis result received' },
-        { status: 500 }
-      );
-    }
-
-    // Parse the JSON response
-    let analysisResult;
-    try {
-      // Try to extract JSON from the response (in case there's extra text)
-      const jsonMatch = content.match(/\{[\s\S]*\}/);
-      if (jsonMatch) {
-        analysisResult = JSON.parse(jsonMatch[0]);
-      } else {
-        throw new Error('No JSON found in response');
-      }
-    } catch (parseError) {
-      logger.error({ route: 'app/api/analyze-ats/route.ts' }, 'Failed to parse analysis result:', content);
-      // Return a default analysis if parsing fails
-      analysisResult = {
-        score: 65,
-        grade: 'C',
-        summary: 'Resume analyzed but detailed parsing was limited.',
-        categories: {
-          formatting: 70,
-          keywords: 60,
-          experience: 65,
-          skills: 65,
-          education: 70,
-          contact_info: 75
+      const response = await fetch(
+        "https://api.mistral.ai/v1/chat/completions",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${MISTRAL_API_KEY}`,
+          },
+          body: JSON.stringify({
+            model: "mistral-large-latest",
+            messages: [
+              { role: "system", content: systemPrompt },
+              { role: "user", content: userPrompt },
+            ],
+            temperature: 0.3,
+            max_tokens: 2000,
+          }),
         },
-        suggestions: [
-          'Add more industry-specific keywords',
-          'Include quantifiable achievements',
-          'Ensure contact information is complete',
-          'Use clear section headers',
-          'Add relevant skills section'
-        ],
-        keywords_found: [],
-        keywords_missing: ['action verbs', 'metrics', 'achievements']
-      };
-    }
+      );
 
-    // The user gets a result (either the parsed analysis or the fallback
-    // default). Mark the reservation as kept BEFORE returning so the
-    // finally guard doesn't refund a successful generation.
-    refundOnExit = false;
-
-    // Log the usage now that the analysis succeeded. Credits were already
-    // reserved atomically above.
-    if (!hasUnlimitedCredits) {
-      const { error: logError } = await supabaseAdmin
-        .from('credit_usage_log')
-        .insert({
-          user_id: user.id,
-          action: 'ats_check',
-          credits_used: creditCost,
-          metadata: { has_job_description: !!jobDescription, resume_length: resumeText.length }
-        });
-
-      if (logError) {
-        logger.error({ route: 'app/api/analyze-ats/route.ts' }, 'Failed to log credit usage:', logError);
-      } else {
-        // console.log(`💳 Deducted ${creditCost} credits for ATS analysis`);
+      if (!response.ok) {
+        const errorText = await response.text();
+        logger.error(
+          { route: "app/api/analyze-ats/route.ts" },
+          "Mistral API error:",
+          errorText,
+        );
+        return NextResponse.json(
+          { error: "Failed to analyze resume. Please try again." },
+          { status: 500 },
+        );
       }
-    }
 
-    return NextResponse.json(analysisResult);
+      const data = await response.json();
+      const content = data.choices?.[0]?.message?.content;
 
+      if (!content) {
+        return NextResponse.json(
+          { error: "No analysis result received" },
+          { status: 500 },
+        );
+      }
+
+      // Parse the JSON response
+      let analysisResult;
+      try {
+        // Try to extract JSON from the response (in case there's extra text)
+        const jsonMatch = content.match(/\{[\s\S]*\}/);
+        if (jsonMatch) {
+          analysisResult = JSON.parse(jsonMatch[0]);
+        } else {
+          throw new Error("No JSON found in response");
+        }
+      } catch (parseError) {
+        logger.error(
+          { route: "app/api/analyze-ats/route.ts" },
+          "Failed to parse analysis result:",
+          content,
+        );
+        // Return a default analysis if parsing fails
+        analysisResult = {
+          score: 65,
+          grade: "C",
+          summary: "Resume analyzed but detailed parsing was limited.",
+          categories: {
+            formatting: 70,
+            keywords: 60,
+            experience: 65,
+            skills: 65,
+            education: 70,
+            contact_info: 75,
+          },
+          suggestions: [
+            "Add more industry-specific keywords",
+            "Include quantifiable achievements",
+            "Ensure contact information is complete",
+            "Use clear section headers",
+            "Add relevant skills section",
+          ],
+          keywords_found: [],
+          keywords_missing: ["action verbs", "metrics", "achievements"],
+        };
+      }
+
+      // The user gets a result (either the parsed analysis or the fallback
+      // default). Mark the reservation as kept BEFORE returning so the
+      // finally guard doesn't refund a successful generation.
+      refundOnExit = false;
+
+      // Log the usage now that the analysis succeeded. Credits were already
+      // reserved atomically above.
+      if (!hasUnlimitedCredits) {
+        const { error: logError } = await supabaseAdmin
+          .from("credit_usage_log")
+          .insert({
+            user_id: user.id,
+            action: "ats_check",
+            credits_used: creditCost,
+            metadata: {
+              has_job_description: !!jobDescription,
+              resume_length: resumeText.length,
+            },
+          });
+
+        if (logError) {
+          logger.error(
+            { route: "app/api/analyze-ats/route.ts" },
+            "Failed to log credit usage:",
+            logError,
+          );
+        } else {
+        }
+      }
+
+      return NextResponse.json(analysisResult);
     } finally {
       if (refundOnExit) {
-        const refunded = await refundCredits(supabaseAdmin, user.id, creditCost);
+        const refunded = await refundCredits(
+          supabaseAdmin,
+          user.id,
+          creditCost,
+        );
         if (!refunded) {
-          logger.error({ route: 'app/api/analyze-ats/route.ts' }, `Failed to refund ${creditCost} credits after ATS analysis failure for user ${user.id}`);
+          logger.error(
+            { route: "app/api/analyze-ats/route.ts" },
+            `Failed to refund ${creditCost} credits after ATS analysis failure for user ${user.id}`,
+          );
         }
       }
     }
-
   } catch (error) {
-    logger.error({ route: 'app/api/analyze-ats/route.ts' }, 'ATS analysis error:', error);
+    logger.error(
+      { route: "app/api/analyze-ats/route.ts" },
+      "ATS analysis error:",
+      error,
+    );
     return NextResponse.json(
-      { error: 'Failed to analyze resume. Please try again.' },
-      { status: 500 }
+      { error: "Failed to analyze resume. Please try again." },
+      { status: 500 },
     );
   }
 }
-

--- a/app/api/generate/diagram/route.ts
+++ b/app/api/generate/diagram/route.ts
@@ -1,81 +1,98 @@
-import { logger } from '@/lib/logger';
-export const dynamic = 'force-dynamic';
-export const runtime = 'nodejs';
+import { logger } from "@/lib/logger";
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
-import { NextResponse } from 'next/server';
-import { generateDiagramWithMistral } from '@/lib/mistral';
-import { createClient } from '@supabase/supabase-js';
-import { ACTION_COSTS, calculateRemainingCredits } from '@/lib/credits-service';
-import { hasUnlimitedDeveloperCredits, logDeveloperCreditBypass } from '@/lib/developer-credit-bypass';
-import { reserveCredits, refundCredits, creditReservationConflictResponse } from '@/lib/credit-operations';
-import { getCachedUserCredits, invalidateUserCredits } from '@/lib/cached-queries';
+import { NextResponse } from "next/server";
+import { generateDiagramWithMistral } from "@/lib/mistral";
+import { createClient } from "@supabase/supabase-js";
+import { ACTION_COSTS, calculateRemainingCredits } from "@/lib/credits-service";
+import {
+  hasUnlimitedDeveloperCredits,
+  logDeveloperCreditBypass,
+} from "@/lib/developer-credit-bypass";
+import {
+  reserveCredits,
+  refundCredits,
+  creditReservationConflictResponse,
+} from "@/lib/credit-operations";
+import {
+  getCachedUserCredits,
+  invalidateUserCredits,
+} from "@/lib/cached-queries";
 
 // Service role client for credit operations
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
 
 export async function POST(request: Request) {
   try {
     // ✅ AUTHENTICATION CHECK
-    const authHeader = request.headers.get('Authorization');
-    const token = authHeader?.replace('Bearer ', '');
-    
+    const authHeader = request.headers.get("Authorization");
+    const token = authHeader?.replace("Bearer ", "");
+
     if (!token) {
       return NextResponse.json(
-        { error: 'Authentication required. Please sign in to create diagrams.' },
-        { status: 401 }
+        {
+          error: "Authentication required. Please sign in to create diagrams.",
+        },
+        { status: 401 },
       );
     }
 
-    const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token);
-    
+    const {
+      data: { user },
+      error: authError,
+    } = await supabaseAdmin.auth.getUser(token);
+
     if (authError || !user) {
       return NextResponse.json(
-        { error: 'Authentication required. Please sign in to create diagrams.' },
-        { status: 401 }
+        {
+          error: "Authentication required. Please sign in to create diagrams.",
+        },
+        { status: 401 },
       );
     }
     const hasUnlimitedCredits = hasUnlimitedDeveloperCredits(user.email);
 
     const body = await request.json();
-    const { prompt, diagramType = 'flowchart' } = body;
+    const { prompt, diagramType = "flowchart" } = body;
 
     if (!prompt) {
-      return NextResponse.json(
-        { error: 'Missing prompt' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Missing prompt" }, { status: 400 });
     }
 
     // Check user credits
     const creditCost = ACTION_COSTS.diagram;
-    
+
     // Get or create user credits (cached, 15 s TTL)
     const userCredits = await getCachedUserCredits(supabaseAdmin, user.id);
     if (!userCredits) {
       return NextResponse.json(
-        { error: 'Failed to initialize credits' },
-        { status: 500 }
+        { error: "Failed to initialize credits" },
+        { status: 500 },
       );
     }
 
     // Check if user has enough credits
     const creditsRemaining = hasUnlimitedCredits
       ? Number.MAX_SAFE_INTEGER
-      : calculateRemainingCredits(userCredits.credits_total, userCredits.credits_used);
-    
+      : calculateRemainingCredits(
+          userCredits.credits_total,
+          userCredits.credits_used,
+        );
+
     if (!hasUnlimitedCredits && creditsRemaining < creditCost) {
       return NextResponse.json(
         {
-          error: 'Not enough credits',
+          error: "Not enough credits",
           message: `You need ${creditCost} credits to generate a diagram. You have ${creditsRemaining} credits remaining.`,
           needsUpgrade: true,
           currentTier: userCredits.tier,
-          creditsRemaining
+          creditsRemaining,
         },
-        { status: 402 }
+        { status: 402 },
       );
     }
 
@@ -86,81 +103,116 @@ export async function POST(request: Request) {
         supabaseAdmin,
         user.id,
         userCredits.credits_used,
-        creditCost
+        creditCost,
       );
       invalidateUserCredits(user.id);
       if (!reserved) {
         return NextResponse.json(
           creditReservationConflictResponse(creditCost, userCredits.tier),
-          { status: 402 }
+          { status: 402 },
         );
       }
     }
 
     if (hasUnlimitedCredits) {
-      logDeveloperCreditBypass({ userId: user.id, email: user.email, action: 'diagram' });
+      logDeveloperCreditBypass({
+        userId: user.id,
+        email: user.email,
+        action: "diagram",
+      });
     }
-
-    // console.log(`📊 Generating ${diagramType} diagram with Mistral...`);
 
     let diagram;
     try {
       diagram = await generateDiagramWithMistral({ prompt, diagramType });
     } catch (genError) {
-      logger.error({ route: 'app/api/generate/diagram/route.ts' }, 'Diagram generation failed:', genError);
+      logger.error(
+        { route: "app/api/generate/diagram/route.ts" },
+        "Diagram generation failed:",
+        genError,
+      );
       if (!hasUnlimitedCredits) {
         await refundCredits(supabaseAdmin, user.id, creditCost);
         invalidateUserCredits(user.id);
       }
-      const errorMsg = genError instanceof Error ? genError.message : 'Unknown error during generation';
+      const errorMsg =
+        genError instanceof Error
+          ? genError.message
+          : "Unknown error during generation";
       return NextResponse.json(
         {
-          error: 'Diagram generation failed',
-          message: errorMsg.includes('parse') ? 'Invalid response format from AI. Please try again with a different description.' : errorMsg,
+          error: "Diagram generation failed",
+          message: errorMsg.includes("parse")
+            ? "Invalid response format from AI. Please try again with a different description."
+            : errorMsg,
           details: errorMsg,
-          hint: 'Try being more specific in your description or use shorter text for labels.'
+          hint: "Try being more specific in your description or use shorter text for labels.",
         },
-        { status: 500 }
+        { status: 500 },
       );
     }
 
     // Validate diagram response
     if (!diagram || !diagram.code) {
-      logger.error({ route: 'app/api/generate/diagram/route.ts' }, 'Invalid diagram response:', diagram);
+      logger.error(
+        { route: "app/api/generate/diagram/route.ts" },
+        "Invalid diagram response:",
+        diagram,
+      );
       if (!hasUnlimitedCredits) {
         await refundCredits(supabaseAdmin, user.id, creditCost);
         invalidateUserCredits(user.id);
       }
       return NextResponse.json(
         {
-          error: 'Invalid diagram response',
-          message: 'The AI did not generate valid diagram code. Please try again with a simpler description.',
-          details: 'Missing code field in response',
-          hint: 'Try: "Simple flowchart with 5 steps for user login process"'
+          error: "Invalid diagram response",
+          message:
+            "The AI did not generate valid diagram code. Please try again with a simpler description.",
+          details: "Missing code field in response",
+          hint: 'Try: "Simple flowchart with 5 steps for user login process"',
         },
-        { status: 500 }
+        { status: 500 },
       );
     }
 
     // Validate Mermaid syntax
     const diagramCode = diagram.code.trim();
-    const validDiagramTypes = ['flowchart', 'graph', 'sequenceDiagram', 'classDiagram', 'stateDiagram', 'erDiagram', 'journey', 'gantt', 'pie', 'gitGraph', 'mindmap', 'timeline'];
-    const hasValidStart = validDiagramTypes.some(type => diagramCode.toLowerCase().startsWith(type.toLowerCase()));
+    const validDiagramTypes = [
+      "flowchart",
+      "graph",
+      "sequenceDiagram",
+      "classDiagram",
+      "stateDiagram",
+      "erDiagram",
+      "journey",
+      "gantt",
+      "pie",
+      "gitGraph",
+      "mindmap",
+      "timeline",
+    ];
+    const hasValidStart = validDiagramTypes.some((type) =>
+      diagramCode.toLowerCase().startsWith(type.toLowerCase()),
+    );
 
     if (!hasValidStart) {
-      logger.error({ route: 'app/api/generate/diagram/route.ts' }, 'Invalid diagram type in code:', diagramCode.substring(0, 50));
+      logger.error(
+        { route: "app/api/generate/diagram/route.ts" },
+        "Invalid diagram type in code:",
+        diagramCode.substring(0, 50),
+      );
       if (!hasUnlimitedCredits) {
         await refundCredits(supabaseAdmin, user.id, creditCost);
         invalidateUserCredits(user.id);
       }
       return NextResponse.json(
         {
-          error: 'Invalid diagram syntax',
-          message: `Diagram must start with one of: ${validDiagramTypes.join(', ')}`,
+          error: "Invalid diagram syntax",
+          message: `Diagram must start with one of: ${validDiagramTypes.join(", ")}`,
           details: `Generated code starts with: ${diagramCode.substring(0, 30)}...`,
-          hint: 'Regenerate or manually edit to start with a valid diagram type.'
+          hint: "Regenerate or manually edit to start with a valid diagram type.",
         },
-        { status: 422 }
+        { status: 422 },
       );
     }
 
@@ -172,35 +224,46 @@ export async function POST(request: Request) {
       }
       return NextResponse.json(
         {
-          error: 'Diagram too short',
-          message: 'Generated diagram is too simple. Please provide a more detailed description.',
-          hint: 'Try a more detailed prompt, for example: "Create a flowchart for an ecommerce checkout process"'
+          error: "Diagram too short",
+          message:
+            "Generated diagram is too simple. Please provide a more detailed description.",
+          hint: 'Try a more detailed prompt, for example: "Create a flowchart for an ecommerce checkout process"',
         },
-        { status: 422 }
+        { status: 422 },
       );
     }
-
-    // console.log('✅ Diagram generated successfully with Mistral');
 
     // Fire-and-forget: log write does not block the response
     if (!hasUnlimitedCredits) {
       supabaseAdmin
-        .from('credit_usage_log')
-        .insert({ user_id: user.id, action_type: 'diagram', credits_used: creditCost, metadata: { diagram_type: diagramType, prompt_length: prompt.length } })
-        .then(({ error }) => { if (error) console.error('Failed to log credit usage:', error); });
+        .from("credit_usage_log")
+        .insert({
+          user_id: user.id,
+          action_type: "diagram",
+          credits_used: creditCost,
+          metadata: { diagram_type: diagramType, prompt_length: prompt.length },
+        })
+        .then(({ error }) => {
+          if (error) console.error("Failed to log credit usage:", error);
+        });
     }
 
     return NextResponse.json(diagram);
   } catch (error) {
-    logger.error({ route: 'app/api/generate/diagram/route.ts' }, 'Error generating diagram:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    logger.error(
+      { route: "app/api/generate/diagram/route.ts" },
+      "Error generating diagram:",
+      error,
+    );
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
     return NextResponse.json(
-      { 
-        error: 'Failed to generate diagram',
-        message: 'An unexpected error occurred. Please try again.',
-        details: errorMessage
+      {
+        error: "Failed to generate diagram",
+        message: "An unexpected error occurred. Please try again.",
+        details: errorMessage,
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/api/generate/letter/route.ts
+++ b/app/api/generate/letter/route.ts
@@ -1,4 +1,4 @@
-import { logger } from '@/lib/logger';
+import { logger } from "@/lib/logger";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 export const maxDuration = 60; // Allow 60 seconds for AI generation (Vercel Hobby limit)
@@ -9,11 +9,11 @@ import {
   generateCoverLetterFromJob,
 } from "@/lib/mistral";
 import { createClient } from "@supabase/supabase-js";
+import { ACTION_COSTS, calculateRemainingCredits } from "@/lib/credits-service";
 import {
-  ACTION_COSTS,
-  calculateRemainingCredits,
-} from "@/lib/credits-service";
-import { hasUnlimitedDeveloperCredits, logDeveloperCreditBypass } from "@/lib/developer-credit-bypass";
+  hasUnlimitedDeveloperCredits,
+  logDeveloperCreditBypass,
+} from "@/lib/developer-credit-bypass";
 import {
   reserveCredits,
   refundCredits,
@@ -24,7 +24,10 @@ import {
   RequestValidationError,
   safeParseBody,
 } from "@/lib/validation";
-import { getCachedUserCredits, invalidateUserCredits } from "@/lib/cached-queries";
+import {
+  getCachedUserCredits,
+  invalidateUserCredits,
+} from "@/lib/cached-queries";
 
 // Service role client for credit operations
 const supabaseAdmin = createClient(
@@ -99,15 +102,19 @@ export async function POST(request: Request) {
     // user_credits row, so a malformed request must be rejected first.
     if (!isCoverLetter && (!prompt || !fromName || !toName || !letterType)) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
-        { status: 400 }
+        { error: "Missing required fields" },
+        { status: 400 },
       );
     }
 
     // Check user credits
     const creditCost = ACTION_COSTS[actionType];
     if (hasUnlimitedCredits) {
-      logDeveloperCreditBypass({ userId: user.id, email: user.email, action: actionType });
+      logDeveloperCreditBypass({
+        userId: user.id,
+        email: user.email,
+        action: actionType,
+      });
     }
 
     // Get or create user credits (cached, 15 s TTL)
@@ -160,8 +167,6 @@ export async function POST(request: Request) {
 
     // Cover-letter branch
     if (isCoverLetter) {
-      // console.log("📝 Generating cover letter from job description with Mistral...");
-      
       const coverJobDescription = jobDescription as string;
       const coverFromName = fromName as string;
 
@@ -191,15 +196,21 @@ export async function POST(request: Request) {
       if (!hasUnlimitedCredits) {
         supabaseAdmin
           .from("credit_usage_log")
-          .insert({ user_id: user.id, action_type: actionType, credits_used: creditCost, metadata: { type: "cover_letter", has_job_description: true } })
-          .then(({ error }) => { if (error) console.error("Failed to log credit usage:", error); });
+          .insert({
+            user_id: user.id,
+            action_type: actionType,
+            credits_used: creditCost,
+            metadata: { type: "cover_letter", has_job_description: true },
+          })
+          .then(({ error }) => {
+            if (error) console.error("Failed to log credit usage:", error);
+          });
       }
 
       return NextResponse.json(coverLetter);
     }
 
     // Standard letter generation
-    // console.log(`📝 Generating ${letterType} letter with Mistral...`);
     const standardPrompt = prompt as string;
     const standardFromName = fromName as string;
     const standardToName = toName as string;
@@ -240,26 +251,39 @@ export async function POST(request: Request) {
           month: "long",
           day: "numeric",
         }),
-      subject: letter.subject || "Re: " + standardPrompt.substring(0, 30) + "...",
+      subject:
+        letter.subject || "Re: " + standardPrompt.substring(0, 30) + "...",
       content: letter.content || "Letter content not available.",
     };
-
-    // console.log("✅ Letter generated successfully with Mistral");
 
     // Fire-and-forget: log write does not block the response
     if (!hasUnlimitedCredits) {
       supabaseAdmin
         .from("credit_usage_log")
-        .insert({ user_id: user.id, action_type: actionType, credits_used: creditCost, metadata: { letter_type: standardLetterType, prompt_length: standardPrompt.length } })
-        .then(({ error }) => { if (error) console.error("Failed to log credit usage:", error); });
+        .insert({
+          user_id: user.id,
+          action_type: actionType,
+          credits_used: creditCost,
+          metadata: {
+            letter_type: standardLetterType,
+            prompt_length: standardPrompt.length,
+          },
+        })
+        .then(({ error }) => {
+          if (error) console.error("Failed to log credit usage:", error);
+        });
     }
 
     return NextResponse.json(formattedResponse);
   } catch (error) {
-    logger.error({ route: 'app/api/generate/letter/route.ts' }, "Error generating letter:", error);
+    logger.error(
+      { route: "app/api/generate/letter/route.ts" },
+      "Error generating letter:",
+      error,
+    );
     return NextResponse.json(
-      { error: 'Failed to generate letter' },
-      { status: 500 }
+      { error: "Failed to generate letter" },
+      { status: 500 },
     );
   }
 }

--- a/app/api/generate/modify-presentation/route.ts
+++ b/app/api/generate/modify-presentation/route.ts
@@ -1,21 +1,24 @@
-import { logger } from '@/lib/logger';
-export const dynamic = 'force-dynamic';
-export const runtime = 'nodejs';
+import { logger } from "@/lib/logger";
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 export const maxDuration = 60;
 
-import { NextResponse } from 'next/server';
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { NextResponse } from "next/server";
+import { GoogleGenerativeAI } from "@google/generative-ai";
 
 function extractJsonFromMarkdown(text: string): string {
   // Remove markdown code blocks
-  let cleaned = text.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
-  
+  let cleaned = text
+    .replace(/```json\n?/g, "")
+    .replace(/```\n?/g, "")
+    .trim();
+
   // Try to find JSON object/array
   const jsonMatch = cleaned.match(/\{[\s\S]*\}|\[[\s\S]*\]/);
   if (jsonMatch) {
     return jsonMatch[0];
   }
-  
+
   return cleaned;
 }
 
@@ -24,41 +27,35 @@ export async function POST(request: Request) {
     const body = await request.json();
     const { slides, instruction, template, originalPrompt } = body;
 
-    // console.log('Modify presentation request:', { 
-    //   slideCount: slides?.length, 
-    //   instruction, 
-    //   template 
-    // });
-
     if (!slides || !instruction) {
       return NextResponse.json(
-        { error: 'Missing slides or instruction' },
-        { status: 400 }
+        { error: "Missing slides or instruction" },
+        { status: 400 },
       );
     }
 
     if (!process.env.GOOGLE_API_KEY) {
       return NextResponse.json(
-        { error: 'Google API key not configured' },
-        { status: 500 }
+        { error: "Google API key not configured" },
+        { status: 500 },
       );
     }
 
     const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY);
-    const model = genAI.getGenerativeModel({ 
+    const model = genAI.getGenerativeModel({
       model: "gemini-2.0-flash-exp",
       generationConfig: {
         temperature: 0.7,
         topP: 0.95,
         topK: 40,
         maxOutputTokens: 8192,
-      }
+      },
     });
 
     // Simplify slides for the prompt (remove base64 images to reduce token count)
     const simplifiedSlides = slides.map((slide: any) => ({
       ...slide,
-      image: slide.image ? '[IMAGE_DATA]' : undefined
+      image: slide.image ? "[IMAGE_DATA]" : undefined,
     }));
 
     const prompt = `You are an expert presentation editor. Modify the presentation based on the user's instruction.
@@ -88,12 +85,9 @@ Return ONLY a valid JSON object (no markdown, no code blocks):
 
 IMPORTANT: Return ONLY the JSON object, nothing else.`;
 
-    // console.log('Sending request to Gemini...');
     const result = await model.generateContent(prompt);
     const response = await result.response;
     let text = response.text();
-    
-    // console.log('Raw response from Gemini:', text.substring(0, 200));
 
     // Extract and clean JSON
     text = extractJsonFromMarkdown(text);
@@ -103,41 +97,59 @@ IMPORTANT: Return ONLY the JSON object, nothing else.`;
     try {
       data = JSON.parse(text);
     } catch (parseError) {
-      logger.error({ route: 'app/api/generate/modify-presentation/route.ts' }, 'JSON parse error:', parseError);
-      logger.error({ route: 'app/api/generate/modify-presentation/route.ts' }, 'Text that failed to parse:', text.substring(0, 500));
-      throw new Error('Failed to parse AI response as JSON');
+      logger.error(
+        { route: "app/api/generate/modify-presentation/route.ts" },
+        "JSON parse error:",
+        parseError,
+      );
+      logger.error(
+        { route: "app/api/generate/modify-presentation/route.ts" },
+        "Text that failed to parse:",
+        text.substring(0, 500),
+      );
+      throw new Error("Failed to parse AI response as JSON");
     }
 
     // Restore original images in modified slides
     if (data.modifiedSlides) {
-      data.modifiedSlides = data.modifiedSlides.map((modifiedSlide: any, index: number) => {
-        const originalSlide = slides[index];
-        return {
-          ...modifiedSlide,
-          image: modifiedSlide.image === '[IMAGE_DATA]' && originalSlide 
-            ? originalSlide.image 
-            : modifiedSlide.image
-        };
-      });
+      data.modifiedSlides = data.modifiedSlides.map(
+        (modifiedSlide: any, index: number) => {
+          const originalSlide = slides[index];
+          return {
+            ...modifiedSlide,
+            image:
+              modifiedSlide.image === "[IMAGE_DATA]" && originalSlide
+                ? originalSlide.image
+                : modifiedSlide.image,
+          };
+        },
+      );
     }
 
-    // console.log('Successfully modified presentation');
     return NextResponse.json(data);
-
   } catch (error) {
-    logger.error({ route: 'app/api/generate/modify-presentation/route.ts' }, 'Error modifying presentation:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    const errorStack = error instanceof Error ? error.stack : '';
-    
-    logger.error({ route: 'app/api/generate/modify-presentation/route.ts' }, 'Error details:', { errorMessage, errorStack });
-    
+    logger.error(
+      { route: "app/api/generate/modify-presentation/route.ts" },
+      "Error modifying presentation:",
+      error,
+    );
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    const errorStack = error instanceof Error ? error.stack : "";
+
+    logger.error(
+      { route: "app/api/generate/modify-presentation/route.ts" },
+      "Error details:",
+      { errorMessage, errorStack },
+    );
+
     return NextResponse.json(
-      { 
-        error: 'Failed to modify presentation', 
+      {
+        error: "Failed to modify presentation",
         details: errorMessage,
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/api/generate/presentation-outline/route.ts
+++ b/app/api/generate/presentation-outline/route.ts
@@ -1,50 +1,80 @@
-import { logger } from '@/lib/logger';
-export const dynamic = 'force-dynamic';
-export const runtime = 'nodejs';
+import { logger } from "@/lib/logger";
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
-import { NextResponse } from 'next/server';
-import { 
-  generatePresentationText, 
-  generateChartData 
-} from '@/lib/mistral';
-import OpenAI from 'openai';
-import { createClient } from '@supabase/supabase-js';
-import { ACTION_COSTS, calculateRemainingCredits } from '@/lib/credits-service';
-import { hasUnlimitedDeveloperCredits, logDeveloperCreditBypass } from '@/lib/developer-credit-bypass';
-import { reserveCredits, refundCredits, creditReservationConflictResponse } from '@/lib/credit-operations';
-import { getCachedUserCredits, invalidateUserCredits } from '@/lib/cached-queries';
+import { NextResponse } from "next/server";
+import { generatePresentationText, generateChartData } from "@/lib/mistral";
+import OpenAI from "openai";
+import { createClient } from "@supabase/supabase-js";
+import { ACTION_COSTS, calculateRemainingCredits } from "@/lib/credits-service";
+import {
+  hasUnlimitedDeveloperCredits,
+  logDeveloperCreditBypass,
+} from "@/lib/developer-credit-bypass";
+import {
+  reserveCredits,
+  refundCredits,
+  creditReservationConflictResponse,
+} from "@/lib/credit-operations";
+import {
+  getCachedUserCredits,
+  invalidateUserCredits,
+} from "@/lib/cached-queries";
 
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
 
 const NEBIUS_BASE_URL =
   process.env.NEBIUS_BASE_URL ||
-  'https://api.tokenfactory.us-central1.nebius.com/v1/';
+  "https://api.tokenfactory.us-central1.nebius.com/v1/";
 
 type NebiusOutlineModel =
-  | 'Qwen/Qwen3-235B-A22B-Instruct-2507'
-  | 'deepseek-ai/DeepSeek-V3.2'
-  | 'meta-llama/Meta-Llama-3.1-70B-Instruct';
+  | "Qwen/Qwen3-235B-A22B-Instruct-2507"
+  | "deepseek-ai/DeepSeek-V3.2"
+  | "meta-llama/Meta-Llama-3.1-70B-Instruct";
 
 function normalizeOutlineModel(value: unknown): NebiusOutlineModel {
-  const model = typeof value === 'string' ? value.trim().toLowerCase() : '';
-  if (model === 'deepseek-ai/deepseek-v3.2' || model === 'deepseek-v3.2' || model === 'deepseek') {
-    return 'deepseek-ai/DeepSeek-V3.2';
+  const model = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (
+    model === "deepseek-ai/deepseek-v3.2" ||
+    model === "deepseek-v3.2" ||
+    model === "deepseek"
+  ) {
+    return "deepseek-ai/DeepSeek-V3.2";
   }
-  if (model === 'qwen/qwen3-235b-a22b-instruct-2507' || model === 'qwen' || model === 'qwen3-235b') {
-    return 'Qwen/Qwen3-235B-A22B-Instruct-2507';
+  if (
+    model === "qwen/qwen3-235b-a22b-instruct-2507" ||
+    model === "qwen" ||
+    model === "qwen3-235b"
+  ) {
+    return "Qwen/Qwen3-235B-A22B-Instruct-2507";
   }
-  return 'meta-llama/Meta-Llama-3.1-70B-Instruct';
+  return "meta-llama/Meta-Llama-3.1-70B-Instruct";
 }
 
 function buildPromptWithSettings(prompt: string, settings: any): string {
-  const language = typeof settings?.language === 'string' && settings.language.trim() ? settings.language.trim() : 'English';
-  const audience = typeof settings?.audience === 'string' && settings.audience.trim() ? settings.audience.trim() : 'Business';
-  const tone = typeof settings?.tone === 'string' && settings.tone.trim() ? settings.tone.trim() : 'Professional';
-  const textDensity = typeof settings?.textDensity === 'string' && settings.textDensity.trim() ? settings.textDensity.trim() : 'concise';
-  const purpose = typeof settings?.purpose === 'string' && settings.purpose.trim() ? settings.purpose.trim() : 'General presentation';
+  const language =
+    typeof settings?.language === "string" && settings.language.trim()
+      ? settings.language.trim()
+      : "English";
+  const audience =
+    typeof settings?.audience === "string" && settings.audience.trim()
+      ? settings.audience.trim()
+      : "Business";
+  const tone =
+    typeof settings?.tone === "string" && settings.tone.trim()
+      ? settings.tone.trim()
+      : "Professional";
+  const textDensity =
+    typeof settings?.textDensity === "string" && settings.textDensity.trim()
+      ? settings.textDensity.trim()
+      : "concise";
+  const purpose =
+    typeof settings?.purpose === "string" && settings.purpose.trim()
+      ? settings.purpose.trim()
+      : "General presentation";
 
   return `${prompt}
 
@@ -59,23 +89,27 @@ Generation Requirements:
 
 /**
  * Helper to create a filler slide with contextual content
- * 
+ *
  * This function is called when the AI generates fewer slides than requested,
  * padding the presentation to reach the correct slide count. It intelligently
  * determines the slide type based on position and context.
- * 
+ *
  * @param slideNumber - The 1-based index of the slide being created
  * @param totalCount - The total number of slides in the presentation
  * @param topic - The presentation topic for contextual content generation
  * @returns A slide object with type, title, content, and bullet points
- * 
+ *
  * Slide type logic:
  * - First slide (1): 'title' - Main presentation title
  * - Last slide: 'conclusion' - Summary and wrap-up
  * - Middle slide (for decks > 2 slides): 'chart' - Data visualization
  * - All others: 'content' - Regular content slides
  */
-function createFillerSlide(slideNumber: number, totalCount: number, topic: string) {
+function createFillerSlide(
+  slideNumber: number,
+  totalCount: number,
+  topic: string,
+) {
   const isFirst = slideNumber === 1;
   const isLast = slideNumber === totalCount;
 
@@ -83,38 +117,38 @@ function createFillerSlide(slideNumber: number, totalCount: number, topic: strin
   let chartPosition: number | null = null;
   if (totalCount > 2) {
     const middlePosition = Math.ceil(totalCount / 2);
-    chartPosition = Math.min(
-      Math.max(middlePosition, 2),
-      totalCount - 1
-    );
+    chartPosition = Math.min(Math.max(middlePosition, 2), totalCount - 1);
   }
   const isChartPosition =
-    !isFirst && !isLast && chartPosition !== null && slideNumber === chartPosition;
+    !isFirst &&
+    !isLast &&
+    chartPosition !== null &&
+    slideNumber === chartPosition;
 
-  let type: 'title' | 'content' | 'conclusion' | 'chart';
+  let type: "title" | "content" | "conclusion" | "chart";
   if (isFirst) {
-    type = 'title';
+    type = "title";
   } else if (isLast) {
-    type = 'conclusion';
+    type = "conclusion";
   } else if (isChartPosition) {
-    type = 'chart';
+    type = "chart";
   } else {
-    type = 'content';
+    type = "content";
   }
 
   let title: string;
   let content: string;
 
   switch (type) {
-    case 'title':
+    case "title":
       title = topic;
       content = `Overview of ${topic}`;
       break;
-    case 'conclusion':
-      title = 'Summary';
+    case "conclusion":
+      title = "Summary";
       content = `Key takeaways and next steps for ${topic}`;
       break;
-    case 'chart':
+    case "chart":
       title = `Key Data for ${topic}`;
       content = `Visual representation of important metrics or trends related to ${topic}`;
       break;
@@ -129,12 +163,8 @@ function createFillerSlide(slideNumber: number, totalCount: number, topic: strin
     type,
     title,
     content,
-    bulletPoints: [
-      'Supporting detail',
-      'Further explanation',
-      'Key takeaway'
-    ],
-    notes: ''
+    bulletPoints: ["Supporting detail", "Further explanation", "Key takeaway"],
+    notes: "",
   };
 }
 
@@ -147,15 +177,13 @@ const nebiusClient = new OpenAI({
 async function generateWithNebius(
   prompt: string,
   pageCount: number,
-  model: NebiusOutlineModel = 'meta-llama/Meta-Llama-3.1-70B-Instruct'
+  model: NebiusOutlineModel = "meta-llama/Meta-Llama-3.1-70B-Instruct",
 ) {
-  // console.log('🔄 Using Nebius/Qwen as fallback...');
-  
   const completion = await nebiusClient.chat.completions.create({
     model,
     messages: [
       {
-        role: 'system',
+        role: "system",
         content: `You are a professional presentation designer. Generate exactly ${pageCount} slides for a presentation.
 Return a JSON array of slides with this structure:
 [
@@ -169,81 +197,91 @@ Return a JSON array of slides with this structure:
   }
 ]
 Slide types: title, content, bullets, stats, comparison, timeline, conclusion
-Make content professional, engaging, and visually focused.`
+Make content professional, engaging, and visually focused.`,
       },
       {
-        role: 'user',
-        content: `Create a ${pageCount}-slide presentation about: ${prompt}`
-      }
+        role: "user",
+        content: `Create a ${pageCount}-slide presentation about: ${prompt}`,
+      },
     ],
     max_tokens: 4000,
     temperature: 0.7,
   });
 
-  const content = completion.choices[0]?.message?.content || '[]';
-  
+  const content = completion.choices[0]?.message?.content || "[]";
+
   // Extract JSON from response
   const jsonMatch = content.match(/\[[\s\S]*\]/);
   if (jsonMatch) {
     try {
       const parsedSlides = JSON.parse(jsonMatch[0]);
-      
+
       // Ensure we have the correct number of slides
       if (parsedSlides.length !== pageCount) {
-        console.warn(`⚠️ Nebius generated ${parsedSlides.length} slides instead of ${pageCount}. Adjusting...`);
-        
+        console.warn(
+          `⚠️ Nebius generated ${parsedSlides.length} slides instead of ${pageCount}. Adjusting...`,
+        );
+
         // If too many slides, trim to pageCount
         if (parsedSlides.length > pageCount) {
           return parsedSlides.slice(0, pageCount);
         }
-        
+
         // If too few slides, generate filler slides based on topic
         while (parsedSlides.length < pageCount) {
-          parsedSlides.push(createFillerSlide(parsedSlides.length + 1, pageCount, prompt));
+          parsedSlides.push(
+            createFillerSlide(parsedSlides.length + 1, pageCount, prompt),
+          );
         }
       }
-      
+
       return parsedSlides;
     } catch (e) {
-      logger.error({ route: 'app/api/generate/presentation-outline/route.ts' }, 'Failed to parse Nebius response:', e);
+      logger.error(
+        { route: "app/api/generate/presentation-outline/route.ts" },
+        "Failed to parse Nebius response:",
+        e,
+      );
     }
   }
-  
+
   // Fallback: create basic slides with exact pageCount using helper
   return Array.from({ length: pageCount }, (_, i) => {
     if (i === 0) {
       return {
         slideNumber: 1,
-        type: 'title',
+        type: "title",
         title: prompt,
-        content: 'Content for this slide',
-        bulletPoints: ['Key point 1', 'Key point 2', 'Key point 3']
+        content: "Content for this slide",
+        bulletPoints: ["Key point 1", "Key point 2", "Key point 3"],
       };
     }
     return createFillerSlide(i + 1, pageCount, prompt);
   });
 }
 
-
 export async function POST(request: Request) {
   try {
     // ✅ AUTHENTICATION CHECK
-    const authHeader = request.headers.get('Authorization');
-    const token = authHeader?.replace('Bearer ', '');
-    
+    const authHeader = request.headers.get("Authorization");
+    const token = authHeader?.replace("Bearer ", "");
+
     if (!token) {
       return NextResponse.json(
-        { error: 'Authentication required. Please sign in.' },
-        { status: 401 }
+        { error: "Authentication required. Please sign in." },
+        { status: 401 },
       );
     }
 
-    const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token);
-    
+    const {
+      data: { user },
+      error: authError,
+    } = await supabaseAdmin.auth.getUser(token);
+
     if (authError || !user) {
       return NextResponse.json(
-        { error: 'Authentication required. Please sign in.' },
-        { status: 401 }
+        { error: "Authentication required. Please sign in." },
+        { status: 401 },
       );
     }
     const hasUnlimitedCredits = hasUnlimitedDeveloperCredits(user.email);
@@ -254,10 +292,7 @@ export async function POST(request: Request) {
     const promptWithSettings = buildPromptWithSettings(prompt, settings);
 
     if (!prompt) {
-      return NextResponse.json(
-        { error: 'Missing prompt' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "Missing prompt" }, { status: 400 });
     }
 
     // Validate pageCount to prevent invalid or abusive credit calculations
@@ -268,8 +303,11 @@ export async function POST(request: Request) {
       validatedPageCount > 100
     ) {
       return NextResponse.json(
-        { error: 'Invalid pageCount. Please provide an integer between 1 and 100.' },
-        { status: 400 }
+        {
+          error:
+            "Invalid pageCount. Please provide an integer between 1 and 100.",
+        },
+        { status: 400 },
       );
     }
 
@@ -277,8 +315,8 @@ export async function POST(request: Request) {
     const userCredits = await getCachedUserCredits(supabaseAdmin, user.id);
     if (!userCredits) {
       return NextResponse.json(
-        { error: 'Failed to initialize credits' },
-        { status: 500 }
+        { error: "Failed to initialize credits" },
+        { status: 500 },
       );
     }
 
@@ -287,21 +325,24 @@ export async function POST(request: Request) {
     const estimatedCreditCost = validatedPageCount * creditsPerSlide;
     const creditsRemaining = hasUnlimitedCredits
       ? Number.MAX_SAFE_INTEGER
-      : calculateRemainingCredits(userCredits.credits_total, userCredits.credits_used);
-    
+      : calculateRemainingCredits(
+          userCredits.credits_total,
+          userCredits.credits_used,
+        );
+
     if (!hasUnlimitedCredits && creditsRemaining < estimatedCreditCost) {
-      const creditWord = estimatedCreditCost === 1 ? 'credit' : 'credits';
-      const slideWord = validatedPageCount === 1 ? 'slide' : 'slides';
+      const creditWord = estimatedCreditCost === 1 ? "credit" : "credits";
+      const slideWord = validatedPageCount === 1 ? "slide" : "slides";
       return NextResponse.json(
         {
-          error: 'Not enough credits',
-          message: `You need ${estimatedCreditCost} ${creditWord} to generate a ${validatedPageCount}-${slideWord} presentation. You have ${creditsRemaining} ${creditsRemaining === 1 ? 'credit' : 'credits'} remaining.`,
+          error: "Not enough credits",
+          message: `You need ${estimatedCreditCost} ${creditWord} to generate a ${validatedPageCount}-${slideWord} presentation. You have ${creditsRemaining} ${creditsRemaining === 1 ? "credit" : "credits"} remaining.`,
           needsUpgrade: true,
           currentTier: userCredits.tier,
           creditsRemaining,
-          creditsRequired: estimatedCreditCost
+          creditsRequired: estimatedCreditCost,
         },
-        { status: 402 }
+        { status: 402 },
       );
     }
 
@@ -313,50 +354,67 @@ export async function POST(request: Request) {
         supabaseAdmin,
         user.id,
         userCredits.credits_used,
-        estimatedCreditCost
+        estimatedCreditCost,
       );
       invalidateUserCredits(user.id);
       if (!reserved) {
         return NextResponse.json(
-          creditReservationConflictResponse(estimatedCreditCost, userCredits.tier),
-          { status: 402 }
+          creditReservationConflictResponse(
+            estimatedCreditCost,
+            userCredits.tier,
+          ),
+          { status: 402 },
         );
       }
     }
 
     if (hasUnlimitedCredits) {
-      logDeveloperCreditBypass({ userId: user.id, email: user.email, action: 'presentation' });
+      logDeveloperCreditBypass({
+        userId: user.id,
+        email: user.email,
+        action: "presentation",
+      });
     }
-
-    // console.log('📝 Step 1: Generating slide text content...');
 
     // Step 1: Generate text content - Use Mistral first, then Nebius fallback
     let outlines;
     try {
-      const nebiusFirst = selectedModel !== 'meta-llama/Meta-Llama-3.1-70B-Instruct';
+      const nebiusFirst =
+        selectedModel !== "meta-llama/Meta-Llama-3.1-70B-Instruct";
       if (nebiusFirst) {
-        // console.log(`Using Nebius model for outline generation: ${selectedModel}`);
-        outlines = await generateWithNebius(promptWithSettings, validatedPageCount, selectedModel);
+        outlines = await generateWithNebius(
+          promptWithSettings,
+          validatedPageCount,
+          selectedModel,
+        );
       } else {
         try {
-          // console.log('Using Mistral Large for text generation');
-          outlines = await generatePresentationText(prompt, validatedPageCount, {
-            language: settings?.language,
-            audience: settings?.audience,
-            tone: settings?.tone,
-            textDensity: settings?.textDensity,
-            purpose: settings?.purpose,
-          });
+          outlines = await generatePresentationText(
+            prompt,
+            validatedPageCount,
+            {
+              language: settings?.language,
+              audience: settings?.audience,
+              tone: settings?.tone,
+              textDensity: settings?.textDensity,
+              purpose: settings?.purpose,
+            },
+          );
 
           if (!outlines || outlines.length === 0) {
-            throw new Error('Mistral generated no content');
+            throw new Error("Mistral generated no content");
           }
-
-          // console.log('Generated with Mistral');
         } catch (mistralError: any) {
-          logger.error({ route: 'app/api/generate/presentation-outline/route.ts' }, 'Mistral failed:', mistralError.message);
-          // console.log('Falling back to Nebius...');
-          outlines = await generateWithNebius(promptWithSettings, validatedPageCount, selectedModel);
+          logger.error(
+            { route: "app/api/generate/presentation-outline/route.ts" },
+            "Mistral failed:",
+            mistralError.message,
+          );
+          outlines = await generateWithNebius(
+            promptWithSettings,
+            validatedPageCount,
+            selectedModel,
+          );
         }
       }
     } catch (err) {
@@ -367,11 +425,8 @@ export async function POST(request: Request) {
       throw err;
     }
 
-    // console.log(`✅ Generated ${outlines.length} slides`);
-
     // If outlineOnly is requested, reconcile credits then return early.
     if (outlineOnly) {
-      // console.log('🚀 Returning outline only as requested');
       if (!hasUnlimitedCredits) {
         const actualCost = outlines.length * creditsPerSlide;
         const overReserved = estimatedCreditCost - actualCost;
@@ -386,73 +441,73 @@ export async function POST(request: Request) {
           totalSlides: outlines.length,
           withImages: 0,
           withCharts: 0,
-        }
+        },
       });
     }
 
-    // console.log('🎨 Step 2: Generating images with FLUX AI...');
-    
     // Step 2: Generate images with FLUX (skip Mistral)
-    const { generatePresentationImages } = await import('@/lib/flux-image-generator');
-    const { getEnhancedImagePrompt } = await import('@/lib/presentation-styles');
-    
+    const { generatePresentationImages } =
+      await import("@/lib/flux-image-generator");
+    const { getEnhancedImagePrompt } =
+      await import("@/lib/presentation-styles");
+
     // Create enhanced image prompts from slide content
     const imagePrompts = outlines.map((outline: any) => {
-      const slideType = outline.type || 'content';
-      const title = outline.title || '';
-      const content = outline.content || outline.bulletPoints?.join(', ') || '';
-      
+      const slideType = outline.type || "content";
+      const title = outline.title || "";
+      const content = outline.content || outline.bulletPoints?.join(", ") || "";
+
       // Create detailed, contextual prompt for stunning images
-      let basePrompt = '';
-      
-      if (slideType === 'title' || slideType === 'cover') {
+      let basePrompt = "";
+
+      if (slideType === "title" || slideType === "cover") {
         basePrompt = `Stunning hero image for presentation titled "${title}", ${prompt}, inspiring and professional`;
-      } else if (slideType === 'conclusion' || slideType === 'summary') {
+      } else if (slideType === "conclusion" || slideType === "summary") {
         basePrompt = `Inspiring conclusion image for "${title}", uplifting and motivational, ${prompt}`;
       } else {
         basePrompt = `Professional visual representation of "${title}", ${content.substring(0, 80)}, ${prompt}`;
       }
-      
+
       // Enhance with style-specific keywords
-      return getEnhancedImagePrompt(basePrompt, 'modern');
+      return getEnhancedImagePrompt(basePrompt, "modern");
     });
-    
+
     // Generate all images with FLUX (using 512x512 - smaller, faster)
     const imageUrls = await generatePresentationImages(imagePrompts, "512x512");
-    
-    // console.log(`✅ Generated ${imageUrls.length} images with FLUX`);
-    // console.log('📊 Step 3: Generating chart data with Mistral AI...');
-    
+
     // Step 3: Generate chart data with Mistral AI (keep this for now)
     let chartDataList: any[] = [];
     try {
       chartDataList = await generateChartData(outlines, prompt);
-      // console.log(`✅ Generated ${chartDataList.length} charts`);
     } catch (error) {
-      logger.error({ route: 'app/api/generate/presentation-outline/route.ts' }, 'Error generating charts:', error);
-      // console.log('⚠️ Skipping chart generation due to rate limit');
+      logger.error(
+        { route: "app/api/generate/presentation-outline/route.ts" },
+        "Error generating charts:",
+        error,
+      );
     }
-    
-    // console.log('✨ Step 4: Combining slides with images and charts...');
-    
+
     // Step 4: Combine everything
     const enhancedOutlines = outlines.map((outline: any, index: number) => {
-      const chartData = chartDataList.find((chart: any) => chart.slideNumber === index + 1);
-      
+      const chartData = chartDataList.find(
+        (chart: any) => chart.slideNumber === index + 1,
+      );
+
       return {
         ...outline,
-        image: imageUrls[index] || `https://placehold.co/512x512/EEE/31343C?text=Slide+${index + 1}`,
+        image:
+          imageUrls[index] ||
+          `https://placehold.co/512x512/EEE/31343C?text=Slide+${index + 1}`,
         imageQuery: imagePrompts[index],
         imageDescription: `AI-generated image for ${outline.title}`,
-        imageUrl: imageUrls[index] || `https://placehold.co/512x512/EEE/31343C?text=Slide+${index + 1}`,
+        imageUrl:
+          imageUrls[index] ||
+          `https://placehold.co/512x512/EEE/31343C?text=Slide+${index + 1}`,
         chartData: chartData || null,
         bullets: outline.bulletPoints || outline.bullets || [],
       };
     });
-    
-    // console.log('✨ Step 5: Presentation enhancement complete!');
-    // console.log(`📊 Final stats: ${enhancedOutlines.length} slides, ${imageUrls.length} FLUX images, ${chartDataList.length} charts`);
-    
+
     // Credits were reserved at estimatedCreditCost. If the model returned
     // fewer slides, refund the difference now and log the actual cost.
     const actualCreditCost = enhancedOutlines.length * creditsPerSlide;
@@ -460,9 +515,16 @@ export async function POST(request: Request) {
     if (!hasUnlimitedCredits) {
       const overReserved = estimatedCreditCost - actualCreditCost;
       if (overReserved > 0) {
-        const refunded = await refundCredits(supabaseAdmin, user.id, overReserved);
+        const refunded = await refundCredits(
+          supabaseAdmin,
+          user.id,
+          overReserved,
+        );
         if (!refunded) {
-          logger.error({ route: 'app/api/generate/presentation-outline/route.ts' }, `Failed to refund ${overReserved} over-reserved credits for user ${user.id}`);
+          logger.error(
+            { route: "app/api/generate/presentation-outline/route.ts" },
+            `Failed to refund ${overReserved} over-reserved credits for user ${user.id}`,
+          );
         } else {
           creditsUsedAfter -= overReserved;
         }
@@ -471,9 +533,19 @@ export async function POST(request: Request) {
 
       // Fire-and-forget: log write does not block the response
       supabaseAdmin
-        .from('credit_usage_log')
-        .insert({ user_id: user.id, action_type: 'presentation', credits_used: actualCreditCost, metadata: { pageCount: enhancedOutlines.length, prompt_length: prompt.length } })
-        .then(({ error }) => { if (error) console.error('Failed to log credit usage:', error); });
+        .from("credit_usage_log")
+        .insert({
+          user_id: user.id,
+          action_type: "presentation",
+          credits_used: actualCreditCost,
+          metadata: {
+            pageCount: enhancedOutlines.length,
+            prompt_length: prompt.length,
+          },
+        })
+        .then(({ error }) => {
+          if (error) console.error("Failed to log credit usage:", error);
+        });
     }
 
     return NextResponse.json({
@@ -488,17 +560,23 @@ export async function POST(request: Request) {
         remaining: hasUnlimitedCredits
           ? Number.MAX_SAFE_INTEGER
           : calculateRemainingCredits(
-            userCredits.credits_total,
-            creditsUsedAfter
-          )
-      }
+              userCredits.credits_total,
+              creditsUsedAfter,
+            ),
+      },
     });
   } catch (error) {
-    logger.error({ route: 'app/api/generate/presentation-outline/route.ts' }, 'Error generating presentation outline:', error);
+    logger.error(
+      { route: "app/api/generate/presentation-outline/route.ts" },
+      "Error generating presentation outline:",
+      error,
+    );
     return NextResponse.json(
-      { error: 'Failed to generate presentation outline', details: error instanceof Error ? error.message : 'Unknown error' },
-      { status: 500 }
+      {
+        error: "Failed to generate presentation outline",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
     );
   }
 }
-

--- a/app/api/generate/slide-image/route.ts
+++ b/app/api/generate/slide-image/route.ts
@@ -166,13 +166,13 @@ export async function POST(request: NextRequest) {
       const placeholderImages = Array(count)
         .fill(null)
         .map((_, i) => ({
-         url: getPlaceholderImage(
-  Number(size.split("x")[0]),
-  Number(size.split("x")[1]),
-  "6366F1",
-  "FFFFFF",
-  topic || "Image"
-),
+          url: getPlaceholderImage(
+            Number(size.split("x")[0]),
+            Number(size.split("x")[1]),
+            "6366F1",
+            "FFFFFF",
+            topic || "Image",
+          ),
           type: imageType,
           prompt: customPrompt || topic,
         }));
@@ -182,8 +182,6 @@ export async function POST(request: NextRequest) {
         fallback: true,
       });
     }
-
-    // console.log(`🎨 Generating ${count} ${imageType} image(s) for: "${topic || customPrompt}"`);
 
     // Parse size
     const [width, height] = size.split("x").map(Number);
@@ -254,8 +252,6 @@ export async function POST(request: NextRequest) {
     );
 
     const successCount = imageResults.filter((r) => r.success).length;
-
-    // console.log(`✅ Generated ${successCount}/${count} images successfully`);
 
     return Response.json({
       images: imageResults,

--- a/app/api/jobs/ranking/route.ts
+++ b/app/api/jobs/ranking/route.ts
@@ -1,10 +1,12 @@
-import { logger } from '@/lib/logger';
+import { logger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseAdmin } from "@/lib/supabase/server";
 import { computeFinalScore, defaultEngagement } from "@/lib/showcase/ranking";
 import type { EngagementRaw } from "@/lib/showcase/ranking";
-import { BURST_LIKE_THRESHOLD, BURST_WINDOW_MINUTES } from "@/lib/showcase/ranking.config";
-
+import {
+  BURST_LIKE_THRESHOLD,
+  BURST_WINDOW_MINUTES,
+} from "@/lib/showcase/ranking.config";
 
 function isAuthorised(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;
@@ -29,7 +31,10 @@ export async function GET(req: NextRequest) {
 
     if (postsError) throw postsError;
     if (!posts || posts.length === 0) {
-      return Response.json({ processed: 0, elapsed_ms: Date.now() - startedAt });
+      return Response.json({
+        processed: 0,
+        elapsed_ms: Date.now() - startedAt,
+      });
     }
 
     const postIds = posts.map((p: { id: string }) => p.id);
@@ -39,7 +44,10 @@ export async function GET(req: NextRequest) {
       .from("showcase_engagement_events")
       .select("post_id, event_type, dwell_ms")
       .in("post_id", postIds)
-      .gte("created_at", new Date(Date.now() - 30 * 24 * 60 * 60_000).toISOString());
+      .gte(
+        "created_at",
+        new Date(Date.now() - 30 * 24 * 60 * 60_000).toISOString(),
+      );
     // Only count last 30 days of engagement — older signals fade naturally via freshness
 
     if (engError) throw engError;
@@ -52,10 +60,18 @@ export async function GET(req: NextRequest) {
       }
       const e = engMap.get(row.post_id)!;
       switch (row.event_type) {
-        case "like":  e.likes++;  break;
-        case "save":  e.saves++;  break;
-        case "share": e.shares++; break;
-        case "view":  e.views++;  break;
+        case "like":
+          e.likes++;
+          break;
+        case "save":
+          e.saves++;
+          break;
+        case "share":
+          e.shares++;
+          break;
+        case "view":
+          e.views++;
+          break;
         case "dwell":
           e.dwell_sum_ms += row.dwell_ms ?? 0;
           e.dwell_count++;
@@ -65,7 +81,7 @@ export async function GET(req: NextRequest) {
 
     // ── 3. Detect burst flags via recent like count ───────────────────────
     const burstWindow = new Date(
-      Date.now() - BURST_WINDOW_MINUTES * 60_000
+      Date.now() - BURST_WINDOW_MINUTES * 60_000,
     ).toISOString();
 
     const { data: burstRows, error: burstError } = await supabase
@@ -76,7 +92,11 @@ export async function GET(req: NextRequest) {
       .gte("created_at", burstWindow);
 
     if (burstError) {
-      logger.error({ route: 'app/api/jobs/ranking/route.ts' }, "[ranking-job] burst detection query failed:", burstError);
+      logger.error(
+        { route: "app/api/jobs/ranking/route.ts" },
+        "[ranking-job] burst detection query failed:",
+        burstError,
+      );
       throw burstError;
     }
 
@@ -102,19 +122,19 @@ export async function GET(req: NextRequest) {
       const breakdown = computeFinalScore({
         quality_score: post.quality_score,
         engagement,
-        created_at:    new Date(post.created_at),
+        created_at: new Date(post.created_at),
         // relevance is viewer-specific — not stored globally
       });
 
       return {
-        post_id:          post.id,
-        quality_score:    post.quality_score,
+        post_id: post.id,
+        quality_score: post.quality_score,
         engagement_score: breakdown.engagement.score,
-        freshness_score:  breakdown.freshness.score,
-        relevance_score:  null,
-        final_score:      breakdown.final_score,
-        score_breakdown:  breakdown,
-        updated_at:       new Date().toISOString(),
+        freshness_score: breakdown.freshness.score,
+        relevance_score: null,
+        final_score: breakdown.final_score,
+        score_breakdown: breakdown,
+        updated_at: new Date().toISOString(),
       };
     });
 
@@ -125,18 +145,20 @@ export async function GET(req: NextRequest) {
       const batch = scoreUpserts.slice(i, i + BATCH);
       const { error: upsertError } = await supabase
         .from("showcase_post_scores")
-        .upsert(batch as any , { onConflict: "post_id" });
+        .upsert(batch as any, { onConflict: "post_id" });
 
       if (upsertError) throw upsertError;
     }
 
     const elapsed_ms = Date.now() - startedAt;
-    // console.log(`[ranking-job] processed ${posts.length} posts in ${elapsed_ms}ms`);
 
     return Response.json({ processed: posts.length, elapsed_ms });
-
   } catch (err) {
-    logger.error({ route: 'app/api/jobs/ranking/route.ts' }, "[ranking-job] error:", err);
+    logger.error(
+      { route: "app/api/jobs/ranking/route.ts" },
+      "[ranking-job] error:",
+      err,
+    );
     return Response.json({ error: String(err) }, { status: 500 });
   }
 }

--- a/app/api/latex/compile/route.ts
+++ b/app/api/latex/compile/route.ts
@@ -1,47 +1,51 @@
-import { logger } from '@/lib/logger';
-const { NextResponse } = require('next/server');
-import type { NextRequest } from 'next/server';
+import { logger } from "@/lib/logger";
+const { NextResponse } = require("next/server");
+import type { NextRequest } from "next/server";
 
 export const maxDuration = 60;
 
 interface CompileRequest {
   latex: string;
-  engine?: 'pdflatex' | 'xelatex' | 'lualatex';
+  engine?: "pdflatex" | "xelatex" | "lualatex";
 }
 
 interface CompileError {
   line?: number;
   message: string;
-  type: 'error' | 'warning';
+  type: "error" | "warning";
 }
 
 export async function POST(request: NextRequest) {
   try {
     const body: CompileRequest = await request.json();
-    const { latex, engine = 'pdflatex' } = body;
+    const { latex, engine = "pdflatex" } = body;
 
     if (!latex) {
       return NextResponse.json(
-        { success: false, error: 'LaTeX code is required' },
-        { status: 400 }
+        { success: false, error: "LaTeX code is required" },
+        { status: 400 },
       );
     }
 
-    if (!latex.includes('\\documentclass') || !latex.includes('\\begin{document}')) {
+    if (
+      !latex.includes("\\documentclass") ||
+      !latex.includes("\\begin{document}")
+    ) {
       return NextResponse.json(
         {
           success: false,
-          error: 'Invalid LaTeX structure. Make sure your document has \\documentclass and \\begin{document}.',
-          errors: [{
-            message: 'Missing \\documentclass or \\begin{document}',
-            type: 'error' as const
-          }]
+          error:
+            "Invalid LaTeX structure. Make sure your document has \\documentclass and \\begin{document}.",
+          errors: [
+            {
+              message: "Missing \\documentclass or \\begin{document}",
+              type: "error" as const,
+            },
+          ],
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
-
-    // console.log('Attempting LaTeX compilation via LaTeX.Online...');
 
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     try {
@@ -52,85 +56,102 @@ export async function POST(request: NextRequest) {
       const compileUrl = `https://latexonline.cc/compile?text=${encodedLatex}&command=${engine}`;
 
       const response = await fetch(compileUrl, {
-        method: 'GET',
+        method: "GET",
         signal: controller.signal,
       });
 
       if (response.ok) {
-        const contentType = response.headers.get('content-type');
+        const contentType = response.headers.get("content-type");
 
-        if (contentType?.includes('application/pdf')) {
-          // console.log('LaTeX compiled successfully!');
+        if (contentType?.includes("application/pdf")) {
           const pdfBuffer = await response.arrayBuffer();
           return new NextResponse(pdfBuffer, {
             headers: {
-              'Content-Type': 'application/pdf',
-              'Content-Disposition': 'inline; filename="resume.pdf"',
-              'Cache-Control': 'no-cache',
+              "Content-Type": "application/pdf",
+              "Content-Disposition": 'inline; filename="resume.pdf"',
+              "Cache-Control": "no-cache",
             },
           });
         } else {
           const errorText = await response.text();
-          logger.error({ route: 'app/api/latex/compile/route.ts' }, 'LaTeX.Online returned non-PDF:', errorText.substring(0, 500));
+          logger.error(
+            { route: "app/api/latex/compile/route.ts" },
+            "LaTeX.Online returned non-PDF:",
+            errorText.substring(0, 500),
+          );
 
-          let errorMessage = 'Compilation failed - check your LaTeX syntax';
-          if (errorText.includes('Undefined control sequence')) {
-            errorMessage = 'Undefined command in LaTeX. Check for typos in command names.';
-          } else if (errorText.includes('Missing')) {
-            errorMessage = 'Missing bracket or brace in LaTeX code.';
-          } else if (errorText.includes('Emergency stop')) {
-            errorMessage = 'Critical LaTeX error - document cannot be compiled.';
+          let errorMessage = "Compilation failed - check your LaTeX syntax";
+          if (errorText.includes("Undefined control sequence")) {
+            errorMessage =
+              "Undefined command in LaTeX. Check for typos in command names.";
+          } else if (errorText.includes("Missing")) {
+            errorMessage = "Missing bracket or brace in LaTeX code.";
+          } else if (errorText.includes("Emergency stop")) {
+            errorMessage =
+              "Critical LaTeX error - document cannot be compiled.";
           }
 
-          return NextResponse.json({
-            success: false,
-            message: errorMessage,
-            errors: [{ message: errorMessage, type: 'error' as const }],
-            logs: errorText.substring(0, 1000),
-          }, { status: 422 });
+          return NextResponse.json(
+            {
+              success: false,
+              message: errorMessage,
+              errors: [{ message: errorMessage, type: "error" as const }],
+              logs: errorText.substring(0, 1000),
+            },
+            { status: 422 },
+          );
         }
       } else {
         const errorText = await response.text();
-        logger.error({ route: 'app/api/latex/compile/route.ts' }, 'LaTeX.Online API error:', response.status, errorText.substring(0, 200));
+        logger.error(
+          { route: "app/api/latex/compile/route.ts" },
+          "LaTeX.Online API error:",
+          response.status,
+          errorText.substring(0, 200),
+        );
 
         if (controller.signal.aborted) {
-          throw new Error('Timeout');
+          throw new Error("Timeout");
         }
-
-        // console.log('Trying alternative compilation method...');
 
         const altController = new AbortController();
         const altTimeoutId = setTimeout(() => altController.abort(), 45000);
 
         try {
-          const altResponse = await fetch('https://latex.ytotech.com/builds/sync', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
+          const altResponse = await fetch(
+            "https://latex.ytotech.com/builds/sync",
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                compiler: engine,
+                resources: [{ main: true, content: latex }],
+              }),
+              signal: altController.signal,
             },
-            body: JSON.stringify({
-              compiler: engine,
-              resources: [{ main: true, content: latex }]
-            }),
-            signal: altController.signal,
-          });
+          );
 
           if (altResponse.ok) {
-            const altContentType = altResponse.headers.get('content-type');
-            if (altContentType?.includes('application/pdf')) {
-              // console.log('LaTeX compiled via alternative service!');
+            const altContentType = altResponse.headers.get("content-type");
+            if (altContentType?.includes("application/pdf")) {
               const pdfBuffer = await altResponse.arrayBuffer();
               return new NextResponse(pdfBuffer, {
                 headers: {
-                  'Content-Type': 'application/pdf',
-                  'Content-Disposition': 'inline; filename="resume.pdf"',
-                  'Cache-Control': 'no-cache',
+                  "Content-Type": "application/pdf",
+                  "Content-Disposition": 'inline; filename="resume.pdf"',
+                  "Cache-Control": "no-cache",
                 },
               });
             }
           }
         } catch (altError) {
-          logger.error({ route: 'app/api/latex/compile/route.ts' }, 'Alternative compilation also failed:', altError);
+          logger.error(
+            { route: "app/api/latex/compile/route.ts" },
+            "Alternative compilation also failed:",
+            altError,
+          );
         } finally {
           clearTimeout(altTimeoutId);
         }
@@ -138,37 +159,62 @@ export async function POST(request: NextRequest) {
         throw new Error(`LaTeX.Online API error: ${response.status}`);
       }
     } catch (fetchError: any) {
-      if (fetchError.name === 'AbortError' || fetchError.message === 'Timeout') {
-        logger.error({ route: 'app/api/latex/compile/route.ts' }, 'LaTeX compilation timed out');
-        return NextResponse.json({
-          success: false,
-          message: 'Compilation timed out. Try simplifying your document or download the .tex file to compile locally.',
-          errors: [{ message: 'Compilation timeout', type: 'error' as const }],
-        }, { status: 408 });
+      if (
+        fetchError.name === "AbortError" ||
+        fetchError.message === "Timeout"
+      ) {
+        logger.error(
+          { route: "app/api/latex/compile/route.ts" },
+          "LaTeX compilation timed out",
+        );
+        return NextResponse.json(
+          {
+            success: false,
+            message:
+              "Compilation timed out. Try simplifying your document or download the .tex file to compile locally.",
+            errors: [
+              { message: "Compilation timeout", type: "error" as const },
+            ],
+          },
+          { status: 408 },
+        );
       }
 
-      logger.error({ route: 'app/api/latex/compile/route.ts' }, 'LaTeX compilation error:', fetchError.message);
+      logger.error(
+        { route: "app/api/latex/compile/route.ts" },
+        "LaTeX compilation error:",
+        fetchError.message,
+      );
 
-      return NextResponse.json({
-        success: false,
-        message: 'PDF compilation service temporarily unavailable. Please download the .tex file and compile in Overleaf or locally.',
-        errors: [{ message: fetchError.message, type: 'error' as const }],
-        previewUrl: null,
-      }, { status: 503 });
+      return NextResponse.json(
+        {
+          success: false,
+          message:
+            "PDF compilation service temporarily unavailable. Please download the .tex file and compile in Overleaf or locally.",
+          errors: [{ message: fetchError.message, type: "error" as const }],
+          previewUrl: null,
+        },
+        { status: 503 },
+      );
     } finally {
       if (timeoutId) clearTimeout(timeoutId);
     }
-
   } catch (error: any) {
-    logger.error({ route: 'app/api/latex/compile/route.ts' }, 'Error in LaTeX compilation:', error);
+    logger.error(
+      { route: "app/api/latex/compile/route.ts" },
+      "Error in LaTeX compilation:",
+      error,
+    );
     return NextResponse.json(
       {
         success: false,
-        error: 'Failed to compile LaTeX',
-        message: error.message || 'An unexpected error occurred',
-        errors: [{ message: error.message || 'Unknown error', type: 'error' as const }],
+        error: "Failed to compile LaTeX",
+        message: error.message || "An unexpected error occurred",
+        errors: [
+          { message: error.message || "Unknown error", type: "error" as const },
+        ],
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/api/linkedin/import-url/route.ts
+++ b/app/api/linkedin/import-url/route.ts
@@ -1,129 +1,177 @@
-import { logger } from '@/lib/logger';
-const { NextResponse } = require('next/server');
-import { createClient } from '@supabase/supabase-js';
-import axios from 'axios';
-import * as cheerio from 'cheerio';
+import { logger } from "@/lib/logger";
+const { NextResponse } = require("next/server");
+import { createClient } from "@supabase/supabase-js";
+import axios from "axios";
+import * as cheerio from "cheerio";
 
 // Method 1: MCP-Powered LinkedIn Scraper (Most Reliable - No API Key Required!)
 async function scrapeWithMCP(profileUrl: string) {
   try {
-    // console.log('🔍 Using MCP to fetch LinkedIn profile...');
-
     // LinkedIn blocks automated requests with error 999
     // This is their anti-bot protection
-    throw new Error('LinkedIn blocks automated scraping (Error 999). Please use PDF Export or Manual Entry method instead.');
+    throw new Error(
+      "LinkedIn blocks automated scraping (Error 999). Please use PDF Export or Manual Entry method instead.",
+    );
 
     // Note: The code below is kept for reference but won't execute
     // LinkedIn actively blocks all automated access attempts
-    
+
     const response = await axios.get(profileUrl, {
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.9',
-        'Accept-Encoding': 'gzip, deflate, br',
-        'Connection': 'keep-alive',
-        'Upgrade-Insecure-Requests': '1',
-        'Sec-Fetch-Dest': 'document',
-        'Sec-Fetch-Mode': 'navigate',
-        'Sec-Fetch-Site': 'none',
-        'Cache-Control': 'max-age=0'
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br",
+        Connection: "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Cache-Control": "max-age=0",
       },
       timeout: 15000,
       maxRedirects: 5,
-      validateStatus: (status) => status < 500
+      validateStatus: (status) => status < 500,
     });
 
     const html = response.data;
     const $ = cheerio.load(html);
 
-    // console.log('📄 HTML content fetched, extracting data...');
-
     // Extract data from LinkedIn's public profile HTML structure
     // LinkedIn uses various class names and structures
-    
+
     // Full Name - Multiple possible selectors
-    const fullName = $('h1.text-heading-xlarge').first().text().trim() || 
-                    $('h1.top-card-layout__title').first().text().trim() ||
-                    $('.pv-text-details__left-panel h1').first().text().trim() ||
-                    $('h1[class*="heading"]').first().text().trim() ||
-                    $('div.pv-top-card--list li:first-child').first().text().trim();
+    const fullName =
+      $("h1.text-heading-xlarge").first().text().trim() ||
+      $("h1.top-card-layout__title").first().text().trim() ||
+      $(".pv-text-details__left-panel h1").first().text().trim() ||
+      $('h1[class*="heading"]').first().text().trim() ||
+      $("div.pv-top-card--list li:first-child").first().text().trim();
 
     // Headline/Title
-    const headline = $('div.text-body-medium').first().text().trim() ||
-                    $('.top-card-layout__headline').first().text().trim() ||
-                    $('.pv-text-details__left-panel .text-body-medium').first().text().trim() ||
-                    $('div[class*="headline"]').first().text().trim();
+    const headline =
+      $("div.text-body-medium").first().text().trim() ||
+      $(".top-card-layout__headline").first().text().trim() ||
+      $(".pv-text-details__left-panel .text-body-medium")
+        .first()
+        .text()
+        .trim() ||
+      $('div[class*="headline"]').first().text().trim();
 
     // Location
-    const location = $('.text-body-small.inline.t-black--light.break-words').first().text().trim() ||
-                    $('.top-card-layout__first-subline').first().text().trim() ||
-                    $('.pv-text-details__left-panel .pb2 .t-black--light').first().text().trim() ||
-                    $('span[class*="location"]').first().text().trim();
+    const location =
+      $(".text-body-small.inline.t-black--light.break-words")
+        .first()
+        .text()
+        .trim() ||
+      $(".top-card-layout__first-subline").first().text().trim() ||
+      $(".pv-text-details__left-panel .pb2 .t-black--light")
+        .first()
+        .text()
+        .trim() ||
+      $('span[class*="location"]').first().text().trim();
 
     // Summary/About - Try multiple selectors
-    const summary = $('.core-section-container__content .inline-show-more-text').first().text().trim() ||
-                   $('#about-section .pv-about__summary-text').first().text().trim() ||
-                   $('.pv-about-section .pv-about__summary-text').first().text().trim() ||
-                   $('section[id*="about"] div.inline-show-more-text').first().text().trim() ||
-                   $('div[class*="summary"]').first().text().trim();
+    const summary =
+      $(".core-section-container__content .inline-show-more-text")
+        .first()
+        .text()
+        .trim() ||
+      $("#about-section .pv-about__summary-text").first().text().trim() ||
+      $(".pv-about-section .pv-about__summary-text").first().text().trim() ||
+      $('section[id*="about"] div.inline-show-more-text')
+        .first()
+        .text()
+        .trim() ||
+      $('div[class*="summary"]').first().text().trim();
 
     // Experience - Extract from experience section
     const experience: any[] = [];
-    $('section[id*="experience"] ul li, .experience-section ul li, div[data-section="experience"] li').each((i, elem) => {
+    $(
+      'section[id*="experience"] ul li, .experience-section ul li, div[data-section="experience"] li',
+    ).each((i, elem) => {
       const $elem = $(elem);
-      const title = $elem.find('div[class*="profile-section-card__title"]').text().trim() ||
-                   $elem.find('h3').first().text().trim() ||
-                   $elem.find('.pv-entity__summary-info h3').first().text().trim();
-      
-      const company = $elem.find('span[class*="profile-section-card__subtitle"]').text().trim() ||
-                     $elem.find('.pv-entity__secondary-title').text().trim() ||
-                     $elem.find('p.pv-entity__secondary-title').first().text().trim();
-      
-      const dates = $elem.find('span[class*="date-range"]').text().trim() ||
-                   $elem.find('.pv-entity__date-range').text().trim() ||
-                   $elem.find('span.t-14.t-black--light').text().trim();
-      
-      const description = $elem.find('div[class*="description"]').text().trim() ||
-                         $elem.find('.pv-entity__description').text().trim();
+      const title =
+        $elem.find('div[class*="profile-section-card__title"]').text().trim() ||
+        $elem.find("h3").first().text().trim() ||
+        $elem.find(".pv-entity__summary-info h3").first().text().trim();
+
+      const company =
+        $elem
+          .find('span[class*="profile-section-card__subtitle"]')
+          .text()
+          .trim() ||
+        $elem.find(".pv-entity__secondary-title").text().trim() ||
+        $elem.find("p.pv-entity__secondary-title").first().text().trim();
+
+      const dates =
+        $elem.find('span[class*="date-range"]').text().trim() ||
+        $elem.find(".pv-entity__date-range").text().trim() ||
+        $elem.find("span.t-14.t-black--light").text().trim();
+
+      const description =
+        $elem.find('div[class*="description"]').text().trim() ||
+        $elem.find(".pv-entity__description").text().trim();
 
       if (title || company) {
         experience.push({
           title: title,
           company: company,
-          location: '',
-          startDate: dates.split('-')[0]?.trim() || '',
-          endDate: dates.split('-')[1]?.trim() || 'Present',
+          location: "",
+          startDate: dates.split("-")[0]?.trim() || "",
+          endDate: dates.split("-")[1]?.trim() || "Present",
           description: description,
-          current: dates.toLowerCase().includes('present')
+          current: dates.toLowerCase().includes("present"),
         });
       }
     });
 
     // Education
     const education: any[] = [];
-    $('section[id*="education"] ul li, .education-section ul li, div[data-section="education"] li').each((i, elem) => {
+    $(
+      'section[id*="education"] ul li, .education-section ul li, div[data-section="education"] li',
+    ).each((i, elem) => {
       const $elem = $(elem);
-      const school = $elem.find('h3, .pv-entity__school-name').first().text().trim();
-      const degree = $elem.find('span[class*="degree"], .pv-entity__degree-name').first().text().trim();
-      const field = $elem.find('span[class*="field"], .pv-entity__fos').first().text().trim();
-      const dates = $elem.find('span[class*="date"], .pv-entity__dates').first().text().trim();
+      const school = $elem
+        .find("h3, .pv-entity__school-name")
+        .first()
+        .text()
+        .trim();
+      const degree = $elem
+        .find('span[class*="degree"], .pv-entity__degree-name')
+        .first()
+        .text()
+        .trim();
+      const field = $elem
+        .find('span[class*="field"], .pv-entity__fos')
+        .first()
+        .text()
+        .trim();
+      const dates = $elem
+        .find('span[class*="date"], .pv-entity__dates')
+        .first()
+        .text()
+        .trim();
 
       if (school) {
         education.push({
           school: school,
           degree: degree,
           field: field,
-          startDate: dates.split('-')[0]?.trim() || '',
-          endDate: dates.split('-')[1]?.trim() || '',
-          description: ''
+          startDate: dates.split("-")[0]?.trim() || "",
+          endDate: dates.split("-")[1]?.trim() || "",
+          description: "",
         });
       }
     });
 
     // Skills - Extract from skills section
     const skills: string[] = [];
-    $('section[id*="skills"] span[class*="skill"], .pv-skill-category-entity__name span, div[data-section="skills"] span').each((i, elem) => {
+    $(
+      'section[id*="skills"] span[class*="skill"], .pv-skill-category-entity__name span, div[data-section="skills"] span',
+    ).each((i, elem) => {
       const skill = $(elem).text().trim();
       if (skill && !skills.includes(skill) && skill.length > 1) {
         skills.push(skill);
@@ -133,7 +181,6 @@ async function scrapeWithMCP(profileUrl: string) {
     // Use AI to enhance/extract more data if available
     if (process.env.OPENAI_API_KEY && html.length > 0) {
       try {
-        // console.log('🤖 Using AI to enhance extracted data...');
         const aiEnhanced = await enhanceWithAI(html, {
           fullName,
           headline,
@@ -141,40 +188,43 @@ async function scrapeWithMCP(profileUrl: string) {
           location,
           experience,
           education,
-          skills
+          skills,
         });
-        
+
         return {
           ...aiEnhanced,
           profileUrl: profileUrl,
-          method: 'MCP + AI Enhancement'
+          method: "MCP + AI Enhancement",
         };
-      } catch (aiError) {
-        // console.log('⚠️ AI enhancement failed, using MCP-only data');
-      }
+      } catch (aiError) {}
     }
 
     // Return what we extracted
     if (!fullName && !headline) {
-      throw new Error('Could not extract profile data. LinkedIn may be blocking access or profile may be private.');
+      throw new Error(
+        "Could not extract profile data. LinkedIn may be blocking access or profile may be private.",
+      );
     }
 
     return {
-      fullName: fullName || 'Name not found',
-      headline: headline || '',
-      summary: summary || '',
-      location: location || '',
+      fullName: fullName || "Name not found",
+      headline: headline || "",
+      summary: summary || "",
+      location: location || "",
       experience: experience,
       education: education,
       skills: skills.slice(0, 20), // Limit to top 20 skills
       languages: [],
       certifications: [],
       profileUrl: profileUrl,
-      method: 'MCP Scraping'
+      method: "MCP Scraping",
     };
-
   } catch (error: any) {
-    logger.error({ route: 'app/api/linkedin/import-url/route.ts' }, '❌ MCP scraping failed:', error.message);
+    logger.error(
+      { route: "app/api/linkedin/import-url/route.ts" },
+      "❌ MCP scraping failed:",
+      error.message,
+    );
     throw new Error(`MCP scraping failed: ${error.message}`);
   }
 }
@@ -183,23 +233,24 @@ async function scrapeWithMCP(profileUrl: string) {
 async function enhanceWithAI(html: string, basicData: any) {
   const openaiApiKey = process.env.OPENAI_API_KEY;
   if (!openaiApiKey) {
-    throw new Error('OPENAI_API_KEY not configured');
+    throw new Error("OPENAI_API_KEY not configured");
   }
 
   // Truncate HTML to focus on profile content
   const truncatedHtml = html.substring(0, 8000);
 
   const aiResponse = await axios.post(
-    'https://api.openai.com/v1/chat/completions',
+    "https://api.openai.com/v1/chat/completions",
     {
-      model: 'gpt-4o-mini',
+      model: "gpt-4o-mini",
       messages: [
         {
-          role: 'system',
-          content: 'You are a LinkedIn profile data extractor. Enhance and validate the extracted data. Return ONLY valid JSON.'
+          role: "system",
+          content:
+            "You are a LinkedIn profile data extractor. Enhance and validate the extracted data. Return ONLY valid JSON.",
         },
         {
-          role: 'user',
+          role: "user",
           content: `Here is partially extracted LinkedIn profile data and the HTML. Enhance, validate, and complete the data.
 
 Current extracted data:
@@ -219,23 +270,23 @@ Extract/enhance and return complete profile as JSON with this structure:
 }
 
 HTML content:
-${truncatedHtml}`
-        }
+${truncatedHtml}`,
+        },
       ],
       temperature: 0.2,
-      max_tokens: 3000
+      max_tokens: 3000,
     },
     {
       headers: {
-        'Authorization': `Bearer ${openaiApiKey}`,
-        'Content-Type': 'application/json'
-      }
-    }
+        Authorization: `Bearer ${openaiApiKey}`,
+        "Content-Type": "application/json",
+      },
+    },
   );
 
   const content = aiResponse.data.choices[0].message.content.trim();
   const jsonMatch = content.match(/\{[\s\S]*\}/);
-  
+
   if (jsonMatch) {
     return JSON.parse(jsonMatch[0]);
   }
@@ -249,57 +300,75 @@ async function scrapeWithCheerio(profileUrl: string) {
     // Add headers to mimic a real browser
     const response = await axios.get(profileUrl, {
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.9',
-        'Accept-Encoding': 'gzip, deflate, br',
-        'Connection': 'keep-alive',
-        'Upgrade-Insecure-Requests': '1'
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br",
+        Connection: "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
       },
       timeout: 10000,
-      maxRedirects: 5
+      maxRedirects: 5,
     });
 
     const $ = cheerio.load(response.data);
-    
+
     // Try to extract basic information from LinkedIn public profile
     // Note: LinkedIn's public profiles have limited data without login
-    const fullName = $('h1.text-heading-xlarge').first().text().trim() || 
-                    $('h1.top-card-layout__title').first().text().trim() ||
-                    $('.pv-text-details__left-panel h1').first().text().trim();
-    
-    const headline = $('div.text-body-medium').first().text().trim() ||
-                    $('.top-card-layout__headline').first().text().trim() ||
-                    $('.pv-text-details__left-panel .text-body-medium').first().text().trim();
-    
-    const location = $('.text-body-small.inline.t-black--light').first().text().trim() ||
-                    $('.top-card-layout__location').first().text().trim() ||
-                    $('.pv-text-details__left-panel .pb2 .t-black--light').first().text().trim();
+    const fullName =
+      $("h1.text-heading-xlarge").first().text().trim() ||
+      $("h1.top-card-layout__title").first().text().trim() ||
+      $(".pv-text-details__left-panel h1").first().text().trim();
+
+    const headline =
+      $("div.text-body-medium").first().text().trim() ||
+      $(".top-card-layout__headline").first().text().trim() ||
+      $(".pv-text-details__left-panel .text-body-medium").first().text().trim();
+
+    const location =
+      $(".text-body-small.inline.t-black--light").first().text().trim() ||
+      $(".top-card-layout__location").first().text().trim() ||
+      $(".pv-text-details__left-panel .pb2 .t-black--light")
+        .first()
+        .text()
+        .trim();
 
     // Extract summary/about section
-    const summary = $('.core-section-container__content .inline-show-more-text').first().text().trim() ||
-                   $('#about-section .pv-about__summary-text').first().text().trim() ||
-                   $('.pv-about-section .pv-about__summary-text').first().text().trim();
+    const summary =
+      $(".core-section-container__content .inline-show-more-text")
+        .first()
+        .text()
+        .trim() ||
+      $("#about-section .pv-about__summary-text").first().text().trim() ||
+      $(".pv-about-section .pv-about__summary-text").first().text().trim();
 
     if (!fullName && !headline) {
-      throw new Error('Could not extract profile data. LinkedIn may be blocking automated access.');
+      throw new Error(
+        "Could not extract profile data. LinkedIn may be blocking automated access.",
+      );
     }
 
     return {
-      fullName: fullName || 'Name not available',
-      headline: headline || '',
-      summary: summary || '',
-      location: location || '',
+      fullName: fullName || "Name not available",
+      headline: headline || "",
+      summary: summary || "",
+      location: location || "",
       experience: [],
       education: [],
       skills: [],
       languages: [],
       certifications: [],
       profileUrl: profileUrl,
-      note: 'Limited data extracted. LinkedIn restricts public profile access. For complete data, please use PDF Export method.'
+      note: "Limited data extracted. LinkedIn restricts public profile access. For complete data, please use PDF Export method.",
     };
   } catch (error: any) {
-    logger.error({ route: 'app/api/linkedin/import-url/route.ts' }, 'Cheerio scraping failed:', error.message);
+    logger.error(
+      { route: "app/api/linkedin/import-url/route.ts" },
+      "Cheerio scraping failed:",
+      error.message,
+    );
     throw error;
   }
 }
@@ -310,30 +379,32 @@ async function scrapeWithAI(profileUrl: string) {
     // First, get the HTML content
     const response = await axios.get(profileUrl, {
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
       },
-      timeout: 10000
+      timeout: 10000,
     });
 
     const html = response.data;
-    
+
     // Use OpenAI to extract structured data from HTML
     const openaiApiKey = process.env.OPENAI_API_KEY;
     if (!openaiApiKey) {
-      throw new Error('OPENAI_API_KEY not configured');
+      throw new Error("OPENAI_API_KEY not configured");
     }
 
     const aiResponse = await axios.post(
-      'https://api.openai.com/v1/chat/completions',
+      "https://api.openai.com/v1/chat/completions",
       {
-        model: 'gpt-4o-mini',
+        model: "gpt-4o-mini",
         messages: [
           {
-            role: 'system',
-            content: 'You are a LinkedIn profile data extractor. Extract structured profile information from HTML. Return ONLY valid JSON.'
+            role: "system",
+            content:
+              "You are a LinkedIn profile data extractor. Extract structured profile information from HTML. Return ONLY valid JSON.",
           },
           {
-            role: 'user',
+            role: "user",
             content: `Extract the following information from this LinkedIn profile HTML and return as JSON:
 {
   "fullName": "string",
@@ -348,31 +419,35 @@ async function scrapeWithAI(profileUrl: string) {
 }
 
 HTML (first 5000 chars):
-${html.substring(0, 5000)}`
-          }
+${html.substring(0, 5000)}`,
+          },
         ],
         temperature: 0.3,
-        max_tokens: 2000
+        max_tokens: 2000,
       },
       {
         headers: {
-          'Authorization': `Bearer ${openaiApiKey}`,
-          'Content-Type': 'application/json'
-        }
-      }
+          Authorization: `Bearer ${openaiApiKey}`,
+          "Content-Type": "application/json",
+        },
+      },
     );
 
     const content = aiResponse.data.choices[0].message.content.trim();
     const jsonMatch = content.match(/\{[\s\S]*\}/);
-    
+
     if (jsonMatch) {
       const profileData = JSON.parse(jsonMatch[0]);
       return { ...profileData, profileUrl };
     }
 
-    throw new Error('Could not parse AI response');
+    throw new Error("Could not parse AI response");
   } catch (error: any) {
-    logger.error({ route: 'app/api/linkedin/import-url/route.ts' }, 'AI scraping failed:', error.message);
+    logger.error(
+      { route: "app/api/linkedin/import-url/route.ts" },
+      "AI scraping failed:",
+      error.message,
+    );
     throw error;
   }
 }
@@ -380,13 +455,13 @@ ${html.substring(0, 5000)}`
 export async function POST(req: Request) {
   try {
     // Get authorization header
-    const authHeader = req.headers.get('authorization');
-    const token = authHeader?.replace('Bearer ', '');
+    const authHeader = req.headers.get("authorization");
+    const token = authHeader?.replace("Bearer ", "");
 
     if (!token) {
       return NextResponse.json(
-        { error: 'Unauthorized - No token provided' },
-        { status: 401 }
+        { error: "Unauthorized - No token provided" },
+        { status: 401 },
       );
     }
 
@@ -397,75 +472,77 @@ export async function POST(req: Request) {
       {
         global: {
           headers: {
-            Authorization: `Bearer ${token}`
-          }
-        }
-      }
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      },
     );
 
     // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
     if (authError || !user) {
-      logger.error({ route: 'app/api/linkedin/import-url/route.ts' }, 'Authentication error:', authError);
+      logger.error(
+        { route: "app/api/linkedin/import-url/route.ts" },
+        "Authentication error:",
+        authError,
+      );
       return NextResponse.json(
-        { error: 'Unauthorized - Please sign in' },
-        { status: 401 }
+        { error: "Unauthorized - Please sign in" },
+        { status: 401 },
       );
     }
 
     const { profileUrl } = await req.json();
 
     // Validate LinkedIn URL
-    if (!profileUrl || typeof profileUrl !== 'string') {
+    if (!profileUrl || typeof profileUrl !== "string") {
       return NextResponse.json(
-        { error: 'LinkedIn profile URL is required' },
-        { status: 400 }
+        { error: "LinkedIn profile URL is required" },
+        { status: 400 },
       );
     }
 
-    const linkedinRegex = /^https?:\/\/(www\.)?linkedin\.com\/(in|pub)\/[\w-]+\/?$/;
+    const linkedinRegex =
+      /^https?:\/\/(www\.)?linkedin\.com\/(in|pub)\/[\w-]+\/?$/;
     if (!linkedinRegex.test(profileUrl)) {
       return NextResponse.json(
-        { error: 'Invalid LinkedIn profile URL format. Example: https://linkedin.com/in/username' },
-        { status: 400 }
+        {
+          error:
+            "Invalid LinkedIn profile URL format. Example: https://linkedin.com/in/username",
+        },
+        { status: 400 },
       );
     }
 
     // Try multiple scraping methods in order of reliability
     let profileData = null;
-    let method = '';
+    let method = "";
     let errors: string[] = [];
-
-    // console.log('🔍 Starting LinkedIn profile scraping for:', profileUrl);
 
     // Method 1: Try MCP-powered scraping (BEST - No API key needed!)
     try {
-      // console.log('🚀 Attempting MCP scraping...');
       profileData = await scrapeWithMCP(profileUrl);
-      method = profileData.method || 'MCP Scraping';
-      // console.log('✅ MCP scraping successful');
+      method = profileData.method || "MCP Scraping";
     } catch (error: any) {
       errors.push(`MCP: ${error.message}`);
-      // console.log('❌ MCP failed, trying AI method...');
-      
+
       // Method 2: Try AI-powered extraction (good quality, requires OpenAI key)
       try {
         profileData = await scrapeWithAI(profileUrl);
-        method = 'AI-Powered Extraction';
-        // console.log('✅ AI scraping successful');
+        method = "AI-Powered Extraction";
       } catch (aiError: any) {
         errors.push(`AI: ${aiError.message}`);
-        // console.log('❌ AI failed, trying basic scraping...');
-        
+
         // Method 3: Try basic Cheerio scraping (limited data, but works without API keys)
         try {
           profileData = await scrapeWithCheerio(profileUrl);
-          method = 'Basic Web Scraping';
-          // console.log('✅ Basic scraping successful');
+          method = "Basic Web Scraping";
         } catch (cheerioError: any) {
           errors.push(`Cheerio: ${cheerioError.message}`);
-          // console.log('❌ All scraping methods failed');
         }
       }
     }
@@ -474,42 +551,44 @@ export async function POST(req: Request) {
     if (!profileData) {
       return NextResponse.json(
         {
-          error: 'LinkedIn URL Import Unavailable',
-          message: '🛡️ LinkedIn is blocking automated access (Error 999). This is their anti-bot protection. Please use PDF Export or Manual Entry method.',
+          error: "LinkedIn URL Import Unavailable",
+          message:
+            "🛡️ LinkedIn is blocking automated access (Error 999). This is their anti-bot protection. Please use PDF Export or Manual Entry method.",
           details: errors,
-          helpfulTip: '💡 PDF Export is the fastest method - takes only 10 seconds!',
+          helpfulTip:
+            "💡 PDF Export is the fastest method - takes only 10 seconds!",
           recommendations: [
-            '� MCP-powered scraping attempted but failed (no API key needed!)',
-            '🤖 Configure OPENAI_API_KEY for AI-enhanced extraction (optional)',
-            '📄 Use PDF Export method (most reliable - works 100%)',
-            '✍️ Use Manual Entry method (always works)'
+            "� MCP-powered scraping attempted but failed (no API key needed!)",
+            "🤖 Configure OPENAI_API_KEY for AI-enhanced extraction (optional)",
+            "📄 Use PDF Export method (most reliable - works 100%)",
+            "✍️ Use Manual Entry method (always works)",
           ],
           alternativeMethods: {
             pdf: {
-              method: 'PDF Export',
-              description: 'Export your LinkedIn profile as PDF and upload it',
+              method: "PDF Export",
+              description: "Export your LinkedIn profile as PDF and upload it",
               steps: [
-                'Go to your LinkedIn profile',
+                "Go to your LinkedIn profile",
                 'Click "More" → "Save to PDF"',
-                'Upload the PDF using the PDF Import tab'
+                "Upload the PDF using the PDF Import tab",
               ],
-              reliability: '100%',
-              recommended: true
+              reliability: "100%",
+              recommended: true,
             },
             manual: {
-              method: 'Manual Entry',
-              description: 'Copy and paste your profile information',
+              method: "Manual Entry",
+              description: "Copy and paste your profile information",
               steps: [
-                'Copy your profile information from LinkedIn',
-                'Paste it in the Manual Entry tab',
-                'Our AI will intelligently parse your data'
+                "Copy your profile information from LinkedIn",
+                "Paste it in the Manual Entry tab",
+                "Our AI will intelligently parse your data",
               ],
-              reliability: '100%',
-              recommended: true
-            }
-          }
+              reliability: "100%",
+              recommended: true,
+            },
+          },
         },
-        { status: 503 } // Service Unavailable (temporary)
+        { status: 503 }, // Service Unavailable (temporary)
       );
     }
 
@@ -518,13 +597,17 @@ export async function POST(req: Request) {
       success: true,
       method: method,
       data: profileData,
-      message: `✅ Profile imported successfully using ${method}`
+      message: `✅ Profile imported successfully using ${method}`,
     });
   } catch (error: any) {
-    logger.error({ route: 'app/api/linkedin/import-url/route.ts' }, "LinkedIn URL import error:", error);
+    logger.error(
+      { route: "app/api/linkedin/import-url/route.ts" },
+      "LinkedIn URL import error:",
+      error,
+    );
     return NextResponse.json(
       { error: error.message || "Failed to import LinkedIn profile" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/api/resume/ats-score/route.ts
+++ b/app/api/resume/ats-score/route.ts
@@ -1,26 +1,39 @@
-import { logger } from '@/lib/logger';
-import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
-import { ACTION_COSTS, TIER_LIMITS, getCreditsResetDate, shouldResetCredits, calculateRemainingCredits } from '@/lib/credits-service';
-import { hasUnlimitedDeveloperCredits, logDeveloperCreditBypass } from '@/lib/developer-credit-bypass';
-import { reserveCredits, refundCredits, creditReservationConflictResponse } from '@/lib/credit-operations';
+import { logger } from "@/lib/logger";
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import {
+  ACTION_COSTS,
+  TIER_LIMITS,
+  getCreditsResetDate,
+  shouldResetCredits,
+  calculateRemainingCredits,
+} from "@/lib/credits-service";
+import {
+  hasUnlimitedDeveloperCredits,
+  logDeveloperCreditBypass,
+} from "@/lib/developer-credit-bypass";
+import {
+  reserveCredits,
+  refundCredits,
+  creditReservationConflictResponse,
+} from "@/lib/credit-operations";
 
 // Service role client for credit operations
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
 );
 
 export async function POST(req: Request) {
   try {
     // Get authorization header
-    const authHeader = req.headers.get('authorization');
-    const token = authHeader?.replace('Bearer ', '');
+    const authHeader = req.headers.get("authorization");
+    const token = authHeader?.replace("Bearer ", "");
 
     if (!token) {
       return NextResponse.json(
-        { error: 'Unauthorized - No token provided' },
-        { status: 401 }
+        { error: "Unauthorized - No token provided" },
+        { status: 401 },
       );
     }
 
@@ -31,19 +44,22 @@ export async function POST(req: Request) {
       {
         global: {
           headers: {
-            Authorization: `Bearer ${token}`
-          }
-        }
-      }
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      },
     );
 
     // Check authentication
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
     if (authError || !user) {
       return NextResponse.json(
-        { error: 'Unauthorized - Please sign in' },
-        { status: 401 }
+        { error: "Unauthorized - Please sign in" },
+        { status: 401 },
       );
     }
     const hasUnlimitedCredits = hasUnlimitedDeveloperCredits(user.email);
@@ -53,39 +69,43 @@ export async function POST(req: Request) {
     if (!resumeData) {
       return NextResponse.json(
         { error: "Resume data is required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
     // Check user credits
     const creditCost = ACTION_COSTS.ats_check;
-    
+
     // Get or create user credits
     let { data: userCredits } = await supabaseAdmin
-      .from('user_credits')
-      .select('*')
-      .eq('user_id', user.id)
+      .from("user_credits")
+      .select("*")
+      .eq("user_id", user.id)
       .single();
 
     // If no credits record exists, create one
     if (!userCredits) {
       const { data: newCredits, error: insertError } = await supabaseAdmin
-        .from('user_credits')
+        .from("user_credits")
         .insert({
           user_id: user.id,
-          tier: 'free',
+          tier: "free",
           credits_total: TIER_LIMITS.free,
           credits_used: 0,
-          credits_reset_at: getCreditsResetDate()
+          credits_reset_at: getCreditsResetDate(),
         })
         .select()
         .single();
-      
+
       if (insertError) {
-        logger.error({ route: 'app/api/resume/ats-score/route.ts' }, 'Failed to create credits record:', insertError);
+        logger.error(
+          { route: "app/api/resume/ats-score/route.ts" },
+          "Failed to create credits record:",
+          insertError,
+        );
         return NextResponse.json(
-          { error: 'Failed to initialize credits' },
-          { status: 500 }
+          { error: "Failed to initialize credits" },
+          { status: 500 },
         );
       }
       userCredits = newCredits;
@@ -95,12 +115,12 @@ export async function POST(req: Request) {
     if (userCredits && shouldResetCredits(userCredits.credits_reset_at)) {
       const resetAt = getCreditsResetDate();
       const { data: updatedCredits } = await supabaseAdmin
-        .from('user_credits')
+        .from("user_credits")
         .update({
           credits_used: 0,
           credits_reset_at: resetAt,
         })
-        .eq('user_id', user.id)
+        .eq("user_id", user.id)
         .select()
         .single();
 
@@ -112,18 +132,21 @@ export async function POST(req: Request) {
     // Check if user has enough credits
     const creditsRemaining = hasUnlimitedCredits
       ? Number.MAX_SAFE_INTEGER
-      : calculateRemainingCredits(userCredits.credits_total, userCredits.credits_used);
-    
+      : calculateRemainingCredits(
+          userCredits.credits_total,
+          userCredits.credits_used,
+        );
+
     if (!hasUnlimitedCredits && creditsRemaining < creditCost) {
       return NextResponse.json(
         {
-          error: 'Not enough credits',
+          error: "Not enough credits",
           message: `You need ${creditCost} credits to calculate ATS score. You have ${creditsRemaining} credits remaining.`,
           needsUpgrade: true,
           currentTier: userCredits.tier,
-          creditsRemaining
+          creditsRemaining,
         },
-        { status: 402 }
+        { status: 402 },
       );
     }
 
@@ -134,19 +157,23 @@ export async function POST(req: Request) {
         supabaseAdmin,
         user.id,
         userCredits.credits_used,
-        creditCost
+        creditCost,
       );
       if (!reserved) {
         return NextResponse.json(
           creditReservationConflictResponse(creditCost, userCredits.tier),
-          { status: 402 }
+          { status: 402 },
         );
       }
       userCredits = reserved;
     }
 
     if (hasUnlimitedCredits) {
-      logDeveloperCreditBypass({ userId: user.id, email: user.email, action: 'ats_check' });
+      logDeveloperCreditBypass({
+        userId: user.id,
+        email: user.email,
+        action: "ats_check",
+      });
     }
 
     // Calculate ATS score
@@ -163,39 +190,51 @@ export async function POST(req: Request) {
     // Credits were already reserved atomically. Log usage after success.
     if (!hasUnlimitedCredits) {
       const { error: logError } = await supabaseAdmin
-        .from('credit_usage_log')
+        .from("credit_usage_log")
         .insert({
           user_id: user.id,
-          action: 'ats_check',
+          action: "ats_check",
           credits_used: creditCost,
-          metadata: { has_job_description: !!jobDescription }
+          metadata: { has_job_description: !!jobDescription },
         });
 
       if (logError) {
-        logger.error({ route: 'app/api/resume/ats-score/route.ts' }, 'Failed to log credit usage:', logError);
+        logger.error(
+          { route: "app/api/resume/ats-score/route.ts" },
+          "Failed to log credit usage:",
+          logError,
+        );
       } else {
-        // console.log(`💳 Deducted ${creditCost} credits for ATS score calculation`);
       }
     }
 
     return NextResponse.json({ atsAnalysis });
   } catch (error: any) {
-    logger.error({ route: 'app/api/resume/ats-score/route.ts' }, "ATS score calculation error:", error);
+    logger.error(
+      { route: "app/api/resume/ats-score/route.ts" },
+      "ATS score calculation error:",
+      error,
+    );
     return NextResponse.json(
       { error: error.message || "Failed to calculate ATS score" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
 // Calculate ATS score using AI
-async function calculateATSScore(resumeData: any, jobDescription?: string): Promise<any> {
+async function calculateATSScore(
+  resumeData: any,
+  jobDescription?: string,
+): Promise<any> {
   // Prioritize Gemini, fallback to OpenAI
   const geminiApiKey = process.env.GEMINI_API_KEY;
   const openaiApiKey = process.env.OPENAI_API_KEY;
-  
+
   if (!geminiApiKey && !openaiApiKey) {
-    throw new Error("AI API key not configured. Please add GEMINI_API_KEY or OPENAI_API_KEY to your .env file");
+    throw new Error(
+      "AI API key not configured. Please add GEMINI_API_KEY or OPENAI_API_KEY to your .env file",
+    );
   }
 
   const useGemini = !!geminiApiKey;
@@ -203,25 +242,37 @@ async function calculateATSScore(resumeData: any, jobDescription?: string): Prom
 
   // Prepare resume text
   const resumeText = `
-Name: ${resumeData.personalInfo?.name || 'N/A'}
-Email: ${resumeData.personalInfo?.email || 'N/A'}
-Phone: ${resumeData.personalInfo?.phone || 'N/A'}
-Location: ${resumeData.personalInfo?.location || 'N/A'}
+Name: ${resumeData.personalInfo?.name || "N/A"}
+Email: ${resumeData.personalInfo?.email || "N/A"}
+Phone: ${resumeData.personalInfo?.phone || "N/A"}
+Location: ${resumeData.personalInfo?.location || "N/A"}
 
-Summary: ${resumeData.summary || 'N/A'}
+Summary: ${resumeData.summary || "N/A"}
 
 Experience:
-${resumeData.experience?.map((exp: any) => `
+${
+  resumeData.experience
+    ?.map(
+      (exp: any) => `
 - ${exp.position} at ${exp.company} (${exp.startDate} - ${exp.endDate})
-  ${exp.description || ''}
-`).join('\n') || 'None'}
+  ${exp.description || ""}
+`,
+    )
+    .join("\n") || "None"
+}
 
 Education:
-${resumeData.education?.map((edu: any) => `
+${
+  resumeData.education
+    ?.map(
+      (edu: any) => `
 - ${edu.degree} in ${edu.field} from ${edu.school} (${edu.year})
-`).join('\n') || 'None'}
+`,
+    )
+    .join("\n") || "None"
+}
 
-Skills: ${resumeData.skills?.join(', ') || 'None'}
+Skills: ${resumeData.skills?.join(", ") || "None"}
 `;
 
   const prompt = `You are an ATS (Applicant Tracking System) expert. Analyze this resume and provide a detailed ATS score.
@@ -229,7 +280,7 @@ Skills: ${resumeData.skills?.join(', ') || 'None'}
 Resume:
 ${resumeText}
 
-${jobDescription ? `Job Description:\n${jobDescription}\n` : ''}
+${jobDescription ? `Job Description:\n${jobDescription}\n` : ""}
 
 Provide a comprehensive ATS analysis in JSON format with:
 {
@@ -273,12 +324,13 @@ async function callOpenAIForATS(apiKey: string, prompt: string): Promise<any> {
       messages: [
         {
           role: "system",
-          content: "You are an expert ATS (Applicant Tracking System) analyzer. Provide detailed, actionable feedback."
+          content:
+            "You are an expert ATS (Applicant Tracking System) analyzer. Provide detailed, actionable feedback.",
         },
         {
           role: "user",
-          content: prompt
-        }
+          content: prompt,
+        },
       ],
       response_format: { type: "json_object" },
       temperature: 0.3,
@@ -313,19 +365,21 @@ async function callGeminiForATS(apiKey: string, prompt: string): Promise<any> {
           {
             parts: [
               {
-                text: prompt + "\n\nIMPORTANT: Respond ONLY with valid JSON, no markdown or explanations."
-              }
-            ]
-          }
+                text:
+                  prompt +
+                  "\n\nIMPORTANT: Respond ONLY with valid JSON, no markdown or explanations.",
+              },
+            ],
+          },
         ],
         generationConfig: {
           temperature: 0.3,
           topK: 40,
           topP: 0.95,
           maxOutputTokens: 8192,
-        }
+        },
       }),
-    }
+    },
   );
 
   if (!response.ok) {
@@ -334,10 +388,13 @@ async function callGeminiForATS(apiKey: string, prompt: string): Promise<any> {
   }
 
   const data = await response.json();
-  let content = data.candidates[0]?.content?.parts[0]?.text || '';
+  let content = data.candidates[0]?.content?.parts[0]?.text || "";
 
   // Clean up Gemini response
-  content = content.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+  content = content
+    .replace(/```json\n?/g, "")
+    .replace(/```\n?/g, "")
+    .trim();
 
   try {
     return JSON.parse(content);

--- a/app/api/resume/generate-smart/route.ts
+++ b/app/api/resume/generate-smart/route.ts
@@ -1,30 +1,30 @@
-import { logger } from '@/lib/logger';
-import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { logger } from "@/lib/logger";
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
 
 export async function POST(req: Request) {
   try {
-    const authHeader = req.headers.get('authorization');
-    const token = authHeader?.replace('Bearer ', '');
+    const authHeader = req.headers.get("authorization");
+    const token = authHeader?.replace("Bearer ", "");
 
     if (!token) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const supabase = createClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
       {
-        global: { headers: { Authorization: `Bearer ${token}` } }
-      }
+        global: { headers: { Authorization: `Bearer ${token}` } },
+      },
     );
 
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const { text, targetRole } = await req.json();
@@ -32,35 +32,39 @@ export async function POST(req: Request) {
     if (!text || !text.trim()) {
       return NextResponse.json(
         { error: "Please provide some information about yourself" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    // console.log('🚀 Generating smart resume from:', text.substring(0, 100) + '...');
-
     // Generate complete resume using AI
     const resume = await generateCompleteResume(text, targetRole);
-    
+
     // Calculate ATS score
     const atsScore = calculateATSScore(resume);
 
-    return NextResponse.json({ 
+    return NextResponse.json({
       success: true,
       resume,
       atsScore,
-      message: "Resume generated successfully!"
+      message: "Resume generated successfully!",
     });
-
   } catch (error: any) {
-    logger.error({ route: 'app/api/resume/generate-smart/route.ts' }, "Smart resume generation error:", error);
+    logger.error(
+      { route: "app/api/resume/generate-smart/route.ts" },
+      "Smart resume generation error:",
+      error,
+    );
     return NextResponse.json(
       { error: error.message || "Failed to generate resume" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
-async function generateCompleteResume(text: string, targetRole?: string): Promise<any> {
+async function generateCompleteResume(
+  text: string,
+  targetRole?: string,
+): Promise<any> {
   const geminiApiKey = process.env.GEMINI_API_KEY;
   const openaiApiKey = process.env.OPENAI_API_KEY;
 
@@ -73,7 +77,7 @@ async function generateCompleteResume(text: string, targetRole?: string): Promis
 User Input:
 ${text}
 
-${targetRole ? `Target Role: ${targetRole}` : ''}
+${targetRole ? `Target Role: ${targetRole}` : ""}
 
 IMPORTANT INSTRUCTIONS:
 1. Create a COMPLETE resume even if the input is minimal (e.g., just a name or job title)
@@ -173,7 +177,10 @@ CRITICAL:
   return await generateWithOpenAI(openaiApiKey!, prompt);
 }
 
-async function generateWithGemini(apiKey: string, prompt: string): Promise<any> {
+async function generateWithGemini(
+  apiKey: string,
+  prompt: string,
+): Promise<any> {
   const response = await fetch(
     `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent?key=${apiKey}`,
     {
@@ -186,9 +193,9 @@ async function generateWithGemini(apiKey: string, prompt: string): Promise<any> 
           topK: 40,
           topP: 0.95,
           maxOutputTokens: 8192,
-        }
+        },
       }),
-    }
+    },
   );
 
   if (!response.ok) {
@@ -196,13 +203,19 @@ async function generateWithGemini(apiKey: string, prompt: string): Promise<any> 
   }
 
   const data = await response.json();
-  let content = data.candidates[0]?.content?.parts[0]?.text || '';
-  content = content.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+  let content = data.candidates[0]?.content?.parts[0]?.text || "";
+  content = content
+    .replace(/```json\n?/g, "")
+    .replace(/```\n?/g, "")
+    .trim();
 
   return JSON.parse(content);
 }
 
-async function generateWithOpenAI(apiKey: string, prompt: string): Promise<any> {
+async function generateWithOpenAI(
+  apiKey: string,
+  prompt: string,
+): Promise<any> {
   const response = await fetch("https://api.openai.com/v1/chat/completions", {
     method: "POST",
     headers: {
@@ -214,12 +227,13 @@ async function generateWithOpenAI(apiKey: string, prompt: string): Promise<any> 
       messages: [
         {
           role: "system",
-          content: "You are an expert resume writer. Generate complete, professional, ATS-optimized resumes. Always return valid JSON."
+          content:
+            "You are an expert resume writer. Generate complete, professional, ATS-optimized resumes. Always return valid JSON.",
         },
         {
           role: "user",
-          content: prompt
-        }
+          content: prompt,
+        },
       ],
       response_format: { type: "json_object" },
       temperature: 0.7,
@@ -241,24 +255,24 @@ function calculateATSScore(resume: any): any {
 
   // Check contact info (20 points)
   const contact = resume.personalInfo || {};
-  if (contact.name && contact.name !== 'Your Name') {
+  if (contact.name && contact.name !== "Your Name") {
     score += 5;
   } else {
     improvements.push("Add your full name");
   }
-  
-  if (contact.email && contact.email.includes('@')) {
+
+  if (contact.email && contact.email.includes("@")) {
     score += 5;
   } else {
     improvements.push("Add a professional email");
   }
-  
+
   if (contact.phone) {
     score += 5;
   } else {
     improvements.push("Add phone number");
   }
-  
+
   if (contact.location) {
     score += 5;
   } else {
@@ -287,19 +301,22 @@ function calculateATSScore(resume: any): any {
   }
 
   // Check for quantifiable achievements
-  const hasMetrics = exp.some((e: any) => 
-    e.achievements?.some((a: string) => /\d+%|\$\d+|\d+\+/.test(a))
+  const hasMetrics = exp.some((e: any) =>
+    e.achievements?.some((a: string) => /\d+%|\$\d+|\d+\+/.test(a)),
   );
   if (hasMetrics) {
     score += 10;
     feedback.push("✅ Includes quantifiable achievements");
   } else {
-    improvements.push("Add numbers/metrics to achievements (e.g., 'increased sales by 25%')");
+    improvements.push(
+      "Add numbers/metrics to achievements (e.g., 'increased sales by 25%')",
+    );
   }
 
   // Check achievement count
-  const totalAchievements = exp.reduce((sum: number, e: any) => 
-    sum + (e.achievements?.length || 0), 0
+  const totalAchievements = exp.reduce(
+    (sum: number, e: any) => sum + (e.achievements?.length || 0),
+    0,
   );
   if (totalAchievements >= 6) {
     score += 10;
@@ -323,10 +340,11 @@ function calculateATSScore(resume: any): any {
 
   // Check skills (15 points)
   const skills = resume.skills || {};
-  const totalSkills = (skills.technical?.length || 0) + 
-                      (skills.soft?.length || 0) + 
-                      (skills.tools?.length || 0);
-  
+  const totalSkills =
+    (skills.technical?.length || 0) +
+    (skills.soft?.length || 0) +
+    (skills.tools?.length || 0);
+
   if (totalSkills >= 10) {
     score += 15;
     feedback.push("✅ Comprehensive skills list");
@@ -347,26 +365,26 @@ function calculateATSScore(resume: any): any {
   }
 
   // Determine grade
-  let grade = 'F';
-  let color = 'red';
+  let grade = "F";
+  let color = "red";
   if (score >= 90) {
-    grade = 'A';
-    color = 'green';
+    grade = "A";
+    color = "green";
     feedback.push("🎉 Excellent! Your resume is ATS-optimized");
   } else if (score >= 80) {
-    grade = 'B';
-    color = 'blue';
+    grade = "B";
+    color = "blue";
     feedback.push("👍 Good! A few tweaks will make it perfect");
   } else if (score >= 70) {
-    grade = 'C';
-    color = 'yellow';
+    grade = "C";
+    color = "yellow";
     feedback.push("⚠️ Decent, but needs improvement");
   } else if (score >= 60) {
-    grade = 'D';
-    color = 'orange';
+    grade = "D";
+    color = "orange";
     feedback.push("⚠️ Needs significant improvement");
   } else {
-    color = 'red';
+    color = "red";
     feedback.push("❌ Needs major improvements for ATS compatibility");
   }
 
@@ -382,7 +400,7 @@ function calculateATSScore(resume: any): any {
       experience: Math.min(30, totalAchievements >= 6 ? 30 : 15),
       education: edu.length > 0 ? 15 : 0,
       skills: Math.min(15, totalSkills >= 10 ? 15 : 8),
-      certifications: resume.certifications?.length > 0 ? 5 : 0
-    }
+      certifications: resume.certifications?.length > 0 ? 5 : 0,
+    },
   };
 }

--- a/app/api/resume/improve/route.ts
+++ b/app/api/resume/improve/route.ts
@@ -1,5 +1,5 @@
-import { logger } from '@/lib/logger';
-import { NextResponse } from 'next/server';
+import { logger } from "@/lib/logger";
+import { NextResponse } from "next/server";
 
 export async function POST(req: Request) {
   try {
@@ -8,11 +8,9 @@ export async function POST(req: Request) {
     if (!resumeData || !userMessage) {
       return NextResponse.json(
         { error: "Resume data and message are required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
-
-    // console.log('🤖 AI Improvement request:', userMessage);
 
     const geminiApiKey = process.env.GEMINI_API_KEY;
     const openaiApiKey = process.env.OPENAI_API_KEY;
@@ -21,30 +19,44 @@ export async function POST(req: Request) {
       throw new Error("AI API key not configured");
     }
 
-    const result = geminiApiKey 
-      ? await improveWithGemini(geminiApiKey, resumeData, userMessage, conversationHistory)
-      : await improveWithOpenAI(openaiApiKey!, resumeData, userMessage, conversationHistory);
+    const result = geminiApiKey
+      ? await improveWithGemini(
+          geminiApiKey,
+          resumeData,
+          userMessage,
+          conversationHistory,
+        )
+      : await improveWithOpenAI(
+          openaiApiKey!,
+          resumeData,
+          userMessage,
+          conversationHistory,
+        );
 
     return NextResponse.json(result);
-
   } catch (error: any) {
-    logger.error({ route: 'app/api/resume/improve/route.ts' }, "AI improvement error:", error);
+    logger.error(
+      { route: "app/api/resume/improve/route.ts" },
+      "AI improvement error:",
+      error,
+    );
     return NextResponse.json(
       { error: error.message || "Failed to generate improvements" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
 async function improveWithGemini(
-  apiKey: string, 
-  resumeData: any, 
+  apiKey: string,
+  resumeData: any,
   userMessage: string,
-  conversationHistory: any[]
+  conversationHistory: any[],
 ): Promise<any> {
-  const historyContext = conversationHistory?.length > 0
-    ? `\n\nPrevious conversation:\n${conversationHistory.map(m => `${m.role}: ${m.content}`).join('\n')}`
-    : '';
+  const historyContext =
+    conversationHistory?.length > 0
+      ? `\n\nPrevious conversation:\n${conversationHistory.map((m) => `${m.role}: ${m.content}`).join("\n")}`
+      : "";
 
   const prompt = `You are an expert resume writer, ATS optimization specialist, and career coach. 
 Help improve this resume based on the user's request.
@@ -95,9 +107,9 @@ Examples of good advice:
           topK: 40,
           topP: 0.95,
           maxOutputTokens: 4096,
-        }
+        },
       }),
-    }
+    },
   );
 
   if (!response.ok) {
@@ -105,8 +117,11 @@ Examples of good advice:
   }
 
   const data = await response.json();
-  let content = data.candidates[0]?.content?.parts[0]?.text || '';
-  content = content.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+  let content = data.candidates[0]?.content?.parts[0]?.text || "";
+  content = content
+    .replace(/```json\n?/g, "")
+    .replace(/```\n?/g, "")
+    .trim();
 
   return JSON.parse(content);
 }
@@ -115,18 +130,19 @@ async function improveWithOpenAI(
   apiKey: string,
   resumeData: any,
   userMessage: string,
-  conversationHistory: any[]
+  conversationHistory: any[],
 ): Promise<any> {
   const messages = [
     {
       role: "system",
-      content: "You are an expert resume writer and ATS optimization specialist. Provide specific, actionable advice and generate improved resume data when requested. Always return valid JSON."
+      content:
+        "You are an expert resume writer and ATS optimization specialist. Provide specific, actionable advice and generate improved resume data when requested. Always return valid JSON.",
     },
     ...(conversationHistory || []),
     {
       role: "user",
-      content: `Current Resume:\n${JSON.stringify(resumeData, null, 2)}\n\nUser Request: ${userMessage}`
-    }
+      content: `Current Resume:\n${JSON.stringify(resumeData, null, 2)}\n\nUser Request: ${userMessage}`,
+    },
   ];
 
   const response = await fetch("https://api.openai.com/v1/chat/completions", {

--- a/components/firebase-auth-provider.tsx
+++ b/components/firebase-auth-provider.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState, useCallback } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+} from "react";
 import { User as FirebaseUser } from "firebase/auth";
 import { firebaseAuth } from "@/lib/firebase/init";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import { getOrCreateSupabaseUser } from "@/lib/auth-utils";
+import { logger } from "@/lib/logger";
 
 // Define the auth context type
 interface AuthContextType {
@@ -26,20 +33,26 @@ const AuthContext = createContext<AuthContextType>({
   signInWithGoogle: async () => {},
   signInWithGitHub: async () => {},
   signInWithEmail: async () => {},
-  signOut: async () => {}
+  signOut: async () => {},
 });
 
 // Custom hook to use auth context
 export const useFirebaseAuth = () => {
   const context = useContext(AuthContext);
   if (!context) {
-    throw new Error("useFirebaseAuth must be used within a FirebaseAuthProvider");
+    throw new Error(
+      "useFirebaseAuth must be used within a FirebaseAuthProvider",
+    );
   }
   return context;
 };
 
 // Firebase Auth Provider component
-export const FirebaseAuthProvider = ({ children }: { children: React.ReactNode }) => {
+export const FirebaseAuthProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   const [user, setUser] = useState<FirebaseUser | null>(null);
   const [supabaseUserId, setSupabaseUserId] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -59,13 +72,17 @@ export const FirebaseAuthProvider = ({ children }: { children: React.ReactNode }
           const supabaseId = await getOrCreateSupabaseUser(firebaseUser);
           setUser(firebaseUser);
           setSupabaseUserId(supabaseId);
-          console.log('Firebase user loaded:', firebaseUser.email);
+          logger.debug(
+            { route: "components/firebase-auth-provider.tsx" },
+            "Firebase user loaded:",
+            firebaseUser.email,
+          );
         } else {
           setUser(null);
           setSupabaseUserId(null);
         }
       } catch (error) {
-        console.error('Error checking initial auth state:', error);
+        console.error("Error checking initial auth state:", error);
         setUser(null);
         setSupabaseUserId(null);
       } finally {
@@ -83,22 +100,29 @@ export const FirebaseAuthProvider = ({ children }: { children: React.ReactNode }
           const supabaseId = await getOrCreateSupabaseUser(firebaseUser);
           setUser(firebaseUser);
           setSupabaseUserId(supabaseId);
-          console.log('Firebase user signed in:', firebaseUser.email);
-          
+          logger.debug(
+            { route: "components/firebase-auth-provider.tsx" },
+            "Firebase user signed in:",
+            firebaseUser.email,
+          );
+
           // Refresh route to update server components
           router.refresh();
         } catch (error) {
-          console.error('Error handling Firebase auth state change:', error);
+          console.error("Error handling Firebase auth state change:", error);
           // Sign out from Firebase if there's an error with Supabase mapping
           await firebaseAuth.signOut();
         }
       } else {
         setUser(null);
         setSupabaseUserId(null);
-        console.log('Firebase user signed out');
-        
+        logger.debug(
+          { route: "components/firebase-auth-provider.tsx" },
+          "Firebase user signed out",
+        );
+
         // Redirect to home and refresh
-        router.push('/');
+        router.push("/");
         router.refresh();
       }
     });
@@ -112,7 +136,7 @@ export const FirebaseAuthProvider = ({ children }: { children: React.ReactNode }
     try {
       await firebaseAuth.signInWithGoogle();
     } catch (error) {
-      console.error('Google sign in error:', error);
+      console.error("Google sign in error:", error);
       throw error;
     }
   }, []);
@@ -121,40 +145,45 @@ export const FirebaseAuthProvider = ({ children }: { children: React.ReactNode }
     try {
       await firebaseAuth.signInWithGitHub();
     } catch (error) {
-      console.error('GitHub sign in error:', error);
+      console.error("GitHub sign in error:", error);
       throw error;
     }
   }, []);
 
-  const signInWithEmail = useCallback(async (email: string, password: string) => {
-    try {
-      await firebaseAuth.signInWithEmail(email, password);
-    } catch (error) {
-      console.error('Email sign in error:', error);
-      throw error;
-    }
-  }, []);
+  const signInWithEmail = useCallback(
+    async (email: string, password: string) => {
+      try {
+        await firebaseAuth.signInWithEmail(email, password);
+      } catch (error) {
+        console.error("Email sign in error:", error);
+        throw error;
+      }
+    },
+    [],
+  );
 
   const signOut = useCallback(async () => {
     try {
       await firebaseAuth.signOut();
     } catch (error) {
-      console.error('Sign out error:', error);
+      console.error("Sign out error:", error);
       throw error;
     }
   }, []);
 
   // Provide auth context
   return (
-    <AuthContext.Provider value={{
-      user,
-      supabaseUserId,
-      loading,
-      signInWithGoogle,
-      signInWithGitHub,
-      signInWithEmail,
-      signOut
-    }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        supabaseUserId,
+        loading,
+        signInWithGoogle,
+        signInWithGitHub,
+        signInWithEmail,
+        signOut,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/hooks/useTrackEvent.ts
+++ b/hooks/useTrackEvent.ts
@@ -1,11 +1,15 @@
 "use client";
 
 import { usePlausible } from "next-plausible";
+import { logger } from "@/lib/logger";
 
 export function useTrackEvent() {
   const plausible = usePlausible();
 
-  const trackEvent = (eventName: string, additionalProps: Record<string, any> = {}) => {
+  const trackEvent = (
+    eventName: string,
+    additionalProps: Record<string, any> = {},
+  ) => {
     let utmData = {};
 
     // 1. Check if we have any trapped UTMs in storage
@@ -15,7 +19,11 @@ export function useTrackEvent() {
         try {
           utmData = JSON.parse(savedUTMs);
         } catch (e) {
-          console.error("Failed to parse UTM data", e);
+          logger.error(
+            { route: "hooks/useTrackEvent.ts" },
+            "Failed to parse UTM data",
+            e,
+          );
         }
       }
     }
@@ -27,9 +35,12 @@ export function useTrackEvent() {
         ...utmData,
       },
     });
-    
-    // Console log just so we can see it working locally!
-    console.log(`📡 Event Tracked: ${eventName}`, { ...additionalProps, ...utmData });
+
+    logger.debug(
+      { route: "hooks/useTrackEvent.ts" },
+      `📡 Event Tracked: ${eventName}`,
+      { ...additionalProps, ...utmData },
+    );
   };
 
   return { trackEvent };

--- a/hooks/useUTMCapture.ts
+++ b/hooks/useUTMCapture.ts
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useSearchParams } from "next/navigation";
+import { logger } from "@/lib/logger";
 
 export function useUTMCapture() {
   const searchParams = useSearchParams();
@@ -14,7 +15,13 @@ export function useUTMCapture() {
     if (!searchParams) return;
 
     // The standard UTM tags marketers use
-    const utmTags = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"];
+    const utmTags = [
+      "utm_source",
+      "utm_medium",
+      "utm_campaign",
+      "utm_term",
+      "utm_content",
+    ];
     let foundUTMs = false;
     const currentUTMs: Record<string, string> = {};
 
@@ -31,7 +38,11 @@ export function useUTMCapture() {
     // They will stay here until the user closes the tab or signs up.
     if (foundUTMs) {
       sessionStorage.setItem("draftdeck_utms", JSON.stringify(currentUTMs));
-      console.log("UTMs captured and stored!", currentUTMs); // Keep this for our local testing
+      logger.debug(
+        { route: "hooks/useUTMCapture.ts" },
+        "UTMs captured and stored!",
+        currentUTMs,
+      );
     }
   }, [searchParams]);
 }

--- a/lib/env-validator.ts
+++ b/lib/env-validator.ts
@@ -1,3 +1,5 @@
+import { logger } from "@/lib/logger";
+
 export interface EnvVar {
   key: string;
   required: boolean;
@@ -6,27 +8,105 @@ export interface EnvVar {
 }
 
 const REQUIRED_VARS: EnvVar[] = [
-  { key: 'NEXT_PUBLIC_SUPABASE_URL', required: true, description: 'Supabase project URL' },
-  { key: 'NEXT_PUBLIC_SUPABASE_ANON_KEY', required: true, description: 'Supabase anonymous key' },
-  { key: 'SUPABASE_SERVICE_ROLE_KEY', required: true, description: 'Supabase service role key', secrets: true },
-  { key: 'NEXT_PUBLIC_APP_URL', required: false, description: 'Application base URL' },
-  { key: 'NEXT_PUBLIC_APP_NAME', required: false, description: 'Application display name' },
-  { key: 'GEMINI_API_KEY', required: false, description: 'Google Gemini AI API key', secrets: true },
-  { key: 'MISTRAL_API_KEY', required: false, description: 'Mistral AI API key', secrets: true },
-  { key: 'OPENAI_API_KEY', required: false, description: 'OpenAI API key', secrets: true },
-  { key: 'NEXT_PUBLIC_ENABLE_STRIPE', required: false, description: 'Enable Stripe payments' },
-  { key: 'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY', required: false, description: 'Stripe publishable key' },
-  { key: 'STRIPE_SECRET_KEY', required: false, description: 'Stripe secret key', secrets: true },
-  { key: 'STRIPE_WEBHOOK_SECRET', required: false, description: 'Stripe webhook signing secret', secrets: true },
-  { key: 'NEXTAUTH_SECRET', required: false, description: 'NextAuth.js secret for session encryption', secrets: true },
-  { key: 'SENTRY_DSN', required: false, description: 'Sentry error tracking DSN', secrets: true },
-  { key: 'NEXT_PUBLIC_SENTRY_DSN', required: false, description: 'Sentry client-side DSN' },
-  { key: 'UPSTASH_REDIS_REST_URL', required: false, description: 'Upstash Redis REST URL', secrets: true },
-  { key: 'UPSTASH_REDIS_REST_TOKEN', required: false, description: 'Upstash Redis REST token', secrets: true },
+  {
+    key: "NEXT_PUBLIC_SUPABASE_URL",
+    required: true,
+    description: "Supabase project URL",
+  },
+  {
+    key: "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    required: true,
+    description: "Supabase anonymous key",
+  },
+  {
+    key: "SUPABASE_SERVICE_ROLE_KEY",
+    required: true,
+    description: "Supabase service role key",
+    secrets: true,
+  },
+  {
+    key: "NEXT_PUBLIC_APP_URL",
+    required: false,
+    description: "Application base URL",
+  },
+  {
+    key: "NEXT_PUBLIC_APP_NAME",
+    required: false,
+    description: "Application display name",
+  },
+  {
+    key: "GEMINI_API_KEY",
+    required: false,
+    description: "Google Gemini AI API key",
+    secrets: true,
+  },
+  {
+    key: "MISTRAL_API_KEY",
+    required: false,
+    description: "Mistral AI API key",
+    secrets: true,
+  },
+  {
+    key: "OPENAI_API_KEY",
+    required: false,
+    description: "OpenAI API key",
+    secrets: true,
+  },
+  {
+    key: "NEXT_PUBLIC_ENABLE_STRIPE",
+    required: false,
+    description: "Enable Stripe payments",
+  },
+  {
+    key: "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+    required: false,
+    description: "Stripe publishable key",
+  },
+  {
+    key: "STRIPE_SECRET_KEY",
+    required: false,
+    description: "Stripe secret key",
+    secrets: true,
+  },
+  {
+    key: "STRIPE_WEBHOOK_SECRET",
+    required: false,
+    description: "Stripe webhook signing secret",
+    secrets: true,
+  },
+  {
+    key: "NEXTAUTH_SECRET",
+    required: false,
+    description: "NextAuth.js secret for session encryption",
+    secrets: true,
+  },
+  {
+    key: "SENTRY_DSN",
+    required: false,
+    description: "Sentry error tracking DSN",
+    secrets: true,
+  },
+  {
+    key: "NEXT_PUBLIC_SENTRY_DSN",
+    required: false,
+    description: "Sentry client-side DSN",
+  },
+  {
+    key: "UPSTASH_REDIS_REST_URL",
+    required: false,
+    description: "Upstash Redis REST URL",
+    secrets: true,
+  },
+  {
+    key: "UPSTASH_REDIS_REST_TOKEN",
+    required: false,
+    description: "Upstash Redis REST token",
+    secrets: true,
+  },
 ];
 
 export function validateEnv(): { valid: boolean; missing: EnvVar[] } {
-  if (typeof window !== 'undefined') {
+  if (typeof window !== "undefined") {
     return { valid: true, missing: [] };
   }
 
@@ -44,18 +124,25 @@ export function validateEnv(): { valid: boolean; missing: EnvVar[] } {
 export function logEnvStatus(): void {
   const { valid, missing } = validateEnv();
 
+  const ctx = { route: "lib/env-validator.ts" };
+
   if (valid) {
-    console.log('[env] All required environment variables are set');
+    logger.info(ctx, "[env] All required environment variables are set");
     return;
   }
 
-  console.warn('[env] Missing required environment variables:');
+  logger.warn(ctx, "[env] Missing required environment variables:");
   for (const v of missing) {
-    console.warn(`  - ${v.key}: ${v.description}`);
+    logger.warn(ctx, `  - ${v.key}: ${v.description}`);
   }
 
-  const optional = REQUIRED_VARS.filter((v) => !v.required && !process.env[v.key]);
+  const optional = REQUIRED_VARS.filter(
+    (v) => !v.required && !process.env[v.key],
+  );
   if (optional.length > 0) {
-    console.log(`[env] ${optional.length} optional variable(s) not set (non-blocking)`);
+    logger.info(
+      ctx,
+      `[env] ${optional.length} optional variable(s) not set (non-blocking)`,
+    );
   }
 }

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,52 +1,63 @@
+import { logger } from "@/lib/logger";
+
 export async function requestNotificationPermission(): Promise<boolean> {
-  if (!('Notification' in window)) {
-    console.log('This browser does not support desktop notification');
+  if (!("Notification" in window)) {
+    logger.debug(
+      { route: "lib/notifications.ts" },
+      "This browser does not support desktop notification",
+    );
     return false;
   }
 
   // Check if preferences allow notifications
-  const prefs = localStorage.getItem('documentGenerationNotifications');
-  if (prefs === 'false') {
+  const prefs = localStorage.getItem("documentGenerationNotifications");
+  if (prefs === "false") {
     return false;
   }
 
-  if (Notification.permission === 'granted') {
+  if (Notification.permission === "granted") {
     return true;
   }
 
-  if (Notification.permission !== 'denied') {
+  if (Notification.permission !== "denied") {
     const permission = await Notification.requestPermission();
-    return permission === 'granted';
+    return permission === "granted";
   }
 
   return false;
 }
 
-export async function showDocumentNotification(title: string, options?: NotificationOptions) {
+export async function showDocumentNotification(
+  title: string,
+  options?: NotificationOptions,
+) {
   const hasPermission = await requestNotificationPermission();
   if (!hasPermission) return;
 
-  if ('serviceWorker' in navigator) {
+  if ("serviceWorker" in navigator) {
     const registration = await navigator.serviceWorker.ready;
     if (registration) {
       // Try to use Service Worker to show notification (works better on mobile)
       try {
         await registration.showNotification(title, {
-          icon: '/android-chrome-192x192.png',
-          badge: '/favicon-32x32.png',
+          icon: "/android-chrome-192x192.png",
+          badge: "/favicon-32x32.png",
           ...options,
         });
         return;
       } catch (err) {
-        console.error('Service worker notification failed, falling back to Notification API', err);
+        console.error(
+          "Service worker notification failed, falling back to Notification API",
+          err,
+        );
       }
     }
   }
 
   // Fallback to standard Notification API
   new Notification(title, {
-    icon: '/android-chrome-192x192.png',
-    badge: '/favicon-32x32.png',
+    icon: "/android-chrome-192x192.png",
+    badge: "/favicon-32x32.png",
     ...options,
   });
 }

--- a/lib/presentation-export.ts
+++ b/lib/presentation-export.ts
@@ -1,5 +1,6 @@
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
+import { logger } from "@/lib/logger";
 import {
   SLIDE_LAYOUT,
   PAD,
@@ -45,8 +46,8 @@ async function waitForSlideResources(element: HTMLElement): Promise<void> {
             const done = () => resolve();
             img.onload = done;
             img.onerror = done;
-          })
-    )
+          }),
+    ),
   );
 
   if (typeof document !== "undefined" && document.fonts?.ready) {
@@ -61,7 +62,8 @@ async function waitForSlideResources(element: HTMLElement): Promise<void> {
 }
 
 function getPdfPageSize(options?: PDFExportOptions) {
-  const orientation = options?.orientation === "portrait" ? "portrait" : "landscape";
+  const orientation =
+    options?.orientation === "portrait" ? "portrait" : "landscape";
 
   if (options?.targetSize) {
     return {
@@ -75,7 +77,7 @@ function getPdfPageSize(options?: PDFExportOptions) {
 
 async function captureSlideCanvas(
   slideElement: HTMLElement,
-  scale = 2
+  scale = 2,
 ): Promise<HTMLCanvasElement> {
   const clone = slideElement.cloneNode(true) as HTMLElement;
 
@@ -115,7 +117,7 @@ async function captureSlideCanvas(
  */
 export async function exportSlideAsPNG(
   slideElement: HTMLElement,
-  slideName: string = "slide"
+  slideName: string = "slide",
 ): Promise<void> {
   try {
     const canvas = await html2canvas(slideElement, {
@@ -127,17 +129,21 @@ export async function exportSlideAsPNG(
       proxy: "/api/proxy-image", // Use our proxy for external images
     });
 
-    canvas.toBlob((blob) => {
-      if (!blob) return;
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = `${slideName}.png`;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      URL.revokeObjectURL(url);
-    }, "image/png", 1.0);
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) return;
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = `${slideName}.png`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+      },
+      "image/png",
+      1.0,
+    );
   } catch (error) {
     console.error("Error exporting slide as PNG:", error);
     throw new Error("Failed to export slide as PNG");
@@ -149,7 +155,7 @@ export async function exportSlideAsPNG(
  */
 export async function exportAllSlidesAsPNG(
   slideElements: HTMLElement[],
-  presentationName: string = "presentation"
+  presentationName: string = "presentation",
 ): Promise<void> {
   if (!slideElements.length) {
     throw new Error("No slides to export");
@@ -169,13 +175,17 @@ export async function exportAllSlidesAsPNG(
       });
 
       const blob = await new Promise<Blob>((resolve, reject) => {
-        canvas.toBlob((b) => {
-          if (!b) {
-            reject(new Error("Unable to create image blob"));
-            return;
-          }
-          resolve(b);
-        }, "image/png", 1.0);
+        canvas.toBlob(
+          (b) => {
+            if (!b) {
+              reject(new Error("Unable to create image blob"));
+              return;
+            }
+            resolve(b);
+          },
+          "image/png",
+          1.0,
+        );
       });
 
       zip.file(`slide-${i + 1}.png`, blob);
@@ -201,14 +211,19 @@ export async function exportAllSlidesAsPNG(
 export async function exportAsPDF(
   slideElements: HTMLElement[],
   presentationName: string = "presentation",
-  options: PDFExportOptions = { format: "pdf", quality: 2, orientation: "landscape" }
+  options: PDFExportOptions = {
+    format: "pdf",
+    quality: 2,
+    orientation: "landscape",
+  },
 ): Promise<void> {
   if (!slideElements.length) {
     throw new Error("No slides to export");
   }
 
   const pageSize = getPdfPageSize(options);
-  const orientation = options.orientation === "portrait" ? "portrait" : "landscape";
+  const orientation =
+    options.orientation === "portrait" ? "portrait" : "landscape";
   const pdf = new jsPDF({
     orientation,
     unit: "px",
@@ -219,7 +234,10 @@ export async function exportAsPDF(
 
   try {
     for (let i = 0; i < slideElements.length; i++) {
-      const canvas = await captureSlideCanvas(slideElements[i], options.quality ?? 2);
+      const canvas = await captureSlideCanvas(
+        slideElements[i],
+        options.quality ?? 2,
+      );
       const imgData = canvas.toDataURL("image/png", 1.0);
 
       if (i > 0) {
@@ -240,7 +258,16 @@ export async function exportAsPDF(
       const offsetX = Math.round((pageSize.width - drawWidth) / 2);
       const offsetY = Math.round((pageSize.height - drawHeight) / 2);
 
-      pdf.addImage(imgData, "PNG", offsetX, offsetY, drawWidth, drawHeight, undefined, "MEDIUM");
+      pdf.addImage(
+        imgData,
+        "PNG",
+        offsetX,
+        offsetY,
+        drawWidth,
+        drawHeight,
+        undefined,
+        "MEDIUM",
+      );
     }
 
     pdf.save(`${presentationName}.pdf`);
@@ -278,7 +305,10 @@ function normalizeHex(hex: string): string {
   hex = hex.replace("#", "").trim();
 
   if (hex.length === 3) {
-    hex = hex.split("").map((char) => char + char).join("");
+    hex = hex
+      .split("")
+      .map((char) => char + char)
+      .join("");
   }
 
   return hex.toUpperCase();
@@ -291,7 +321,7 @@ export async function exportAsPPTX(
   slideElements: HTMLElement[],
   presentationName: string = "presentation",
   slides?: any[],
-  theme?: any
+  theme?: any,
 ): Promise<void> {
   try {
     const PptxGenJS = (await import("pptxgenjs")).default;
@@ -307,10 +337,19 @@ export async function exportAsPPTX(
     let globalBgColor = "FFFFFF";
     let globalTextColor = "000000";
 
-    console.log("🎨 Exporting PPTX with theme:", theme);
+    logger.debug(
+      { route: "lib/presentation-export.ts" },
+      "🎨 Exporting PPTX with theme:",
+      theme,
+    );
 
     if (theme && theme.colors) {
-      if (theme.id === "alien" || theme.id === "fluo" || theme.id === "vortex" || theme.type === "dark") {
+      if (
+        theme.id === "alien" ||
+        theme.id === "fluo" ||
+        theme.id === "vortex" ||
+        theme.type === "dark"
+      ) {
         if (theme.id === "alien") globalBgColor = "000000";
         else if (theme.id === "fluo") globalBgColor = "111111";
         else if (theme.id === "vortex") globalBgColor = "020617";
@@ -323,17 +362,30 @@ export async function exportAsPPTX(
       }
     }
 
-    console.log("🎨 Calculated Colors - BG:", globalBgColor, "Text:", globalTextColor);
+    logger.debug(
+      { route: "lib/presentation-export.ts" },
+      "🎨 Calculated Colors - BG:",
+      globalBgColor,
+      "Text:",
+      globalTextColor,
+    );
 
     if (globalBgColor === "FFFFFF" && globalTextColor === "FFFFFF") {
       globalTextColor = "000000";
     }
-    if ((globalBgColor === "000000" || globalBgColor === "111111" || globalBgColor === "020617") && globalTextColor === "000000") {
+    if (
+      (globalBgColor === "000000" ||
+        globalBgColor === "111111" ||
+        globalBgColor === "020617") &&
+      globalTextColor === "000000"
+    ) {
       globalTextColor = "FFFFFF";
     }
 
     if (!slides || slides.length === 0) {
-      console.warn("No structured slide data provided, falling back to image capture");
+      console.warn(
+        "No structured slide data provided, falling back to image capture",
+      );
       for (let i = 0; i < slideElements.length; i++) {
         const canvas = await html2canvas(slideElements[i], {
           scale: 2,
@@ -403,7 +455,9 @@ export async function exportAsPPTX(
 
         const bodyY = slideData.subtitle ? 2.6 : 2.0;
         const bodyW = hasImage ? SPLIT.textW : SAFE.w;
-        const bodyH = hasImage ? CONTENT.bullets_split.h : CONTENT.bullets_full.h;
+        const bodyH = hasImage
+          ? CONTENT.bullets_split.h
+          : CONTENT.bullets_full.h;
 
         if (slideData.content) {
           const bodyFit = fitTextInBox({
@@ -441,7 +495,11 @@ export async function exportAsPPTX(
           });
           const bulletItems = slideData.bullets.map((b: string) => ({
             text: b,
-            options: { fontSize: bulletFit.fontSize, color: textColor, breakLine: true },
+            options: {
+              fontSize: bulletFit.fontSize,
+              color: textColor,
+              breakLine: true,
+            },
           }));
           slide.addText(bulletItems, {
             x: PAD.left,
@@ -468,7 +526,11 @@ export async function exportAsPPTX(
                 y: CONTENT.image.y,
                 w: CONTENT.image.w,
                 h: CONTENT.image.h,
-                sizing: { type: "contain", w: CONTENT.image.w, h: CONTENT.image.h },
+                sizing: {
+                  type: "contain",
+                  w: CONTENT.image.w,
+                  h: CONTENT.image.h,
+                },
               });
             }
           } catch (err) {
@@ -493,7 +555,7 @@ export async function exportPresentation(
   presentationName: string,
   options: ExportOptions,
   slides?: any[],
-  theme?: any
+  theme?: any,
 ): Promise<void> {
   if (slideElements.length === 0) {
     throw new Error("No slides to export");


### PR DESCRIPTION
## Summary

Closes #657

A previous PR (#812) addressing this issue was closed by the maintainer for going stale with unresolved merge conflicts after 3 weeks, with a request to open a fresh PR against current `main`. This is that fresh PR.

### What changed

**6 active debug `console.log` calls removed, replaced with `lib/logger.ts`:**

| File | What it was logging |
|---|---|
| `components/firebase-auth-provider.tsx` (3 calls) | Firebase auth state transitions — including the user's email address, printed straight to console on every sign-in/sign-out |
| `hooks/useTrackEvent.ts` | Analytics event debug output |
| `hooks/useUTMCapture.ts` | UTM capture debug output (comment literally said "Keep this for our local testing") |
| `lib/notifications.ts` | Browser notification-support check |
| `lib/presentation-export.ts` (2 calls) | PPTX theme/color values during export |
| `lib/env-validator.ts` (2 calls) | Startup env-var validation status — used `logger.info`/`logger.warn` here instead of `logger.debug`, since this is meaningful in all environments, not just local debugging |

`logger.debug()` is a no-op when `NODE_ENV=production` (see `lib/logger.ts`), so none of these are visible in DevTools in production regardless of which level they're logged at.

**44 dead, already-commented-out `// console.log(...)` lines removed** across 12 API route files (`app/api/latex`, `resume`, `analyze-ats`, `generate/*`, `jobs/ranking`, `linkedin/import-url`). These were leftovers from a prior partial cleanup pass — stale artifacts per CONTRIBUTING.md's repository hygiene section, not doing anything since they were already commented out, but cluttering the files.

**Left unchanged:** `console.error` calls (already correct per the issue's own "error cases use console.error" criterion, and already using `logger.error` in most call sites), and all user-facing `toast()` notifications, per the issue's explicit scope note.

## Testing

- `npx eslint <all 18 changed files> --max-warnings=0` → 0 errors, 0 warnings
- `npm test` (pre-push hook, full suite) → 410/410 passing
- `grep -rn "console\.log" app/ hooks/ lib/ components/` (excluding tests) → 0 matches

GSSoC 2026