### PR TITLE
fix: repair diagnostic page guard

### DIFF
--- a/app/diagnostic/page.tsx
+++ b/app/diagnostic/page.tsx
@@ -2,20 +2,6 @@ import { notFound } from 'next/navigation';
 import { createServer } from '@/lib/supabase/server';
 
 export default async function DiagnosticPage() {
- restrict-diagnostic-page
-
-    // Restrict diagnostic page in production
-  if (process.env.NODE_ENV === 'production') {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <h1 className="text-2xl font-bold">
-          Access Denied
-        </h1>
-      </div>
-    );
-  }
-  const supabase = createClient();
-
   const diagnosticsEnabled =
     process.env.NODE_ENV !== 'production' &&
     process.env.ENABLE_DIAGNOSTIC_PAGE === 'true';
@@ -24,7 +10,7 @@ export default async function DiagnosticPage() {
     notFound();
   }
 
- main
+  const supabase = await createServer();
 
   // Check if tables exist by trying to query them
   let tablesStatus = {


### PR DESCRIPTION
## Summary
- remove stale conflict text from the diagnostic page
- use the server Supabase helper instead of an undefined client helper
- keep diagnostics behind ENABLE_DIAGNOSTIC_PAGE outside production

## Testing
- git diff --check
- npm run lint -- --file app/diagnostic/page.tsx (blocked locally: dependencies are not installed, next command is missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access handling for the diagnostics page so it is only available when diagnostics are enabled, with a proper not-found response when it’s disabled.
  * Stabilized diagnostic data loading to reduce issues when checking database-related status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->